### PR TITLE
Add UI progress bar component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,10 +24,12 @@
             (ready)="onMapReady($event)"
             (zoom)="onMapZoom($event)"
             (featureClick)="onFeatureClick($event)"
-            (hoverChanged)="onFeatureHover($event)">
+            (hoverChanged)="onFeatureHover($event)"
+            (render)="onMapRender($event)">
         </app-mapbox>
     </div>
     <div class="map-ui-wrapper">
+        <app-progress-bar *ngIf="mapLoading"></app-progress-bar>
         <app-ui-slider class="zoom-slider" tabindex="3"
             [vertical]="true"
             [currentValue]="zoom" 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,6 +53,7 @@ export class AppComponent {
     axis: { x: { label: null }, y: { label: 'Evictions' } },
     margin: { left: 60 }
   };
+  mapLoading = true;
   private _activeFeature;
   private hover_HACK = 0; // used to ignore first hover event when on touch, temp hack
 
@@ -112,6 +113,7 @@ export class AppComponent {
    * @param event
    */
   onMapRender(event) {
+    this.mapLoading = this.map.isMapLoading();
     if (this.activeDataLevel) {
       this.mapFeatures = this.map.queryMapLayer(this.activeDataLevel);
     }

--- a/src/app/map-ui/map-ui.module.ts
+++ b/src/app/map-ui/map-ui.module.ts
@@ -8,13 +8,15 @@ import { UiSelectComponent } from './ui-select/ui-select.component';
 import { MapTooltipComponent } from './map-tooltip/map-tooltip.component';
 import { PredictiveSearchComponent } from './predictive-search/predictive-search.component';
 import { UiSliderComponent } from './ui-slider/ui-slider.component';
+import { ProgressBarComponent } from './progress-bar/progress-bar.component';
 
 @NgModule({
   exports: [
     UiSelectComponent,
     MapTooltipComponent,
     PredictiveSearchComponent,
-    UiSliderComponent
+    UiSliderComponent,
+    ProgressBarComponent
   ],
   imports: [
     CommonModule,
@@ -26,7 +28,8 @@ import { UiSliderComponent } from './ui-slider/ui-slider.component';
     UiSelectComponent,
     MapTooltipComponent,
     PredictiveSearchComponent,
-    UiSliderComponent
+    UiSliderComponent,
+    ProgressBarComponent
   ]
 })
 export class MapUiModule { }

--- a/src/app/map-ui/progress-bar/progress-bar.component.html
+++ b/src/app/map-ui/progress-bar/progress-bar.component.html
@@ -1,0 +1,4 @@
+<div class="progress-line"></div>
+<div [style.display]="indeterminate ? 'none' : 'inherit'" [style.width]="percent" class="subline progress"></div>
+<div [style.display]="indeterminate ? 'inherit' : 'none'" class="subline inc"></div>
+<div [style.display]="indeterminate ? 'inherit' : 'none'"  class="subline dec"></div>

--- a/src/app/map-ui/progress-bar/progress-bar.component.scss
+++ b/src/app/map-ui/progress-bar/progress-bar.component.scss
@@ -1,0 +1,59 @@
+@import "progress-bar.theme";
+
+$progressBarColor: rgb(224,64,0);
+
+// Implementation based on https://codepen.io/shalimano/pen/wBmNGJ
+:host {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 5px;
+  overflow-x: hidden;
+}
+
+.progress-line {
+  position: absolute;
+  opacity: 0.4;
+  width: 150%;
+  height: 5px;
+  @include progress-bar-bg($progressBarColor);
+}
+
+.subline{
+  position: absolute;
+  height: 5px;
+  @include progress-bar-bg($progressBarColor);
+}
+
+.subline.progress {
+  left: 0;
+}
+
+.inc{
+  animation: increase 2s infinite;
+}
+
+.dec{
+  animation: decrease 2s 0.5s infinite;
+}
+
+@keyframes increase {
+  from {
+    left: -5%;
+    width: 5%;
+  }
+  to {
+    left: 130%;
+    width: 100%;
+  }
+}
+@keyframes decrease {
+  from {
+    left: -80%;
+    width: 80%;
+  }
+  to {
+    left: 110%;
+    width: 10%;
+  }
+}

--- a/src/app/map-ui/progress-bar/progress-bar.component.spec.ts
+++ b/src/app/map-ui/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressBarComponent } from './progress-bar.component';
+
+describe('ProgressBarComponent', () => {
+  let component: ProgressBarComponent;
+  let fixture: ComponentFixture<ProgressBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProgressBarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProgressBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/map-ui/progress-bar/progress-bar.component.ts
+++ b/src/app/map-ui/progress-bar/progress-bar.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-progress-bar',
+  templateUrl: './progress-bar.component.html',
+  styleUrls: ['./progress-bar.component.scss']
+})
+export class ProgressBarComponent implements OnInit {
+  indeterminate = true;
+  // Input shoud be between 0 and 1
+  @Input() progress: number;
+  get percent(): string { return (this.progress * 100) + '%'; }
+
+  constructor() { }
+
+  ngOnInit() {
+    this.indeterminate = typeof this.progress !== 'number';
+  }
+
+}

--- a/src/app/map-ui/progress-bar/progress-bar.theme.scss
+++ b/src/app/map-ui/progress-bar/progress-bar.theme.scss
@@ -1,0 +1,4 @@
+// Progress bar theme
+@mixin progress-bar-bg($progressBarColor) {
+    background: $progressBarColor;
+}

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -155,6 +155,13 @@ export class MapService {
   }
 
   /**
+   * Helper for checking whether or not the map is currently loading
+   */
+  isMapLoading() {
+    return !this.map.areTilesLoaded();
+  }
+
+  /**
    * Zoom to supplied map features
    * @param feature
    */


### PR DESCRIPTION
Closes #52. Relatively straightforward, but after seeing how often the map loads, I think using a bar rather than spinner is good because it shows up a lot and this is visible but not too intrusive.

Also, I used the `:host` selector to make it completely full-width, but I can use a container element that in if it makes more sense.