### PR TITLE
Improved hover performance, reduced layers

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -148,18 +148,10 @@ export class AppComponent {
     if (this.hover_HACK > 0 || !this.platform.isMobile()) {
       this.hover_HACK = 0;
       this.hoveredFeature = feature;
-      const hoverLayer =
-        this.activeDataLevel.layerIds[this.activeDataLevel.layerIds.length - 1];
       if (this.hoveredFeature) {
-        this.map.setLayerFilter(
-          hoverLayer, [
-            'all',
-            ['==', 'name', this.hoveredFeature.properties.name],
-            ['==', 'parent-location', this.hoveredFeature.properties['parent-location']]
-          ]
-        );
+        this.map.setSourceData('hover', feature);
       } else {
-        this.map.setLayerFilter(hoverLayer, ['==', 'name', '']);
+        this.map.setSourceData('hover');
       }
     } else if (this.hover_HACK === 0 && feature) {
       this.hover_HACK = 1;

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -8,8 +8,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'blockgroups',
           'blockgroups_stroke',
           'blockgroups_bubbles',
-          'blockgroups_text',
-          'blockgroups_hover'
+          'blockgroups_text'
        ],
        'zoom': [ 10, 16 ]
     },
@@ -20,8 +19,7 @@ export const DataLevels: Array<MapLayerGroup> = [
         'zipcodes',
         'zipcodes_stroke',
         'zipcodes_bubbles',
-        'zipcodes_text',
-        'zipcodes_hover'
+        'zipcodes_text'
        ],
        'zoom': [ 9, 10 ]
     },
@@ -32,8 +30,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'tracts',
           'tracts_stroke',
           'tracts_bubbles',
-          'tracts_text',
-          'tracts_hover'
+          'tracts_text'
        ],
        'zoom': [ 8, 9 ]
     },
@@ -44,8 +41,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'cities',
           'cities_stroke',
           'cities_bubbles',
-          'cities_text',
-          'cities_hover'
+          'cities_text'
        ]
     },
     {
@@ -55,8 +51,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'counties',
           'counties_stroke',
           'counties_bubbles',
-          'counties_text',
-          'counties_hover'
+          'counties_text'
        ],
        'zoom': [ 5, 8 ]
     },
@@ -67,8 +62,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'states',
           'states_stroke',
           'states_bubbles',
-          'states_text',
-          'states_hover'
+          'states_text'
        ],
        'zoom': [ 0, 5 ]
     }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -107,6 +107,20 @@ export class MapService {
   }
 
   /**
+   * Set the data of a GeoJSON layer source, or empty the data if no
+   * feature supplied
+   * @param sourceId ID of GeoJSON source to modify
+   * @param feature MapFeature object
+   */
+  setSourceData(sourceId: string, feature?: MapFeature) {
+    const features = feature ? [feature] : [];
+    (this.map.getSource(sourceId) as mapboxgl.GeoJSONSource).setData({
+      'type': 'FeatureCollection',
+      'features': features
+    });
+  }
+
+  /**
    * Updates the map zoom level
    * @param newZoom new zoom value for map
    */

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -48,6 +48,13 @@
       "tiles": [
         "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-states/{z}/{x}/{y}.pbf"
       ]
+    },
+    "hover": {
+      "type": "geojson",
+      "data": {
+        "type": "FeatureCollection",
+        "features": []
+      }
     }
   },
   "sprite": "https://openmaptiles.github.io/positron-gl-style/sprite",
@@ -1452,25 +1459,6 @@
       }
     },
     {
-      "id": "blockgroups_hover",
-      "type": "line",
-      "source": "us-block-groups",
-      "source-layer": "block-groups",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
-      "paint": {
-        "line-color": "rgba(255,255,255,0.5)",
-        "line-width": 4,
-        "line-opacity": 1
-      }
-    },
-    {
       "id": "zipcodes",
       "type": "fill",
       "source": "us-zip-codes",
@@ -1493,25 +1481,6 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "zipcodes_hover",
-      "type": "line",
-      "source": "us-zip-codes",
-      "source-layer": "zip-codes",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
-      "paint": {
-        "line-color": "rgba(255,255,255,0.5)",
-        "line-width": 4,
         "line-opacity": 1
       }
     },
@@ -1542,25 +1511,6 @@
       }
     },
     {
-      "id": "tracts_hover",
-      "type": "line",
-      "source": "us-tracts",
-      "source-layer": "tracts",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
-      "paint": {
-        "line-color": "rgba(255,255,255,0.5)",
-        "line-width": 5,
-        "line-opacity": 1
-      }
-    },
-    {
       "id": "counties",
       "type": "fill",
       "source": "us-counties",
@@ -1583,25 +1533,6 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "counties_hover",
-      "type": "line",
-      "source": "us-counties",
-      "source-layer": "counties",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
-      "paint": {
-        "line-color": "rgba(255,255,255,0.5)",
-        "line-width": 4,
         "line-opacity": 1
       }
     },
@@ -2541,37 +2472,10 @@
       }
     },
     {
-      "id": "cities_hover",
+      "id": "hover",
       "type": "line",
-      "source": "us-cities",
-      "source-layer": "cities",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
-      "paint": {
-        "line-color": "rgba(255,255,255,0.5)",
-        "line-width": 4,
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "states_hover",
-      "type": "line",
-      "source": "us-states",
-      "source-layer": "states",
-      "layout": {
-        "visibility": "none"
-      },
-      "filter": [
-        "==",
-        "name",
-        ""
-      ],
+      "source": "hover",
+      "layout": {},
       "paint": {
         "line-color": "rgba(255,255,255,0.5)",
         "line-width": 4,


### PR DESCRIPTION
I was looking around at some best practices and examples of using Mapbox GL and vector tiles, and I found a hover implementation that's significantly faster https://github.com/ccusa/Disaster_Vulnerability_Map/blob/master/js/mapbox.js#L206

Instead of adding an additional layer for each source, we can just have one hover layer that's blank GeoJSON and update the source with the GeoJSON-like feature returned from the event. Here's some screen recording gifs for comparison

Current State:
![current-hover](https://user-images.githubusercontent.com/8291663/31280235-53608eb8-aa71-11e7-92f0-754743f7fd2a.gif)

With this PR:
![improved-hover](https://user-images.githubusercontent.com/8291663/31280247-5d5655c4-aa71-11e7-9fc1-0f56c7b97df6.gif)
