### PR TITLE
Switch map boolean to fix progress

### DIFF
--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -94,7 +94,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map.on('zoom', (zoomEvent) => { this.zoom.emit(this.map.getZoom()); });
     this.map.on('render', (e) => {
       this.render.emit(e);
-      this.mapService.setLoading(!this.map.areTilesLoaded());
+      this.mapService.setLoading(!this.map.loaded());
     });
     this.eventLayers.forEach((layer) => {
       this.map.on('click', layer, (e) => {


### PR DESCRIPTION
This seems like it shouldn't make a difference, and we'll need to verify, but it looks like using the more general `loaded()` (which I don't know why I didn't use in the first place) resolves the issue. To test on a deployed site, I updated one of the prototypes with this branch http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/low-zoom-layers/