### PR TITLE
Using shortened properties

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,7 @@
             <app-predictive-search
                 class="search"
                 [options]="map.mapFeatures"
-                optionField="properties.name"
+                optionField="properties.n"
                 (selectionChange)="onSearchSelect($event)">
             </app-predictive-search>
             <app-ui-select

--- a/src/app/data-panel/data-panel.component.html
+++ b/src/app/data-panel/data-panel.component.html
@@ -3,7 +3,7 @@
       <div class="data-content-inner">
           <ul>
             <li *ngFor="let location of locations">
-              {{ location.properties["name"] }}
+              {{ location.properties["n"] }}
               <button class="btn btn-close" (click)="locationRemoved.emit(location)">&times;</button>
             </li>
           </ul>

--- a/src/app/data-panel/data-panel.component.ts
+++ b/src/app/data-panel/data-panel.component.ts
@@ -46,7 +46,7 @@ export class DataPanelComponent implements OnChanges {
         id: 'usavg',
         data: [{
           x: 'US Average',
-          y: this.locations[0].properties[`e-${this.year % 100}`] * Math.random() * 2
+          y: this.locations[0].properties[`e-${('' + this.year).slice(2)}`] * Math.random() * 2
         }]
       }
     ];
@@ -72,7 +72,7 @@ export class DataPanelComponent implements OnChanges {
       data.push(
         {
           id: 'sample' + i,
-          data: [ { x: f.properties.n, y: f.properties[`e-${this.year % 100}`] }]
+          data: [{ x: f.properties.n, y: f.properties[`e-${('' + this.year).slice(2)}`] }]
         }
       );
     });

--- a/src/app/data-panel/data-panel.component.ts
+++ b/src/app/data-panel/data-panel.component.ts
@@ -46,7 +46,7 @@ export class DataPanelComponent implements OnChanges {
         id: 'usavg',
         data: [{
           x: 'US Average',
-          y: this.locations[0].properties[`evictions-${this.year}`] * Math.random() * 2
+          y: this.locations[0].properties[`e-${this.year % 100}`] * Math.random() * 2
         }]
       }
     ];
@@ -72,7 +72,7 @@ export class DataPanelComponent implements OnChanges {
       data.push(
         {
           id: 'sample' + i,
-          data: [ { x: f.properties.name, y: f.properties[`evictions-${this.year}`] }]
+          data: [ { x: f.properties.n, y: f.properties[`e-${this.year % 100}`] }]
         }
       );
     });

