### PR TITLE
Use distinctUntilChanged for progress load

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/distinctUntilChanged';
 
 import { MapDataAttribute } from './map/map-data-attribute';
 import { MapLayerGroup } from './map/map-layer-group';
@@ -90,7 +91,9 @@ export class AppComponent {
     // FIXME: Doing a hack to get layers because we likely won't be loading them outside
     // of prototypes anyway
     setTimeout(() => { this.mapFeatures = this.map.queryMapLayer(this.activeDataLevel); }, 1000);
-    this.map.isLoading$.debounceTime(200).subscribe((state) => { this.mapLoading = state; });
+    this.map.isLoading$.distinctUntilChanged()
+      .debounceTime(200)
+      .subscribe((state) => { this.mapLoading = state; });
   }
 
   /**


### PR DESCRIPTION
Fixes #72. Using `debounceTime` without `distinctUntilChanged` meant the last debounced event might not be the change in state. This makes sure that only changes in state are sent, and looks like it fixes the issue