### PR TITLE
Switch zoomend to zoom for smoother animation

### DIFF
--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -138,7 +138,7 @@ export class MapComponent implements OnInit {
     this.map.on('mouseleave', 'blockgroups', this.onMouseLeaveFeature.bind(this));
 
     // Emit all zoom end events from map
-    this.map.on('zoomend', this.zoomChange.bind(this));
+    this.map.on('zoom', this.zoomChange.bind(this));
 
     this.ready.emit(this.map);
 


### PR DESCRIPTION
Small tweak, but `zoom` makes the animation look a bit smoother. The zoom control is a little delayed, but switching it to `setZoom` instead of `zoomTo` looks choppy to me. That's subjective though