### PR TITLE
Temporarily remove buggy e2e test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
 - npm install -g @angular/cli
 script:
 - ng test --watch=false --sourcemaps=false
-- ng e2e
 - ng build --prod
 before_deploy:
 - pip install --user awscli


### PR DESCRIPTION
We can add this back when we're actually using it, but it's causing a bunch of timeout failures on Travis