### PR TITLE
WIP: Prototypes/low zoom layers

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -47,7 +47,7 @@
                 class="layer-select"
                 labelProperty="name"
                 [selectedValue]="activeDataLevel"
-                [values]="dataLevels" 
+                [values]="selectDataLevels"
                 (change)="setGroupVisibility($event)">
             </app-ui-select>
             <app-ui-select

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -83,7 +83,7 @@ export class AppComponent {
    */
   onMapReady(map) {
     this.map.setMapInstance(map);
-    this.activeDataLevel = this.dataLevels[5];
+    this.activeDataLevel = this.dataLevels[0];
     this.activeDataHighlight = this.attributes[0];
     this.setDataYear(this.dataYear);
     this.onMapZoom(this.mapConfig.zoom);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent {
   zoom: number;
   dataYear = 2010;
   dataLevels: Array<MapLayerGroup> = DataLevels;
+  selectDataLevels: Array<MapLayerGroup> = DataLevels.filter(l => l.minzoom < 3);
   attributes: Array<MapDataAttribute> = DataAttributes;
   hoveredFeature;
   set activeFeature(val) {
@@ -98,6 +99,10 @@ export class AppComponent {
    */
   onMapZoom(zoom) {
     this.zoom = zoom;
+    this.selectDataLevels = DataLevels.filter((l) => l.minzoom <= zoom);
+    if (this.activeDataLevel.minzoom > zoom) {
+      this.autoSwitchLayers = true;
+    }
     if (this.autoSwitchLayers) {
       const visibleGroups = this.map.filterLayerGroupsByZoom(this.dataLevels, zoom);
       if (visibleGroups.length > 0) {

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -10,6 +10,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'blockgroups_bubbles',
           'blockgroups_text'
        ],
+       'minzoom': 7,
        'zoom': [ 10, 16 ]
     },
     {
@@ -21,6 +22,7 @@ export const DataLevels: Array<MapLayerGroup> = [
         'zipcodes_bubbles',
         'zipcodes_text'
        ],
+       'minzoom': 6,
        'zoom': [ 9, 10 ]
     },
     {
@@ -32,6 +34,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'tracts_bubbles',
           'tracts_text'
        ],
+       'minzoom': 7,
        'zoom': [ 8, 9 ]
     },
     {
@@ -42,7 +45,8 @@ export const DataLevels: Array<MapLayerGroup> = [
           'cities_stroke',
           'cities_bubbles',
           'cities_text'
-       ]
+       ],
+       'minzoom': 0,
     },
     {
        'id': 'counties',
@@ -53,6 +57,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'counties_bubbles',
           'counties_text'
        ],
+       'minzoom': 0,
        'zoom': [ 5, 8 ]
     },
     {
@@ -64,6 +69,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'states_bubbles',
           'states_text'
        ],
+       'minzoom': 0,
        'zoom': [ 0, 5 ]
     }
  ];

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -2,28 +2,51 @@ import { MapLayerGroup } from '../map/map-layer-group';
 
 export const DataLevels: Array<MapLayerGroup> = [
     {
-       'id': 'blockgroups',
-       'name': 'Block Groups',
-       'layerIds': [
-          'blockgroups',
-          'blockgroups_stroke',
-          'blockgroups_bubbles',
-          'blockgroups_text'
-       ],
-       'minzoom': 7,
-       'zoom': [ 10, 16 ]
+        'id': 'states',
+        'name': 'States',
+        'layerIds': [
+            'states',
+            'states_stroke',
+            'states_bubbles',
+            'states_text'
+        ],
+        'minzoom': 0,
+        'zoom': [0, 5]
     },
     {
-       'id': 'zipcodes',
-       'name': 'Zip Codes',
-       'layerIds': [
-        'zipcodes',
-        'zipcodes_stroke',
-        'zipcodes_bubbles',
-        'zipcodes_text'
-       ],
-       'minzoom': 6,
-       'zoom': [ 9, 10 ]
+        'id': 'counties',
+        'name': 'Counties',
+        'layerIds': [
+            'counties',
+            'counties_stroke',
+            'counties_bubbles',
+            'counties_text'
+        ],
+        'minzoom': 0,
+        'zoom': [5, 8]
+    },
+    {
+        'id': 'zipcodes',
+        'name': 'Zip Codes',
+        'layerIds': [
+            'zipcodes',
+            'zipcodes_stroke',
+            'zipcodes_bubbles',
+            'zipcodes_text'
+        ],
+        'minzoom': 5,
+        'zoom': [9, 10]
+    },
+    {
+        'id': 'cities',
+        'name': ' Cities',
+        'layerIds': [
+            'cities',
+            'cities_stroke',
+            'cities_bubbles',
+            'cities_text'
+        ],
+        'minzoom': 5,
     },
     {
        'id': 'tracts',
@@ -38,38 +61,15 @@ export const DataLevels: Array<MapLayerGroup> = [
        'zoom': [ 8, 9 ]
     },
     {
-       'id': 'cities',
-       'name': ' Cities',
-       'layerIds': [
-          'cities',
-          'cities_stroke',
-          'cities_bubbles',
-          'cities_text'
-       ],
-       'minzoom': 0,
-    },
-    {
-       'id': 'counties',
-       'name': 'Counties',
-       'layerIds': [
-          'counties',
-          'counties_stroke',
-          'counties_bubbles',
-          'counties_text'
-       ],
-       'minzoom': 0,
-       'zoom': [ 5, 8 ]
-    },
-    {
-       'id': 'states',
-       'name': 'States',
-       'layerIds': [
-          'states',
-          'states_stroke',
-          'states_bubbles',
-          'states_text'
-       ],
-       'minzoom': 0,
-       'zoom': [ 0, 5 ]
+        'id': 'blockgroups',
+        'name': 'Block Groups',
+        'layerIds': [
+            'blockgroups',
+            'blockgroups_stroke',
+            'blockgroups_bubbles',
+            'blockgroups_text'
+        ],
+        'minzoom': 7,
+        'zoom': [10, 16]
     }
  ];

--- a/src/app/map/map-layer-group.ts
+++ b/src/app/map/map-layer-group.ts
@@ -5,4 +5,5 @@ export interface MapLayerGroup extends MapDataObject {
     name: string;
     layerIds?: string[];
     zoom?: Array<number>;
+    minzoom: number;
 }


### PR DESCRIPTION
This is an interaction that's been talked about, but not confirmed on whether we want to use it. Opening a PR so we don't forget we have this branch out there.

`MapLayerGroup`s now have a `minzoom` property that sets the minimum zoom level for them to be displayed. If a layer with minzoom is being viewed, and the users zooms out past the minzoom, auto switching of layers is turned back on to handle the currently displayed layer.