--- a/src/app/data/data-attributes.ts
+++ b/src/app/data/data-attributes.ts
@@ -2,7 +2,7 @@ import { MapDataAttribute } from '../map/map-data-attribute';
 
 export const DataAttributes: Array<MapDataAttribute> = [
     {
-        'id': 'population',
+        'id': 'p',
         'name': 'Population',
         'default': 'rgba(0, 0, 0, 0)',
         'fillStops': {
@@ -44,7 +44,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
         }
     },
     {
-        'id': 'poverty-rate',
+        'id': 'pr',
         'name': 'Poverty Rate',
         'default': 'rgba(0, 0, 0, 0)',
         'fillStops': {

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -10,7 +10,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'states_bubbles',
             'states_text'
         ],
-        'zoom': [0, 5]
+        'zoom': [0, 6]
     },
     {
         'id': 'counties',
@@ -21,7 +21,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'counties_bubbles',
             'counties_text'
         ],
-        'zoom': [5, 8]
+        'zoom': [6, 8]
     },
     {
         'id': 'zipcodes',

--- a/src/app/map-ui/map-tooltip/map-tooltip.component.html
+++ b/src/app/map-ui/map-tooltip/map-tooltip.component.html
@@ -11,23 +11,23 @@
       </h1>
       <ul class="tooltip-stats">
         <li *ngIf="feature.properties['eviction-rate-' + dataYear ]">
-          <span class="stat-value">{{ feature.properties["er" + (dataYear % 100) ] | number:'1.0-0' }}</span>
+          <span class="stat-value">{{ feature.properties["er" + ('' + dataYear).slice(2) ] | number:'1.0-0' }}</span>
           <span class="stat-label">Evictions / 100 renter households</span>
         </li>
 
         <li *ngIf="feature.properties['evictions-' + dataYear ]">
-          <span class="stat-value">{{ feature.properties["e-" + (dataYear % 100) ] }}</span>
-          <span class="stat-label">{{ feature.properties["e-" + (dataYear % 100) ] | i18nPlural: evictionLabelMapping }}</span>
+          <span class="stat-value">{{ feature.properties["e-" + ('' + dataYear).slice(2) ] }}</span>
+          <span class="stat-label">{{ feature.properties["e-" + ('' + dataYear).slice(2) ] | i18nPlural: evictionLabelMapping }}</span>
         </li>
         <li *ngIf="!feature.properties['eviction-rate-' + dataYear] && !feature.properties['evictions-' + dataYear]">
             <span class="stat-value">NO DATA</span>
         </li>
         <li class="extra-stat" *ngIf="feature.properties['average-household-size-' + dataYear]">
-            <span class="stat-value">{{ feature.properties["ahs-" + (dataYear % 100)] | number:'1.0-1' }}</span>
+            <span class="stat-value">{{ feature.properties["ahs-" + ('' + dataYear).slice(2)] | number:'1.0-1' }}</span>
             <span class="stat-label">Average Household Size</span>
           </li>
         <li class="extra-stat" *ngIf="feature.properties['poverty-rate-' + dataYear]">
-          <span class="stat-value">{{ feature.properties["pr-" + (dataYear % 100)] | percent }}</span>
+          <span class="stat-value">{{ feature.properties["pr-" + ('' + dataYear).slice(2)] | percent }}</span>
           <span class="stat-label">Poverty Rate</span>
         </li>
       </ul>

--- a/src/app/map-ui/map-tooltip/map-tooltip.component.html
+++ b/src/app/map-ui/map-tooltip/map-tooltip.component.html
@@ -6,28 +6,28 @@
           <span class="glyphicon glyphicon-chevron-down"></span>
           MORE
         </button>
-        {{feature.properties.name}} 
-        <small class="header-row-subtitle">{{feature.properties["parent-location"]}}</small>
+        {{feature.properties.n}} 
+        <small class="header-row-subtitle">{{feature.properties.pl}}</small>
       </h1>
       <ul class="tooltip-stats">
         <li *ngIf="feature.properties['eviction-rate-' + dataYear ]">
-          <span class="stat-value">{{ feature.properties["eviction-rate-" + dataYear ] | number:'1.0-0' }}</span>
+          <span class="stat-value">{{ feature.properties["er" + (dataYear % 100) ] | number:'1.0-0' }}</span>
           <span class="stat-label">Evictions / 100 renter households</span>
         </li>
 
         <li *ngIf="feature.properties['evictions-' + dataYear ]">
-          <span class="stat-value">{{ feature.properties["evictions-" + dataYear ] }}</span>
-          <span class="stat-label">{{ feature.properties["evictions-" + dataYear ] | i18nPlural: evictionLabelMapping }}</span>
+          <span class="stat-value">{{ feature.properties["e-" + (dataYear % 100) ] }}</span>
+          <span class="stat-label">{{ feature.properties["e-" + (dataYear % 100) ] | i18nPlural: evictionLabelMapping }}</span>
         </li>
         <li *ngIf="!feature.properties['eviction-rate-' + dataYear] && !feature.properties['evictions-' + dataYear]">
             <span class="stat-value">NO DATA</span>
         </li>
         <li class="extra-stat" *ngIf="feature.properties['average-household-size-' + dataYear]">
-            <span class="stat-value">{{ feature.properties["average-household-size-" + dataYear] | number:'1.0-1' }}</span>
+            <span class="stat-value">{{ feature.properties["ahs-" + (dataYear % 100)] | number:'1.0-1' }}</span>
             <span class="stat-label">Average Household Size</span>
           </li>
         <li class="extra-stat" *ngIf="feature.properties['poverty-rate-' + dataYear]">
-          <span class="stat-value">{{ feature.properties["poverty-rate-" + dataYear] | percent }}</span>
+          <span class="stat-value">{{ feature.properties["pr-" + (dataYear % 100)] | percent }}</span>
           <span class="stat-label">Poverty Rate</span>
         </li>
       </ul>

--- a/src/app/map/map-feature.ts
+++ b/src/app/map/map-feature.ts
@@ -1,5 +1,5 @@
 export interface MapFeature extends GeoJSON.Feature<GeoJSON.GeometryObject> {
     properties: {
-        [name: string]: string
+        [n: string]: string
     };
 }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -116,8 +116,8 @@ export class MapService {
       layers: [layerId],
       filter: [
         'all',
-        ['==', 'name', feature.properties.name],
-        ['==', 'parent-location', feature.properties['parent-location']]
+        ['==', 'n', feature.properties.n],
+        ['==', 'pl', feature.properties.pl]
       ]
     }).reduce((currFeat, nextFeat) => {
       return union(
@@ -171,7 +171,7 @@ export class MapService {
    */
   queryMapLayer(layerGroup: MapLayerGroup) {
     return Observable.from(this.map.queryRenderedFeatures(undefined, {layers: [layerGroup.id]}))
-      .distinct((f: MapFeature) => f.properties.name);
+      .distinct((f: MapFeature) => f.properties.n);
   }
 
   /**

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -117,7 +117,7 @@ export class MapComponent {
     this.setDataHighlight(this.addYearToObject(this.activeDataHighlight, this.dataYear));
     this.setGroupVisibility(this.activeDataLevel);
     this.mapEventLayers.forEach((layer) => {
-      this.map.setLayerDataProperty(`${layer}_bubbles`, 'circle-radius', `eviction-rate-${year}`);
+      this.map.setLayerDataProperty(`${layer}_bubbles`, 'circle-radius', `er-${year % 100}`);
     });
     this.updateLegend();
   }
@@ -230,10 +230,10 @@ export class MapComponent {
    * @param year
    */
   private addYearToObject(dataObject: MapDataObject, year: number) {
-    if (/.*\d{4}.*/g.test(dataObject.id)) {
-      dataObject.id = dataObject.id.replace(/\d{4}/g, year + '');
+    if (/.*\d{2}.*/g.test(dataObject.id)) {
+      dataObject.id = dataObject.id.replace(/\d{2}/g, (year % 100) + '');
     } else {
-      dataObject.id += '-' + year;
+      dataObject.id += '-' + (year % 100);
     }
     return dataObject;
   }

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -85,6 +85,7 @@ export class MapComponent {
   setDataHighlight(attr: MapDataAttribute) {
     const dataAttr: MapDataAttribute = this.addYearToObject(attr, this.dataYear);
     this.activeDataHighlight = dataAttr;
+    console.log(this.activeDataHighlight);
     this.updateLegend();
     this.mapEventLayers.forEach((layerId) => {
       const layerStem = layerId.split('-')[0];
@@ -117,7 +118,9 @@ export class MapComponent {
     this.setDataHighlight(this.addYearToObject(this.activeDataHighlight, this.dataYear));
     this.setGroupVisibility(this.activeDataLevel);
     this.mapEventLayers.forEach((layer) => {
-      this.map.setLayerDataProperty(`${layer}_bubbles`, 'circle-radius', `er-${year % 100}`);
+      this.map.setLayerDataProperty(
+        `${layer}_bubbles`, 'circle-radius', `er-${('' + year).slice(2)}`
+      );
     });
     this.updateLegend();
   }
@@ -231,9 +234,9 @@ export class MapComponent {
    */
   private addYearToObject(dataObject: MapDataObject, year: number) {
     if (/.*\d{2}.*/g.test(dataObject.id)) {
-      dataObject.id = dataObject.id.replace(/\d{2}/g, (year % 100) + '');
+      dataObject.id = dataObject.id.replace(/\d{2}/g, ('' + year).slice(2));
     } else {
-      dataObject.id += '-' + (year % 100);
+      dataObject.id += '-' + ('' + year).slice(2);
     }
     return dataObject;
   }

--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -67,8 +67,8 @@ export class MapboxComponent implements AfterViewInit {
       const feature = e.features[0];
       if (
         !this.activeFeature ||
-        this.activeFeature.properties.name !== feature.properties.name ||
-        this.activeFeature.properties['parent-location'] !== feature.properties['parent-location']
+        this.activeFeature.properties.n !== feature.properties.n ||
+        this.activeFeature.properties.pl !== feature.properties.pl
       ) {
         this.activeFeature = feature;
         this.hoverChanged.emit(this.activeFeature);

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -11,42 +11,42 @@
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-block-groups/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-block-groups/{z}/{x}/{y}.pbf"
       ]
     },
     "us-zip-codes": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-zip-codes/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-zip-codes/{z}/{x}/{y}.pbf"
       ]
     },
     "us-tracts": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-tracts/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-tracts/{z}/{x}/{y}.pbf"
       ]
     },
     "us-cities": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-cities/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-cities/{z}/{x}/{y}.pbf"
       ]
     },
     "us-counties": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-counties/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-counties/{z}/{x}/{y}.pbf"
       ]
     },
     "us-states": {
       "type": "vector",
       "maxzoom": 10,
       "tiles": [
-        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fake/evictions-states/{z}/{x}/{y}.pbf"
+        "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/evictions-states/{z}/{x}/{y}.pbf"
       ]
     },
     "hover": {
@@ -1455,7 +1455,27 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
+        "line-opacity": {
+          "default": 0,
+          "stops": [
+            [
+              0,
+              0
+            ],
+            [
+              5,
+              0
+            ],
+            [
+              7,
+              0
+            ],
+            [
+              9,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -1481,7 +1501,27 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
+        "line-opacity": {
+          "default": 0,
+          "stops": [
+            [
+              0,
+              0
+            ],
+            [
+              3,
+              0
+            ],
+            [
+              5,
+              0
+            ],
+            [
+              7,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -1507,7 +1547,27 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
+        "line-opacity": {
+          "default": 0,
+          "stops": [
+            [
+              0,
+              0
+            ],
+            [
+              5,
+              0
+            ],
+            [
+              7,
+              0
+            ],
+            [
+              9,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -1533,7 +1593,27 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
+        "line-opacity": {
+          "default": 0,
+          "stops": [
+            [
+              0,
+              0
+            ],
+            [
+              2,
+              0
+            ],
+            [
+              3,
+              0.5
+            ],
+            [
+              4,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -2200,7 +2280,27 @@
       "paint": {
         "line-color": "rgba(0,0,0,0.1)",
         "line-width": 1,
-        "line-opacity": 1
+        "line-opacity": {
+          "default": 0,
+          "stops": [
+            [
+              0,
+              0
+            ],
+            [
+              5,
+              0
+            ],
+            [
+              7,
+              0
+            ],
+            [
+              9,
+              1
+            ]
+          ]
+        }
       }
     },
     {

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -2329,7 +2329,7 @@
           ]
         },
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [
@@ -2608,7 +2608,7 @@
         "circle-stroke-color": "rgba(255, 255, 255, 1)",
         "circle-stroke-width": 2,
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [
@@ -2816,7 +2816,7 @@
         "circle-stroke-color": "rgba(255, 255, 255, 1)",
         "circle-stroke-width": 2,
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [
@@ -3103,7 +3103,7 @@
         "circle-stroke-color": "rgba(255, 255, 255, 1)",
         "circle-stroke-width": 2,
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [
@@ -3303,7 +3303,7 @@
         "circle-stroke-color": "rgba(255, 255, 255, 1)",
         "circle-stroke-width": 2,
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [
@@ -3793,7 +3793,7 @@
         "circle-stroke-width": 2,
         "circle-stroke-color": "rgba(255, 255, 255, 1)",
         "circle-radius": {
-          "property": "eviction-rate-2010",
+          "property": "er-10",
           "default": 0,
           "stops": [
             [

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -2553,7 +2553,7 @@
       "source-layer": "block-groups-centers",
       "minzoom": 8,
       "layout": {
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-font": [
           "Metropolis Regular",
           ""
@@ -2762,7 +2762,7 @@
       "source-layer": "tracts-centers",
       "minzoom": 8,
       "layout": {
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-ignore-placement": false,
         "text-allow-overlap": false,
         "text-font": [
@@ -3040,7 +3040,7 @@
       "source-layer": "counties-centers",
       "minzoom": 7,
       "layout": {
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-allow-overlap": false,
         "text-ignore-placement": false,
         "text-anchor": "center",
@@ -3228,7 +3228,7 @@
       "source": "us-states",
       "source-layer": "states-centers",
       "layout": {
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-size": {
           "stops": [
             [
@@ -3710,7 +3710,7 @@
             ]
           ]
         },
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-letter-spacing": 0.07
       },
       "paint": {
@@ -3947,7 +3947,7 @@
       "source-layer": "zip-codes-centers",
       "minzoom": 8,
       "layout": {
-        "text-field": "{name}",
+        "text-field": "{n}",
         "text-ignore-placement": false,
         "text-allow-overlap": false,
         "text-font": [


### PR DESCRIPTION
Shortens the property names, updates the endpoint for tiles, and reduces line opacity to make some of the new shapes less apparent. I deployed it here http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/shorthand-props/

Most of the work on this was really getting the tiles to cooperate, so https://github.com/EvictionLab/eviction-lab-etl/pull/24 can be merged when this is. Also, the gzip encoding reduces the size significantly, so this amount of data (running it with 2001-2010) is actually pretty manageable 