### PR TITLE
Add getUnionFeature to consolidate hover features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,14 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.3.tgz",
       "integrity": "sha1-A4lwF46QyOQ899/tedV4IpihCA0="
     },
+    "@turf/union": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-4.7.3.tgz",
+      "integrity": "sha1-AS1Kx0ZdbK1n/klI1AG3+L4P5BI=",
+      "requires": {
+        "jsts": "1.3.0"
+      }
+    },
     "@types/d3": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.10.1.tgz",
@@ -523,11 +531,6 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.42.tgz",
       "integrity": "sha1-dMt3+2BS7a/yqJhN2v2I1BnyXKw=",
       "dev": true
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "abbrev": {
       "version": "1.1.0",
@@ -4383,6 +4386,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4391,14 +4402,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5947,6 +5950,16 @@
           "dev": true
         }
       }
+    },
+    "jsts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-1.3.0.tgz",
+      "integrity": "sha1-6Tp2+XrJvafUYl2dZHDw1grIDkU="
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "karma": {
       "version": "1.7.0",
@@ -9620,6 +9633,11 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -9646,11 +9664,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -10419,8 +10432,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
-      "dev": true
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "v8flags": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
     "@turf/bbox": "^4.7.3",
+    "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.39.5",
     "angular-d3-graph": "^0.1.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -151,7 +151,8 @@ export class AppComponent {
       this.hover_HACK = 0;
       this.hoveredFeature = feature;
       if (this.hoveredFeature) {
-        this.map.setSourceData('hover', feature);
+        const union = this.map.getUnionFeature(this.activeDataLevel.id, feature);
+        this.map.setSourceData('hover', union);
       } else {
         this.map.setSourceData('hover');
       }


### PR DESCRIPTION
Instead of modifying the source data and creating larger tilesets to account for features used in the hover layer being split in vector tiling, this uses the spatial union function from turf.js to combine the geographies of all features matching the name and parent-location of a feature (which should be unique). Performance doesn't appear to suffer.