### PR TITLE
Fix Mapbox rendering on prod

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -20,9 +20,12 @@
       "prefix": "app",
       "styles": [
         "styles.css",
-        "../node_modules/bootstrap/dist/css/bootstrap.min.css"
+        "../node_modules/bootstrap/dist/css/bootstrap.min.css",
+        "../node_modules/mapbox-gl/dist/mapbox-gl.css"
       ],
-      "scripts": [],
+      "scripts": [
+        "../node_modules/mapbox-gl/dist/mapbox-gl.js"
+      ],
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 script:
 - ng test --watch=false --sourcemaps=false
 - ng e2e
-- ng build
+- ng build --prod
 before_deploy:
 - pip install --user awscli
 - export PATH=$PATH:$HOME/.local/bin

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,6 +267,14 @@
         "@types/jasmine": "2.5.53"
       }
     },
+    "@types/mapbox-gl": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.39.5.tgz",
+      "integrity": "sha512-vCmg7ckpfoF2nxK2xWvMEl/P6kc2sBDCxnQ5Ibs30nS45ROLy8LFwFlaPZ6luCR2XpeMb4TIOMErg2jBOpymoQ==",
+      "requires": {
+        "@types/geojson": "1.0.3"
+      }
+    },
     "@types/node": {
       "version": "6.0.87",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.87.tgz",
@@ -422,57 +430,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "angular-mapbox": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/angular-mapbox/-/angular-mapbox-0.0.13.tgz",
-      "integrity": "sha1-3kmp03Di7F8JWA7wyaMTWN8yDbY=",
-      "requires": {
-        "@angular/common": "4.3.5",
-        "@angular/compiler": "4.3.5",
-        "@angular/core": "4.3.5",
-        "@angular/forms": "4.3.5",
-        "@angular/http": "4.3.5",
-        "@angular/platform-browser": "4.3.5",
-        "@angular/platform-browser-dynamic": "4.3.5",
-        "@angular/router": "4.3.5",
-        "core-js": "2.5.0",
-        "mapbox-gl": "0.38.0",
-        "rxjs": "5.4.3",
-        "zone.js": "0.8.16"
-      },
-      "dependencies": {
-        "mapbox-gl": {
-          "version": "0.38.0",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.38.0.tgz",
-          "integrity": "sha1-ZHMbtV6r2qUgJwgVF1/PMeWjzYA=",
-          "requires": {
-            "@mapbox/gl-matrix": "0.0.1",
-            "@mapbox/shelf-pack": "3.0.0",
-            "@mapbox/unitbezier": "0.0.0",
-            "@mapbox/whoots-js": "3.0.0",
-            "brfs": "1.4.3",
-            "bubleify": "0.7.0",
-            "earcut": "2.1.1",
-            "geojson-rewind": "0.1.0",
-            "geojson-vt": "2.4.0",
-            "grid-index": "1.0.0",
-            "mapbox-gl-supported": "1.2.0",
-            "package-json-versionify": "1.0.4",
-            "pbf": "1.3.7",
-            "point-geometry": "0.0.0",
-            "quickselect": "1.0.0",
-            "supercluster": "2.3.0",
-            "through2": "2.0.3",
-            "tinyqueue": "1.2.2",
-            "unassertify": "2.0.4",
-            "unflowify": "1.0.1",
-            "vector-tile": "1.3.0",
-            "vt-pbf": "2.1.4",
-            "webworkify": "1.4.0"
-          }
-        }
-      }
     },
     "ansi-escapes": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "^4.2.4",
     "@turf/bbox": "^4.7.3",
     "@types/geojson": "^1.0.3",
-    "angular-mapbox": "0.0.13",
+    "@types/mapbox-gl": "^0.39.5",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "mapbox-gl": "^0.39.1",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,9 +4,6 @@ import { AppComponent } from './app.component';
 import { MapboxComponent } from './map/mapbox/mapbox.component';
 import { MapUiModule } from './map-ui/map-ui.module';
 
