### PR TITLE
Remove zoom slider and replace with buttons, add geolocation control

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,14 +30,6 @@
     </div>
     <div class="map-ui-wrapper">
         <app-progress-bar *ngIf="mapLoading"></app-progress-bar>
-        <app-ui-slider class="zoom-slider" tabindex="3"
-            [vertical]="true"
-            [currentValue]="zoom" 
-            [step]="0.1"
-            [min]="mapConfig.minZoom" 
-            [max]="mapConfig.maxZoom" 
-            (change)="setMapZoomLevel($event)">
-        </app-ui-slider>
         <div class="map-ui">
             <app-ui-select
                 class="eviction-select"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,21 +1,9 @@
-
-
-// Zoom Control
-// - Hidden on mobile
-// - Middle of screen on left side for desktop
-.zoom-slider { 
-    display: none;
-    height: 300px;
-    width: 40px;
-    position:absolute;
-    left: 16px;
-    top:0;
-    bottom:0;
-    margin: auto;
+:host ::ng-deep .mapboxgl-ctrl-top-left {
+  top: 50px;
 }
 
-@media (min-width: 767px) {
-    .zoom-slider {
-        display:block;
+@media(max-width: 768px) {
+    :host ::ng-deep .mapboxgl-ctrl-top-left {
+        top: 175px;
     }
 }

--- a/src/app/map/mapbox/mapbox.component.scss
+++ b/src/app/map/mapbox/mapbox.component.scss
@@ -4,4 +4,8 @@
   position:absolute;
   left:0;right:0;top:0;bottom:0;
 }
-  
+
+// Hide rotate button because it's confusing
+:host ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
+  display: none;
+}

--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -34,6 +34,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map = this.mapService.createMap({
       ...this.mapConfig, container: this.mapEl.nativeElement
     });
+    this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
     this.map.on('load', () => {
       this.onMapInstance(this.map);
     });

--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -35,6 +35,7 @@ export class MapboxComponent implements AfterViewInit {
       ...this.mapConfig, container: this.mapEl.nativeElement
     });
     this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
+    this.map.addControl(new mapboxgl.GeolocateControl({showUserLocation: false}), 'top-left');
     this.map.on('load', () => {
       this.onMapInstance(this.map);
     });


### PR DESCRIPTION
Based on some of the UX feedback, it sounds like we might be removing the zoom slider and replacing it with the standard +/- buttons. A button for geolocation has also been discussed, so adding it in as well (it won't show up on staging sites because S3 sites are over HTTP)