### PR TITLE
Deploy prototype branches from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ deploy:
   script: scripts/invalidate-cache.sh
   on:
     branch: master
+- provider: script
+  script: if [[ $TRAVIS_BRANCH == prototypes/* ]]; then aws s3 cp dist/ s3://eviction-lab-prototypes/${TRAVIS_BRANCH:11} --recursive --acl=public-read; fi
+  on:
+    all_branches: true
 notifications:
   slack:
     template:


### PR DESCRIPTION
Adding a shortcut for deploying prototypes to S3 as long as the branch starts with `prototypes/`. It didn't work initially, but not sure if Travis allows for changing deployment settings from a non-master branch