### PR TITLE
keyboard bindings for select dropdowns

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -40,10 +40,12 @@
         </app-ui-slider>
         <div class="map-ui">
             <app-ui-select
+                tabindex="4"
                 class="eviction-select"
                 [values]="['Judgments', 'Filings']"
             ></app-ui-select>
             <app-ui-select
+                tabindex="5"
                 class="layer-select"
                 labelProperty="name"
                 [selectedValue]="activeDataLevel"
@@ -51,6 +53,7 @@
                 (change)="setGroupVisibility($event)">
             </app-ui-select>
             <app-ui-select
+                tabindex="6"
                 class="highlight-select"
                 labelProperty="name"
                 [values]="attributes"

--- a/src/app/map-ui/ui-select/ui-select.component.html
+++ b/src/app/map-ui/ui-select/ui-select.component.html
@@ -4,7 +4,12 @@
   </button>
   <ul *dropdownMenu class="dropdown-menu" role="menu">
     <li *ngFor="let value of values" role="menuitem">
-      <a class="dropdown-item" (click)="changeValue(value)">{{getLabel(value)}}</a>
+      <a 
+        class="dropdown-item" 
+        [class.highlighted]="highlightedItem === value" 
+        (click)="changeValue(value)">
+        {{getLabel(value)}}
+      </a>
     </li>
   </ul>
 </div>

--- a/src/app/map-ui/ui-select/ui-select.component.scss
+++ b/src/app/map-ui/ui-select/ui-select.component.scss
@@ -1,0 +1,3 @@
+.highlighted {
+    background:#eee;
+}

--- a/src/app/map-ui/ui-select/ui-select.component.ts
+++ b/src/app/map-ui/ui-select/ui-select.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, HostListener, ViewChild } from '@angular/core';
+import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
 import { MapLayerGroup } from '../../map/map-layer-group';
 import * as _isEqual from 'lodash.isequal';
 
@@ -13,6 +14,8 @@ export class UiSelectComponent implements OnInit {
   @Input() selectedValue: any;
   @Input() values: Array<any> = [];
   @Output() change: EventEmitter<any> = new EventEmitter<any>();
+  @ViewChild(BsDropdownDirective) dropdown;
+  highlightedItem: any;
   get selectedLabel(): string { return this.getLabel(this.selectedValue); }
   private stringArray = false;
 
@@ -47,6 +50,41 @@ export class UiSelectComponent implements OnInit {
     if (_isEqual(newValue, this.selectedValue)) { return; }
     this.selectedValue = newValue;
     this.change.emit(newValue);
+  }
+
+  getNextHighlightedItem(previousItem = false) {
+    const i = this.values.findIndex((v) => _isEqual(this.highlightedItem, v));
+    const offset = previousItem ? -1 : 1;
+    return this.values[(i + offset) % this.values.length];
+  }
+
+  @HostListener('keydown', ['$event']) onFocus(e) {
+    const keys = { 'SPACE': 32, 'ENTER': 13, 'UP': 38, 'DOWN': 40, 'ESC': 27 };
+    if (this.dropdown.isOpen) {
+      if (e.keyCode === keys['UP'] || e.keyCode === keys['DOWN']) {
+        // go to next item
+        this.highlightedItem = this.getNextHighlightedItem((e.keyCode === keys['UP']));
+      }
+      if (e.keyCode === keys['SPACE'] || e.keyCode === keys['ENTER']) {
+        // select item and close
+        this.selectedValue = this.highlightedItem;
+        this.dropdown.toggle();
+      }
+      if (e.keyCode === keys['ESC']) {
+        // close
+        this.dropdown.toggle();
+      }
+    } else {
+      if (e.keyCode === keys['SPACE'] || e.keyCode === keys['UP'] || e.keyCode === keys['DOWN']) {
+        // open the menu
+        this.dropdown.toggle();
+        this.highlightedItem = this.selectedValue;
+      }
+    }
+  }
+
+  @HostListener('blur', ['$event']) onBlur(e) {
+    if (this.dropdown.isOpen) { this.dropdown.hide(); }
   }
 
 }


### PR DESCRIPTION
I used our UI Select component as a wrapper to add keyboard bindings to the bootstrap select, and added tabindex attributes in the component.  This should be the same behaviour as a native HTML select element.

Closes #36 