### PR TITLE
Suppress 404 vector tile errors

### DIFF
--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -37,6 +37,12 @@ export class MapboxComponent implements AfterViewInit {
     this.map.on('load', () => {
       this.onMapInstance(this.map);
     });
+    this.map.on('error', (e) => {
+      if (e && e.error && e.error.tile && e.error.tile.state === 'Errored') {
+      } else {
+        console.error(e);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Was originally just going to make this an issue, but then figured out the quick fix. Mentioned in #29, but that's really a separate issue. In just about every prototype, on navigating the map you get multiple `Error at Actor.receive` messages in the console log. From digging around, it's related to the 404s we get when the map requests tiles we didn't generate (intentionally, i.e. outside the US). The confusion is that Angular bundling the vendor files doesn't throw the normal "Not Found" error.

Based on [this StackOverflow comment](https://stackoverflow.com/a/42777638), code to check for the errors, and suppress them if they're related to 404s (checking for `tile` properties and not the message text, which is changed). 

We'll still get the HTTP 404s logged to the console, but I think that's normal with tiled maps, and while there are some [ways to customize that on CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html), it's probably not worth it.