### PR TITLE
Fix auto switch layers by re-ordering data levels

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -98,7 +98,7 @@ export class AppComponent {
    */
   onMapReady(map) {
     this.map.setMapInstance(map);
-    this.activeDataLevel = this.dataLevels[5];
+    this.activeDataLevel = this.dataLevels[0];
     this.activeDataHighlight = this.attributes[0];
     this.setDataYear(this.dataYear);
     this.onMapZoom(this.mapConfig.zoom);

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -2,6 +2,60 @@ import { MapLayerGroup } from '../map/map-layer-group';
 
 export const DataLevels: Array<MapLayerGroup> = [
     {
+        'id': 'states',
+        'name': 'States',
+        'layerIds': [
+            'states',
+            'states_stroke',
+            'states_bubbles',
+            'states_text'
+        ],
+        'zoom': [0, 5]
+    },
+    {
+        'id': 'counties',
+        'name': 'Counties',
+        'layerIds': [
+            'counties',
+            'counties_stroke',
+            'counties_bubbles',
+            'counties_text'
+        ],
+        'zoom': [5, 8]
+    },
+    {
+        'id': 'zipcodes',
+        'name': 'Zip Codes',
+        'layerIds': [
+            'zipcodes',
+            'zipcodes_stroke',
+            'zipcodes_bubbles',
+            'zipcodes_text'
+        ],
+        'zoom': [9, 10]
+    },
+    {
+        'id': 'cities',
+        'name': ' Cities',
+        'layerIds': [
+            'cities',
+            'cities_stroke',
+            'cities_bubbles',
+            'cities_text'
+        ]
+    },
+    {
+        'id': 'tracts',
+        'name': 'Tracts',
+        'layerIds': [
+            'tracts',
+            'tracts_stroke',
+            'tracts_bubbles',
+            'tracts_text'
+        ],
+        'zoom': [8, 9]
+    },
+    {
        'id': 'blockgroups',
        'name': 'Block Groups',
        'layerIds': [
@@ -11,59 +65,5 @@ export const DataLevels: Array<MapLayerGroup> = [
           'blockgroups_text'
        ],
        'zoom': [ 10, 16 ]
-    },
-    {
-       'id': 'zipcodes',
-       'name': 'Zip Codes',
-       'layerIds': [
-        'zipcodes',
-        'zipcodes_stroke',
-        'zipcodes_bubbles',
-        'zipcodes_text'
-       ],
-       'zoom': [ 9, 10 ]
-    },
-    {
-       'id': 'tracts',
-       'name': 'Tracts',
-       'layerIds': [
-          'tracts',
-          'tracts_stroke',
-          'tracts_bubbles',
-          'tracts_text'
-       ],
-       'zoom': [ 8, 9 ]
-    },
-    {
-       'id': 'cities',
-       'name': ' Cities',
-       'layerIds': [
-          'cities',
-          'cities_stroke',
-          'cities_bubbles',
-          'cities_text'
-       ]
-    },
-    {
-       'id': 'counties',
-       'name': 'Counties',
-       'layerIds': [
-          'counties',
-          'counties_stroke',
-          'counties_bubbles',
-          'counties_text'
-       ],
-       'zoom': [ 5, 8 ]
-    },
-    {
-       'id': 'states',
-       'name': 'States',
-       'layerIds': [
-          'states',
-          'states_stroke',
-          'states_bubbles',
-          'states_text'
-       ],
-       'zoom': [ 0, 5 ]
     }
  ];


### PR DESCRIPTION
Not sure why this hadn't been triggered earlier (potentially was refactored), but the initial on-change event for the UI-select was getting triggered after render, which then called `setGroupVisibility` and disabled auto-switching. We should probably have the layers in descending order of size anyway, so I made states the first layer as well as the default layer so that the initial load doesn't trigger a change event and it seems to be working