### PR TITLE
Remove restriction on travis branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: required
 dist: trusty
 node_js:
 - '6.9'
-branches:
-  only:
-  - master
 before_install:
 - export CHROME_BIN=/usr/bin/google-chrome
 - export DISPLAY=:99.0


### PR DESCRIPTION
For now I'm just adding `development` as a Travis branch, but since we have controls on the deployment so that it only runs on `development` and `master`, should we even restrict the tests running at all?