### PR TITLE
Remove Mapbox API key

### DIFF
--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -10,10 +10,7 @@ import { MapboxComponent } from './mapbox/mapbox.component';
   ],
   imports: [
     CommonModule,
-    MapBoxModule.forRoot(
-      'pk.eyJ1IjoiZXZpY3Rpb25sYWIiLCJhIjoiY2o2Z3NsMG85MDF6dzMybW15cWswMGJwNCJ9' +
-      '.PW6rLbRiQdme0py5f8IstA'
-    ),
+    MapBoxModule.forRoot(''),
   ],
   declarations: [MapboxComponent]
 })


### PR DESCRIPTION
It looks like the restriction on the module is a type error where it's expecting a string. Just to be sure that we aren't going to be charged for anything that we don't realize, I replaced it with a blank string and it's still loading and tests are running. 

If it ends up throwing any errors with things we add later on, then at least we'll know for sure what we're being charged for.