-import { MapBoxModule } from 'angular-mapbox/module';
-import { MapboxService } from 'angular-mapbox/services/mapbox.service';
-
 describe('AppComponent', () => {
   beforeEach(async(() => {
     const mapboxServiceStub = {
@@ -14,16 +11,13 @@ describe('AppComponent', () => {
     };
     TestBed.configureTestingModule({
       imports: [
-        MapBoxModule,
         MapUiModule
       ],
       declarations: [
         AppComponent,
         MapboxComponent
       ],
-      providers: [
-        { provide: MapboxService, useValue: mapboxServiceStub }
-      ]
+      providers: []
     }).compileComponents();
   }));
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { MapBoxModule } from 'angular-mapbox/module';
 
 import { AppComponent } from './app.component';
 import { MapModule } from './map/map.module';

--- a/src/app/map/map-feature.ts
+++ b/src/app/map/map-feature.ts
@@ -1,7 +1,4 @@
-export interface MapFeature {
-    type: string;
-    layer: Object;
-    geometry: any;
+export interface MapFeature extends GeoJSON.Feature<GeoJSON.GeometryObject> {
     properties: {
         [name: string]: string
     };

--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MapBoxModule } from 'angular-mapbox/module';
 import { MapboxComponent } from './mapbox/mapbox.component';
 
 
@@ -9,8 +8,7 @@ import { MapboxComponent } from './mapbox/mapbox.component';
     MapboxComponent
   ],
   imports: [
-    CommonModule,
-    MapBoxModule.forRoot(''),
+    CommonModule
   ],
   declarations: [MapboxComponent]
 })

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -2,16 +2,23 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/distinct';
 import * as bbox from '@turf/bbox';
-import mapboxgl from 'mapbox-gl';
 
 import { MapLayerGroup } from './map-layer-group';
 import { MapFeature } from './map-feature';
 
 @Injectable()
 export class MapService {
-  map;
+  map: mapboxgl.Map;
 
   constructor() { }
+
+  /**
+   * Create new Mapbox GL map from options object
+   * @param options
+   */
+  createMap(options: Object) {
+    return new mapboxgl.Map(options);
+  }
 
   /**
    * Sets the map instance for the service to control
@@ -26,7 +33,7 @@ export class MapService {
    */
   setLayerVisibility(layerId: string, visible: boolean) {
     const visibility = visible ? 'visible' : 'none';
-    if (this.map.style.getLayer(layerId)) {
+    if (this.map.getLayer(layerId)) {
       this.map.setLayoutProperty(layerId, 'visibility', visibility);
     }
   }
@@ -98,7 +105,7 @@ export class MapService {
    * @param layerGroup
    */
   queryMapLayer(layerGroup: MapLayerGroup) {
-    return Observable.from(this.map.queryRenderedFeatures({layers: [layerGroup.id]}))
+    return Observable.from(this.map.queryRenderedFeatures(undefined, {layers: [layerGroup.id]}))
       .distinct((f: MapFeature) => f.properties.name);
   }
 

--- a/src/app/map/mapbox/mapbox.component.css
+++ b/src/app/map/mapbox/mapbox.component.css
@@ -1,7 +1,7 @@
-ng-mapbox {
-    width:100%;
-    height:100%;
-    position:absolute;
-    left:0;right:0;top:0;bottom:0;
-  }
+#map {
+  width:100%;
+  height:100%;
+  position:absolute;
+  left:0;right:0;top:0;bottom:0;
+}
   

--- a/src/app/map/mapbox/mapbox.component.html
+++ b/src/app/map/mapbox/mapbox.component.html
@@ -1,1 +1,1 @@
-<ng-mapbox (map)="onMapInstance($event)" [config]="mapConfig"></ng-mapbox>
+<div id="map"></div>

--- a/src/app/map/mapbox/mapbox.component.spec.ts
+++ b/src/app/map/mapbox/mapbox.component.spec.ts
@@ -1,30 +1,28 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapboxComponent } from './mapbox.component';
-import { MapBoxModule } from 'angular-mapbox/module';
-import { MapboxService } from 'angular-mapbox/services/mapbox.service';
+import { MapService } from '../map.service';
 
 describe('MapboxComponent', () => {
   let component: MapboxComponent;
   let fixture: ComponentFixture<MapboxComponent>;
+  const mapConfigStub = {
+    style: '/assets/style.json',
+    center: [-77.99, 41.041480],
+    zoom: 6.5,
+    minZoom: 3,
+    maxZoom: 14,
+    container: 'map'
+  };
 
   beforeEach(async(() => {
-    const mapboxServiceStub = {
-      accessToken: '',
-      map: () => ({ on: () => {}, emit: () => {} }),
-      addControl: () => {},
-      addNavigationControl: () => {}
-    };
     TestBed.configureTestingModule({
-      imports: [
-        MapBoxModule.forRoot(
-          'pk.eyJ1IjoiZXZpY3Rpb25sYWIiLCJhIjoiY2o2Z3NsMG85MDF6dzMybW15cWswMGJwNCJ9' +
-          '.PW6rLbRiQdme0py5f8IstA'
-        )
+      imports: [],
+      declarations: [
+        MapboxComponent
       ],
-      declarations: [ MapboxComponent ],
       providers: [
-        { provide: MapboxService, useValue: mapboxServiceStub }
+        MapService
       ]
     }).compileComponents();
   }));
@@ -32,6 +30,7 @@ describe('MapboxComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MapboxComponent);
     component = fixture.componentInstance;
+    component.mapConfig = mapConfigStub;
     fixture.detectChanges();
   });
 

--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-
+import { MapService } from '../map.service';
 import { MapLayerGroup } from '../../map/map-layer-group';
 
 @Component({
@@ -11,7 +11,7 @@ import { MapLayerGroup } from '../../map/map-layer-group';
 export class MapboxComponent implements OnInit {
   private map: any;
   private activeFeature: any;
-  @Input() mapConfig;
+  @Input() mapConfig: Object;
   @Input() eventLayers: Array<string> = [];
   @Output() ready: EventEmitter<any> = new EventEmitter();
   @Output() zoom: EventEmitter<number> = new EventEmitter();
@@ -22,9 +22,14 @@ export class MapboxComponent implements OnInit {
   @Output() featureMouseMove: EventEmitter<any> = new EventEmitter();
   @Output() hoverChanged: EventEmitter<any> = new EventEmitter();
 
-  constructor() {}
+  constructor(private mapService: MapService) { }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.map = this.mapService.createMap(this.mapConfig);
+    this.map.on('load', () => {
+      this.onMapInstance(this.map);
+    });
+  }
 
   /**
    * Pass any .on() calls to the map instance

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
 <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href='https://api.mapbox.com/mapbox-gl-js/v0.39.1/mapbox-gl.css' rel='stylesheet' />
 </head>
 <body>
   <app-root></app-root>

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -4,7 +4,10 @@
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
     "module": "es2015",
-    "types": []
+    "types": [
+      "mapbox-gl",
+      "geojson"
+    ]
   },
   "exclude": [
     "test.ts",

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -6,6 +6,8 @@
     "module": "commonjs",
     "target": "es5",
     "types": [
+      "mapbox-gl",
+      "geojson",
       "jasmine",
       "node"
     ]


### PR DESCRIPTION
Fixes #7 by making the changes described in that comment. The package `angular-mapbox` was also contributing to the problem, and we weren't really using it/it doesn't seem to be maintained so that's removed here. Adds typings for `mapboxgl` and `geojson`, and replaces the package functionality with the corrected types. Works with `ng build --prod` and then running the static files on localhost.