### PR TITLE
Disable touch rotate

### DIFF
--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -17,7 +17,9 @@ export class MapService {
    * @param options
    */
   createMap(options: Object) {
-    return new mapboxgl.Map(options);
+    const map = new mapboxgl.Map(options);
+    map.touchZoomRotate.disableRotation();
+    return map;
   }
 
   /**


### PR DESCRIPTION
When I was playing around with the mobile prototype, I accidentally rotated the map a bit while zooming. I don't know if we really have a use case for rotating, so it made sense to disable it for touch gestures. There's also [an option to disable rotation for right-click and drag](https://www.mapbox.com/mapbox-gl-js/example/disable-rotation/) which could be worth considering too