### PR TITLE
Update Travis for cache invalidation on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,11 @@ script:
 - ng test --watch=false --sourcemaps=false
 - ng e2e
 - ng build
+before_deploy:
+- pip install --user awscli
+- export PATH=$PATH:$HOME/.local/bin
 deploy:
-  skip_cleanup: true
+- skip_cleanup: true
   provider: s3
   access_key_id: $AWS_KEY
   secret_access_key: $AWS_SECRET
@@ -29,7 +32,11 @@ deploy:
   acl: public_read
   local_dir: dist
   on:
-    repo: EvictionLab/eviction-maps
+    branch: development
+- provider: script
+  script: scripts/invalidate-cache.sh
+  on:
+    branch: master
 notifications:
   slack:
     template:

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -5,4 +5,4 @@ export AWS_SECRET_ACCESS_KEY=$AWS_SECRET
 
 aws cloudfront create-invalidation \
     --distribution-id ELMVCLYHTM582 \
-    --paths "/index.html"
+    --paths "/*"

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export AWS_ACCESS_KEY_ID=$AWS_KEY
+export AWS_SECRET_ACCESS_KEY=$AWS_SECRET
+
+aws cloudfront create-invalidation \
+    --distribution-id ELMVCLYHTM582 \
+    --paths "/index.html"


### PR DESCRIPTION
Added a check for the branch in the Travis configuration, added a `before_deploy` hook to install the AWS CLI, and made a quick script to invalidate the cache. Let me know if you want to keep the distribution ID in an environment variable, but it sounds like we'll be keeping that pretty static