### PR TITLE
Fix zoom layer change, hover interactions

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -197,11 +197,17 @@ export class AppComponent {
    * @param mapLayer the layer group that was selected
    */
   setGroupVisibility(layerGroup: MapLayerGroup) {
-    this.autoSwitchLayers = false;
+    // Only change data level and turn off auto switch if wasn't already
+    // changed by the onMapZoom event handler
+    if (this.activeDataLevel !== layerGroup) {
+      this.activeDataLevel = layerGroup;
+      this.autoSwitchLayers = false;
+    }
     this.dataLevels.forEach((group: MapLayerGroup) => {
       this.map.setLayerGroupVisibility(group, (group.id === layerGroup.id));
     });
-    this.activeDataLevel = layerGroup;
+    // Reset the hover layer
+    this.map.setSourceData('hover');
   }
 
   /**


### PR DESCRIPTION
The previous PR #82 hadn't actually fixed the layers auto-switching. Because the UI select component fired an event on any change to the selected element and the `onMapZoom` event changed the selected level, even if `autoSwitchLayers` was reset in `onMapZoom` the select event would un-toggle it. 

Added a check in `setGroupVisibility` to see if the data level had already been changed in `onMapZoom`, and only toggle `autoSwitchLayers` if it had. Also emptying the hover layer on layer change so that state outlines don't appear if someone zooms in while hovering and the layer changes.