### PR TITLE
auto adjust data levels by zoom

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,6 +11,7 @@
     </app-mapbox>
     <div class="map-ui">
         <app-layer-select 
+            [selectedLayer]="activeDataLevel"
             [layers]="dataLevels" 
             (change)="setGroupVisibility($event)">
         </app-layer-select>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,6 +18,8 @@ export class AppComponent implements OnInit {
   zoom: number;
   dataLevels: Array<MapLayerGroup> = DataLevels;
   attributes: Array<MapDataAttribute> = DataAttributes;
+  activeDataLevel: MapLayerGroup;
+  autoSwitchLayers = true;
   mapConfig = {
     style: '/assets/style.json',
     center: [-77.99, 41.041480],
@@ -36,12 +38,24 @@ export class AppComponent implements OnInit {
 
   onMapReady(map) {
     this.map.setMapInstance(map);
-    this.setGroupVisibility(this.dataLevels[0]);
+    // this.setGroupVisibility(this.dataLevels[0]);
     this.setDataHighlight(this.attributes[0]);
-    this.zoom = this.mapConfig.zoom;
+    this.onMapZoom(this.mapConfig.zoom);
   }
 
-  onMapZoom(zoom) { this.zoom = zoom; }
+  /**
+   * Set the zoom value for the app, auto adjust layers if enabled
+   * @param zoom the current zoom level of the map
+   */
+  onMapZoom(zoom) {
+    this.zoom = zoom;
+    if (this.autoSwitchLayers) {
+      const visibleGroups = this.map.filterLayerGroupsByZoom(this.dataLevels, zoom);
+      if (visibleGroups.length > 0) {
+        this.activeDataLevel = visibleGroups[0];
+      }
+    }
+  }
 
   onMapFeatureClick(feature) {
     console.log('feature click:', feature);
@@ -64,6 +78,7 @@ export class AppComponent implements OnInit {
    * @param mapLayer the layer group that was selected
    */
   setGroupVisibility(layerGroup: MapLayerGroup) {
+    this.autoSwitchLayers = false;
     this.dataLevels.forEach((group: MapLayerGroup) => {
       this.map.setLayerGroupVisibility(group, (group.id === layerGroup.id));
     });

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -9,7 +9,8 @@ export const DataLevels: Array<MapLayerGroup> = [
           'blockgroups_stroke',
           'blockgroups_bubbles',
           'blockgroups_text'
-       ]
+       ],
+       'zoom': [ 10, 16 ]
     },
     {
        'id': 'zipcodes',
@@ -19,7 +20,8 @@ export const DataLevels: Array<MapLayerGroup> = [
         'zipcodes_stroke',
         'zipcodes_bubbles',
         'zipcodes_text'
-       ]
+       ],
+       'zoom': [ 9, 10 ]
     },
     {
        'id': 'tracts',
@@ -29,7 +31,8 @@ export const DataLevels: Array<MapLayerGroup> = [
           'tracts_stroke',
           'tracts_bubbles',
           'tracts_text'
-       ]
+       ],
+       'zoom': [ 8, 9 ]
     },
     {
        'id': 'cities',
@@ -49,7 +52,8 @@ export const DataLevels: Array<MapLayerGroup> = [
           'counties_stroke',
           'counties_bubbles',
           'counties_text'
-       ]
+       ],
+       'zoom': [ 5, 8 ]
     },
     {
        'id': 'states',
@@ -59,6 +63,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'states_stroke',
           'states_bubbles',
           'states_text'
-       ]
+       ],
+       'zoom': [ 0, 5 ]
     }
  ];

--- a/src/app/map-ui/layer-select/layer-select.component.ts
+++ b/src/app/map-ui/layer-select/layer-select.component.ts
@@ -7,7 +7,7 @@ import { MapLayerGroup } from '../../map/map-layer-group';
   styleUrls: ['./layer-select.component.css']
 })
 export class LayerSelectComponent implements OnInit {
-  public selectedLayer: MapLayerGroup;
+  @Input() selectedLayer: MapLayerGroup;
   @Input() layers: Array<MapLayerGroup> = [];
   @Output() change: EventEmitter<MapLayerGroup> = new EventEmitter<MapLayerGroup>();
 
@@ -17,8 +17,9 @@ export class LayerSelectComponent implements OnInit {
    * set the selected layer to the first item, or none if there are no layers
    */
   ngOnInit() {
-    this.selectedLayer =
-      this.layers.length > 0 ? this.layers[0] : { id: 'none', name: 'None' };
+    if (!this.selectedLayer && this.layers.length) {
+      this.selectedLayer = this.layers[0];
+    }
   }
 
   /**

--- a/src/app/map/map-layer-group.ts
+++ b/src/app/map/map-layer-group.ts
@@ -2,4 +2,5 @@ export interface MapLayerGroup {
     id: string;
     name: string;
     layerIds?: string[];
+    zoom?: Array<number>;
 }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -69,6 +69,23 @@ export class MapService {
   }
 
   /**
+   * Hides all layer groups that do not have a zoom range that falls within `zoom`
+   * @param layerGroups an array of MapLayerGroup objects, with zoom properties
+   * @param zoom the zoom level to hide based on
+   * @return an array of MapLayerGroup objects that are currently visible
+   */
+  filterLayerGroupsByZoom(layerGroups: Array<MapLayerGroup>, zoom: number): Array<MapLayerGroup> {
+    const visibleGroups = [];
+    layerGroups.forEach((group) => {
+      if (!group.zoom) { group.zoom = [-1, -1]; }
+      const visible = (zoom >= group.zoom[0] && zoom < group.zoom[1]);
+      this.setLayerGroupVisibility(group, visible);
+      if (visible) { visibleGroups.push(group); }
+    });
+    return visibleGroups;
+  }
+
+  /**
    * Adds a popup on the map in the clicked area
    * TODO: make generic function for popups / tooltips
    * @param e The mapbox click event

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1687,7 +1687,7 @@
       "source-layer": "zip-codes-centers",
       "paint": {
         "circle-color": "#0079bf",
-        "circle-opacity": 0.7,
+        "circle-opacity": 0.25,
         "circle-radius": {
           "property": "eviction-rate",
           "stops": [
@@ -1770,7 +1770,7 @@
       "source-layer": "tracts-centers",
       "paint": {
         "circle-color": "#0079bf",
-        "circle-opacity": 0.7,
+        "circle-opacity": 0.25,
         "circle-radius": {
           "property": "eviction-rate",
           "stops": [
@@ -1853,7 +1853,7 @@
       "source-layer": "cities-centers",
       "paint": {
         "circle-color": "#0079bf",
-        "circle-opacity": 0.7,
+        "circle-opacity": 0.25,
         "circle-radius": {
           "property": "eviction-rate",
           "stops": [
@@ -1984,7 +1984,7 @@
       "source-layer": "counties-centers",
       "paint": {
         "circle-color": "#0079bf",
-        "circle-opacity": 0.7,
+        "circle-opacity": 0.25,
         "circle-radius": {
           "property": "eviction-rate",
           "stops": [
@@ -2069,7 +2069,7 @@
       "source-layer": "states-centers",
       "paint": {
         "circle-color": "#0079bf",
-        "circle-opacity": 0.7,
+        "circle-opacity": 0.25,
         "circle-radius": {
           "property": "eviction-rate",
           "stops": [


### PR DESCRIPTION
Auto updates the current data level displayed based on the current zoom.

Turns off the auto update behaviour when the user selects a data level to display.  Might need a toggle somewhere to turn the auto-adjust behaviour back on if required.

The min / max zoom each level displays at is in `data-levels.ts`.  Might need to adjust these values a bit.