### PR TITLE
Basic implementation of data years

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -33,7 +33,7 @@
             <span class="legend-end">{{legend[1][0]}}</span>
         </div>
     </div>
-    <app-map-tooltip [feature]="hoveredFeature"></app-map-tooltip>
+    <app-map-tooltip [dataYear]="dataYear" [feature]="hoveredFeature"></app-map-tooltip>
 </div>
 <div class="data-wrapper">
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { MapDataAttribute } from './map/map-data-attribute';
 import { MapLayerGroup } from './map/map-layer-group';
+import { MapDataObject } from './map/map-data-object';
 import { MapFeature } from './map/map-feature';
 import { MapboxComponent } from './map/mapbox/mapbox.component';
 import { MapService } from './map/map.service';
@@ -18,6 +19,8 @@ import { DataAttributes } from './data/data-attributes';
 export class AppComponent implements OnInit {
   title = 'Eviction Lab';
   zoom: number;
+  censusYear = 2010;
+  dataYear = 2015;
   dataLevels: Array<MapLayerGroup> = DataLevels;
   attributes: Array<MapDataAttribute> = DataAttributes;
   hoveredFeature;
@@ -36,7 +39,12 @@ export class AppComponent implements OnInit {
   };
   legend;
   mapEventLayers: Array<string> = [
-    'states', 'cities', 'tracts', 'blockgroups', 'zipcodes', 'counties'
+    'states-2010',
+    'cities-2010',
+    'tracts-2010',
+    'blockgroups-2010',
+    'zipcodes-2010',
+    'counties-2010'
   ];
 
   constructor(private map: MapService) {}
@@ -55,8 +63,11 @@ export class AppComponent implements OnInit {
   onMapReady(map) {
     this.map.setMapInstance(map);
     // this.setGroupVisibility(this.dataLevels[0]);
-    this.setDataHighlight(this.attributes[0]);
+    this.activeDataLevel = this.dataLevels[4];
+    this.activeDataHighlight = this.attributes[0];
+    this.setDataYear(this.dataYear);
     this.onMapZoom(this.mapConfig.zoom);
+    this.autoSwitchLayers = true;
   }
 
   /**
@@ -97,16 +108,17 @@ export class AppComponent implements OnInit {
   onFeatureHover(feature) {
     console.log('feature hover', feature);
     this.hoveredFeature = feature;
+    const hoverLayer = this.activeDataLevel.layerIds[this.activeDataLevel.layerIds.length - 1];
     if (this.hoveredFeature) {
       this.map.setLayerFilter(
-        this.activeDataLevel.id + '_hover', [
+        hoverLayer, [
           'all',
           ['==', 'name', this.hoveredFeature.properties.name],
           ['==', 'parent-location', this.hoveredFeature.properties['parent-location']]
         ]
       );
     } else {
-      this.map.setLayerFilter(this.activeDataLevel.id + '_hover', ['==', 'name', '']);
+      this.map.setLayerFilter(hoverLayer, ['==', 'name', '']);
     }
   }
 
@@ -125,6 +137,7 @@ export class AppComponent implements OnInit {
    */
   setGroupVisibility(layerGroup: MapLayerGroup) {
     this.autoSwitchLayers = false;
+    layerGroup = this.addYearToObject(layerGroup, this.censusYear);
     this.dataLevels.forEach((group: MapLayerGroup) => {
       this.map.setLayerGroupVisibility(group, (group.id === layerGroup.id));
     });
@@ -136,7 +149,8 @@ export class AppComponent implements OnInit {
    * @param attr the map data attribute to set highlights for
    */
   setDataHighlight(attr: MapDataAttribute) {
-    this.activeDataHighlight = attr;
+    console.log(attr);
+    this.activeDataHighlight = this.addYearToObject(attr, this.dataYear);
     this.updateLegend();
     this.mapEventLayers.forEach((layerId) => {
       const newFill = {
@@ -156,4 +170,37 @@ export class AppComponent implements OnInit {
     this.map.setZoomLevel(zoomLevel);
   }
 
+  /**
+   * Add year to data attribute or level from selector
+   * @param dataObject
+   * @param year
+   */
+  addYearToObject(dataObject: MapDataObject, year: number) {
+    if (/.*\d{4}.*/g.test(dataObject.id)) {
+      dataObject.id = dataObject.id.replace(/\d{4}/g, year + '');
+    } else {
+      dataObject.id += '-' + year;
+    }
+    return dataObject;
+  }
+
+  /**
+   * Sets the data year for the map, updates data highlights and layers
+   * @param year
+   */
+  setDataYear(year: number) {
+    this.dataYear = year;
+    this.censusYear = this.getCensusYear(year);
+    this.setDataHighlight(this.addYearToObject(this.activeDataHighlight, this.dataYear));
+    this.setGroupVisibility(this.addYearToObject(this.activeDataLevel, this.censusYear));
+    this.updateLegend();
+  }
+
+  /**
+   * Returns the nearest census year for a given year
+   * @param year
+   */
+  getCensusYear(year: number) {
+    return Math.floor(year / 10) * 10;
+  }
 }

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -2,73 +2,73 @@ import { MapLayerGroup } from '../map/map-layer-group';
 
 export const DataLevels: Array<MapLayerGroup> = [
     {
-       'id': 'blockgroups',
+       'id': 'blockgroups-2010',
        'name': 'Block Groups',
        'layerIds': [
-          'blockgroups',
-          'blockgroups_stroke',
-          'blockgroups_bubbles',
-          'blockgroups_text',
-          'blockgroups_hover'
+          'blockgroups-2010',
+          'blockgroups_stroke-2010',
+          'blockgroups_bubbles-2010',
+          'blockgroups_text-2010',
+          'blockgroups_hover-2010'
        ],
        'zoom': [ 10, 16 ]
     },
     {
-       'id': 'zipcodes',
+       'id': 'zipcodes-2010',
        'name': 'Zip Codes',
        'layerIds': [
-        'zipcodes',
-        'zipcodes_stroke',
-        'zipcodes_bubbles',
-        'zipcodes_text',
-        'zipcodes_hover'
+        'zipcodes-2010',
+        'zipcodes_stroke-2010',
+        'zipcodes_bubbles-2010',
+        'zipcodes_text-2010',
+        'zipcodes_hover-2010'
        ],
        'zoom': [ 9, 10 ]
     },
     {
-       'id': 'tracts',
+       'id': 'tracts-2010',
        'name': 'Tracts',
        'layerIds': [
-          'tracts',
-          'tracts_stroke',
-          'tracts_bubbles',
-          'tracts_text',
-          'tracts_hover'
+          'tracts-2010',
+          'tracts_stroke-2010',
+          'tracts_bubbles-2010',
+          'tracts_text-2010',
+          'tracts_hover-2010'
        ],
        'zoom': [ 8, 9 ]
     },
     {
-       'id': 'cities',
+       'id': 'cities-2010',
        'name': ' Cities',
        'layerIds': [
-          'cities',
-          'cities_stroke',
-          'cities_bubbles',
-          'cities_text',
-          'cities_hover'
+          'cities-2010',
+          'cities_stroke-2010',
+          'cities_bubbles-2010',
+          'cities_text-2010',
+          'cities_hover-2010'
        ]
     },
     {
-       'id': 'counties',
+       'id': 'counties-2010',
        'name': 'Counties',
        'layerIds': [
-          'counties',
-          'counties_stroke',
-          'counties_bubbles',
-          'counties_text',
-          'counties_hover'
+          'counties-2010',
+          'counties_stroke-2010',
+          'counties_bubbles-2010',
+          'counties_text-2010',
+          'counties_hover-2010'
        ],
        'zoom': [ 5, 8 ]
     },
     {
-       'id': 'states',
+       'id': 'states-2010',
        'name': 'States',
        'layerIds': [
-          'states',
-          'states_stroke',
-          'states_bubbles',
-          'states_text',
-          'states_hover'
+          'states-2010',
+          'states_stroke-2010',
+          'states_bubbles-2010',
+          'states_text-2010',
+          'states_hover-2010'
        ],
        'zoom': [ 0, 5 ]
     }

--- a/src/app/map-ui/map-tooltip/map-tooltip.component.html
+++ b/src/app/map-ui/map-tooltip/map-tooltip.component.html
@@ -6,20 +6,20 @@
           <small class="tooltip-parent-location">{{feature.properties["parent-location"]}}</small>
         </h1>
         <ul class="tooltip-stats">
-          <li *ngIf="feature.properties['eviction-rate']">
-            <span class="stat-value">{{ feature.properties["eviction-rate"] | number:'1.0-0' }}</span>
+          <li *ngIf="feature.properties['eviction-rate-' + dataYear]">
+            <span class="stat-value">{{ feature.properties["eviction-rate-" + dataYear] | number:'1.0-0' }}</span>
             <span class="stat-label">Evictions per 100 renter-occupied households</span>
           </li>
-          <li *ngIf="feature.properties['evictions']">
-            <span class="stat-value">{{ feature.properties["evictions"] }}</span>
-            <span class="stat-label">{{ feature.properties["evictions"] | i18nPlural: evictionLabelMapping }}</span>
+          <li *ngIf="feature.properties['evictions-' + dataYear]">
+            <span class="stat-value">{{ feature.properties["evictions-" + dataYear] }}</span>
+            <span class="stat-label">{{ feature.properties["evictions-" + dataYear] | i18nPlural: evictionLabelMapping }}</span>
           </li>
-          <li *ngIf="feature.properties['average-household-size']">
-              <span class="stat-value">{{ feature.properties["average-household-size"] | number:'1.0-1' }}</span>
+          <li *ngIf="feature.properties['average-household-size-' + dataYear]">
+              <span class="stat-value">{{ feature.properties["average-household-size-" + dataYear] | number:'1.0-1' }}</span>
               <span class="stat-label">Average Household Size</span>
             </li>
-          <li *ngIf="feature.properties['poverty-rate']">
-            <span class="stat-value">{{ feature.properties["poverty-rate"] | percent }}</span>
+          <li *ngIf="feature.properties['poverty-rate-' + dataYear]">
+            <span class="stat-value">{{ feature.properties["poverty-rate-" + dataYear] | percent }}</span>
             <span class="stat-label">Poverty Rate</span>
           </li>
         </ul>

--- a/src/app/map-ui/map-tooltip/map-tooltip.component.ts
+++ b/src/app/map-ui/map-tooltip/map-tooltip.component.ts
@@ -9,6 +9,7 @@ import { I18nPluralPipe, PercentPipe } from '@angular/common';
 export class MapTooltipComponent implements OnInit {
 
   @Input() feature;
+  @Input() dataYear: number;
   evictionLabelMapping: {[k: string]: string} = {'=1': 'Eviction', 'other': 'Evictions'};
 
   constructor() { }

--- a/src/app/map/map-data-attribute.ts
+++ b/src/app/map/map-data-attribute.ts
@@ -1,7 +1,9 @@
-export interface MapDataAttribute {
+import { MapDataObject } from './map-data-object';
+
+export interface MapDataAttribute extends MapDataObject {
     id: string;
     name: string;
-    fillStops: {
+    fillStops?: {
         [id: string]: Array<Array<any>>
     };
 }

--- a/src/app/map/map-data-object.ts
+++ b/src/app/map/map-data-object.ts
@@ -1,0 +1,4 @@
+export interface MapDataObject {
+    id: string;
+    name: string;
+}

--- a/src/app/map/map-layer-group.ts
+++ b/src/app/map/map-layer-group.ts
@@ -1,4 +1,6 @@
-export interface MapLayerGroup {
+import { MapDataObject } from './map-data-object';
+
+export interface MapLayerGroup extends MapDataObject {
     id: string;
     name: string;
     layerIds?: string[];

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -56,7 +56,10 @@ export class MapService {
    * @param newStyle the new property style (e.g. "#000000")
    */
   setLayerStyle(layerId: string, styleProperty: string, newStyle: any) {
+    console.log(styleProperty);
+    console.log(newStyle);
     this.map.setPaintProperty(layerId, styleProperty, newStyle);
+    console.log(this.map.getLayer(layerId));
   }
 
   /**

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -7,46 +7,46 @@
       "type": "vector",
       "url": "https://free.tilehosting.com/data/v3.json?key=JgNOMnZWmIN2iBSFGgsi"
     },
-    "us-block-groups": {
+    "us-block-groups-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-block-groups/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-block-groups-2010/{z}/{x}/{y}.pbf"
       ]
     },
-    "us-zip-codes": {
+    "us-zip-codes-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-zip-codes/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-zip-codes-2010/{z}/{x}/{y}.pbf"
       ]
     },
-    "us-tracts": {
+    "us-tracts-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-tracts/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-tracts-2010/{z}/{x}/{y}.pbf"
       ]
     },
-    "us-cities": {
+    "us-cities-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-cities/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-cities-2010/{z}/{x}/{y}.pbf"
       ]
     },
-    "us-counties": {
+    "us-counties-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-counties/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-counties-2010/{z}/{x}/{y}.pbf"
       ]
     },
-    "us-states": {
+    "us-states-2010": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/evictions-states/{z}/{x}/{y}.pbf"
+        "https://s3.amazonaws.com/eviction-lab-data/evictions-states-2010/{z}/{x}/{y}.pbf"
       ]
     }
   },
@@ -184,10 +184,10 @@
       }
     },
     {
-      "id": "blockgroups",
+      "id": "blockgroups-2010",
       "type": "fill",
-      "source": "us-block-groups",
-      "source-layer": "block-groups",
+      "source": "us-block-groups-2010",
+      "source-layer": "block-groups-2010",
       "layout": {
         "visibility": "none"
       },
@@ -197,10 +197,10 @@
       }
     },
     {
-      "id": "blockgroups_stroke",
+      "id": "blockgroups_stroke-2010",
       "type": "line",
-      "source": "us-block-groups",
-      "source-layer": "block-groups",
+      "source": "us-block-groups-2010",
+      "source-layer": "block-groups-2010",
       "layout": {
         "visibility": "none"
       },
@@ -211,10 +211,10 @@
       }
     },
     {
-      "id": "blockgroups_hover",
+      "id": "blockgroups_hover-2010",
       "type": "line",
-      "source": "us-block-groups",
-      "source-layer": "block-groups",
+      "source": "us-block-groups-2010",
+      "source-layer": "block-groups-2010",
       "layout": {
         "visibility": "none"
       },
@@ -226,10 +226,10 @@
       }
     },
     {
-      "id": "zipcodes",
+      "id": "zipcodes-2010",
       "type": "fill",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes",
+      "source": "us-zip-codes-2010",
+      "source-layer": "zip-codes-2010",
       "layout": {
         "visibility": "none"
       },
@@ -239,10 +239,10 @@
       }
     },
     {
-      "id": "zipcodes_stroke",
+      "id": "zipcodes_stroke-2010",
       "type": "line",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes",
+      "source": "us-zip-codes-2010",
+      "source-layer": "zip-codes-2010",
       "layout": {
         "visibility": "none"
       },
@@ -253,10 +253,10 @@
       }
     },
     {
-      "id": "zipcodes_hover",
+      "id": "zipcodes_hover-2010",
       "type": "line",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes",
+      "source": "us-zip-codes-2010",
+      "source-layer": "zip-codes-2010",
       "layout": {
         "visibility": "none"
       },
@@ -268,10 +268,10 @@
       }
     },
     {
-      "id": "tracts",
+      "id": "tracts-2010",
       "type": "fill",
-      "source": "us-tracts",
-      "source-layer": "tracts",
+      "source": "us-tracts-2010",
+      "source-layer": "tracts-2010",
       "layout": {
         "visibility": "none"
       },
@@ -281,10 +281,10 @@
       }
     },
     {
-      "id": "tracts_stroke",
+      "id": "tracts_stroke-2010",
       "type": "line",
-      "source": "us-tracts",
-      "source-layer": "tracts",
+      "source": "us-tracts-2010",
+      "source-layer": "tracts-2010",
       "layout": {
         "visibility": "none"
       },
@@ -295,10 +295,10 @@
       }
     },
     {
-      "id": "tracts_hover",
+      "id": "tracts_hover-2010",
       "type": "line",
-      "source": "us-tracts",
-      "source-layer": "tracts",
+      "source": "us-tracts-2010",
+      "source-layer": "tracts-2010",
       "layout": {
         "visibility": "none"
       },
@@ -310,10 +310,10 @@
       }
     },
     {
-      "id": "cities",
+      "id": "cities-2010",
       "type": "fill",
-      "source": "us-cities",
-      "source-layer": "cities",
+      "source": "us-cities-2010",
+      "source-layer": "cities-2010",
       "layout": {
         "visibility": "none"
       },
@@ -323,10 +323,10 @@
       }
     },
     {
-      "id": "cities_stroke",
+      "id": "cities_stroke-2010",
       "type": "line",
-      "source": "us-cities",
-      "source-layer": "cities",
+      "source": "us-cities-2010",
+      "source-layer": "cities-2010",
       "layout": {
         "visibility": "none"
       },
@@ -337,10 +337,10 @@
       }
     },
     {
-      "id": "cities_hover",
+      "id": "cities_hover-2010",
       "type": "line",
-      "source": "us-cities",
-      "source-layer": "cities",
+      "source": "us-cities-2010",
+      "source-layer": "cities-2010",
       "layout": {
         "visibility": "none"
       },
@@ -352,10 +352,10 @@
       }
     },
     {
-      "id": "counties",
+      "id": "counties-2010",
       "type": "fill",
-      "source": "us-counties",
-      "source-layer": "counties",
+      "source": "us-counties-2010",
+      "source-layer": "counties-2010",
       "layout": {
         "visibility": "none"
       },
@@ -365,10 +365,10 @@
       }
     },
     {
-      "id": "counties_stroke",
+      "id": "counties_stroke-2010",
       "type": "line",
-      "source": "us-counties",
-      "source-layer": "counties",
+      "source": "us-counties-2010",
+      "source-layer": "counties-2010",
       "layout": {
         "visibility": "none"
       },
@@ -379,10 +379,10 @@
       }
     },
     {
-      "id": "counties_hover",
+      "id": "counties_hover-2010",
       "type": "line",
-      "source": "us-counties",
-      "source-layer": "counties",
+      "source": "us-counties-2010",
+      "source-layer": "counties-2010",
       "layout": {
         "visibility": "none"
       },
@@ -394,10 +394,10 @@
       }
     },
     {
-      "id": "states",
+      "id": "states-2010",
       "type": "fill",
-      "source": "us-states",
-      "source-layer": "states",
+      "source": "us-states-2010",
+      "source-layer": "states-2010",
       "layout": {
         "visibility": "none"
       },
@@ -407,10 +407,10 @@
       }
     },
     {
-      "id": "states_stroke",
+      "id": "states_stroke-2010",
       "type": "line",
-      "source": "us-states",
-      "source-layer": "states",
+      "source": "us-states-2010",
+      "source-layer": "states-2010",
       "layout": {
         "visibility": "none"
       },
@@ -421,10 +421,10 @@
       }
     },
     {
-      "id": "states_hover",
+      "id": "states_hover-2010",
       "type": "line",
-      "source": "us-states",
-      "source-layer": "states",
+      "source": "us-states-2010",
+      "source-layer": "states-2010",
       "layout": {
         "visibility": "none"
       },
@@ -1674,10 +1674,10 @@
       }
     },
     {
-      "id": "blockgroups_bubbles",
+      "id": "blockgroups_bubbles-2010",
       "type": "circle",
-      "source": "us-block-groups",
-      "source-layer": "block-groups-centers",
+      "source": "us-block-groups-2010",
+      "source-layer": "block-groups-2010-centers",
       "layout": {
         "visibility": "none"
       },
@@ -1685,7 +1685,7 @@
         "circle-color": "#0079bf",
         "circle-opacity": 0.7,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -1762,10 +1762,10 @@
       }
     },
     {
-      "id": "blockgroups_text",
+      "id": "blockgroups_text-2010",
       "type": "symbol",
-      "source": "us-block-groups",
-      "source-layer": "block-groups-centers",
+      "source": "us-block-groups-2010",
+      "source-layer": "block-groups-2010-centers",
       "minzoom": 8,
       "layout": {
         "text-size": 10,
@@ -1774,10 +1774,10 @@
       }
     },
     {
-      "id": "zipcodes_bubbles",
+      "id": "zipcodes_bubbles-2010",
       "type": "circle",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes-centers",
+      "source": "us-zip-codes-2010",
+      "source-layer": "zip-codes-2010-centers",
       "layout": {
         "visibility": "none"
       },
@@ -1785,7 +1785,7 @@
         "circle-color": "#0079bf",
         "circle-opacity": 0.25,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -1848,10 +1848,10 @@
       }
     },
     {
-      "id": "zipcodes_text",
+      "id": "zipcodes_text-2010",
       "type": "symbol",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes-centers",
+      "source": "us-zip-codes-2010",
+      "source-layer": "zip-codes-2010-centers",
       "minzoom": 8,
       "layout": {
         "text-size": 10,
@@ -1860,10 +1860,10 @@
       }
     },
     {
-      "id": "tracts_bubbles",
+      "id": "tracts_bubbles-2010",
       "type": "circle",
-      "source": "us-tracts",
-      "source-layer": "tracts-centers",
+      "source": "us-tracts-2010",
+      "source-layer": "tracts-2010-centers",
       "layout": {
         "visibility": "none"
       },
@@ -1871,7 +1871,7 @@
         "circle-color": "#0079bf",
         "circle-opacity": 0.25,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -1934,10 +1934,10 @@
       }
     },
     {
-      "id": "tracts_text",
+      "id": "tracts_text-2010",
       "type": "symbol",
-      "source": "us-tracts",
-      "source-layer": "tracts-centers",
+      "source": "us-tracts-2010",
+      "source-layer": "tracts-2010-centers",
       "minzoom": 8,
       "layout": {
         "text-size": 10,
@@ -1946,23 +1946,23 @@
       }
     },
     {
-      "id": "cities_bubbles",
+      "id": "cities_bubbles-2010",
       "type": "circle",
-      "source": "us-cities",
-      "source-layer": "cities-centers",
+      "source": "us-cities-2010",
+      "source-layer": "cities-2010-centers",
       "layout": {
         "visibility": "none"
       },
       "filter": [
         ">",
-        "eviction-rate",
+        "eviction-rate-2015",
         0
       ],
       "paint": {
         "circle-color": "#0079bf",
         "circle-opacity": 0.25,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -2097,10 +2097,10 @@
       "maxzoom": 24
     },
     {
-      "id": "cities_text",
+      "id": "cities_text-2010",
       "type": "symbol",
-      "source": "us-cities",
-      "source-layer": "cities-centers",
+      "source": "us-cities-2010",
+      "source-layer": "cities-2010-centers",
       "layout": {
         "text-size": 10,
         "text-field": "{name}",
@@ -2178,10 +2178,10 @@
       }
     },
     {
-      "id": "counties_bubbles",
+      "id": "counties_bubbles-2010",
       "type": "circle",
-      "source": "us-counties",
-      "source-layer": "counties-centers",
+      "source": "us-counties-2010",
+      "source-layer": "counties-2010-centers",
       "layout": {
         "visibility": "none"
       },
@@ -2189,7 +2189,7 @@
         "circle-color": "#0079bf",
         "circle-opacity": 0.25,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -2252,10 +2252,10 @@
       }
     },
     {
-      "id": "counties_text",
+      "id": "counties_text-2010",
       "type": "symbol",
-      "source": "us-counties",
-      "source-layer": "counties-centers",
+      "source": "us-counties-2010",
+      "source-layer": "counties-2010-centers",
       "minzoom": 5,
       "layout": {
         "text-size": 10,
@@ -2266,10 +2266,10 @@
       }
     },
     {
-      "id": "states_bubbles",
+      "id": "states_bubbles-2010",
       "type": "circle",
-      "source": "us-states",
-      "source-layer": "states-centers",
+      "source": "us-states-2010",
+      "source-layer": "states-2010-centers",
       "layout": {
         "visibility": "none"
       },
@@ -2277,7 +2277,7 @@
         "circle-color": "#0079bf",
         "circle-opacity": 0.25,
         "circle-radius": {
-          "property": "eviction-rate",
+          "property": "eviction-rate-2015",
           "stops": [
             [
               {
@@ -2312,10 +2312,10 @@
       }
     },
     {
-      "id": "states_text",
+      "id": "states_text-2010",
       "type": "symbol",
-      "source": "us-states",
-      "source-layer": "states-centers",
+      "source": "us-states-2010",
+      "source-layer": "states-2010-centers",
       "layout": {
         "text-field": "{name}",
         "visibility": "none"


### PR DESCRIPTION
Added methods and changed layers to support a `dataYear` property on the main app component, as well as a `censusYear` property for the decennial census. We'll probably need to change parts of this going forward, but it sets up a framework for the year selector component.

The most changes are in the `style.json` file, and it's pointing at a different bucket where I deployed the tiles from the pending PR in `eviction-lab-etl`. If this basic setup works, I think we can merge that as well (although Travis isn't cutting it for that deployment, so we'll probably have to do it semi-manually for now)