### PR TITLE
Prototype for Mapzen search geocoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@angular-devkit/build-optimizer": {
       "version": "0.0.13",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.13.tgz",
-      "integrity": "sha512-yEMkYU4YU8XlA5OauPhg22ZEWJ4X2VhiFKUwfeo4UWJ7lz4XWiuBJocrT5NHWqI1S0rOLpSixLXG9byvFMbavA==",
+      "integrity": "sha1-zzl692q+iZqpCdSnNRBmlMofCM8=",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -26,7 +26,7 @@
     "@angular/cli": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.3.0.tgz",
-      "integrity": "sha512-Sv6Gly7yNPZtNEsJJegtHxUTrkrvl0IsDRVcALrBQzdMvMXRWOEhn1jrdOY5HtU9eFQ27sdqrwijUVrTabZubw==",
+      "integrity": "sha1-FA/mmFCKjAI7S32gHAzAY89xEBg=",
       "dev": true,
       "requires": {
         "@angular-devkit/build-optimizer": "0.0.13",
@@ -207,6 +207,11 @@
       "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.1.0.tgz",
       "integrity": "sha1-Ht6pwL9nFbIXFxumBkbCAa9SD2o="
     },
+    "@mapbox/sphericalmercator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
+      "integrity": "sha1-cCN7l3QJXtHP286nqP0fyCsmkfI="
+    },
     "@mapbox/tiny-sdf": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
@@ -239,7 +244,7 @@
     "@ngtools/webpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.6.0.tgz",
-      "integrity": "sha512-qlY3Fj5ZJULIeFVvnnmzrKJCJnBkZ3rDf6ApaSc3uAAlhWjmBenUCJKlDQFTYZ6SuixmGYN3WTR5kGy6P7jZrA==",
+      "integrity": "sha1-YmLxECg/y/76KtRbx5wshVw5Y7s=",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -254,6 +259,19 @@
       "requires": {
         "@turf/meta": "4.7.3"
       }
+    },
+    "@turf/inside": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-4.7.3.tgz",
+      "integrity": "sha1-5KhJafKIaJGzQ7Ebg/2jCV+6VCw=",
+      "requires": {
+        "@turf/invariant": "4.7.3"
+      }
+    },
+    "@turf/invariant": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-4.7.3.tgz",
+      "integrity": "sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0="
     },
     "@turf/meta": {
       "version": "4.7.3",
@@ -494,7 +512,7 @@
     "@types/jasmine": {
       "version": "2.5.53",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.53.tgz",
-      "integrity": "sha512-2YNL0jXYuN7w07mb1sMZQ6T6zOvGi83v8UbjhBZ8mhvI1VkQ2STU9XOrTFyvWswMyh5rW1evS+e7qltYJvTqPA==",
+      "integrity": "sha1-TgzvrQnfXsSMjdQEM1EvhLFWjWE=",
       "dev": true
     },
     "@types/jasminewd2": {
@@ -517,7 +535,7 @@
     "@types/node": {
       "version": "6.0.87",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.87.tgz",
-      "integrity": "sha512-Xo0pYENOBaGtJUhi50KH6gdBNQmZQQxAwBArsJpBd15ncoz+LZD5Ev14vuezcw62CsQ1q6bM++7jA6jfwaAbfQ==",
+      "integrity": "sha1-WrV3T4NRozqTUJn6a+hQqgsK1WQ=",
       "dev": true
     },
     "@types/q": {
@@ -531,11 +549,6 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.42.tgz",
       "integrity": "sha1-dMt3+2BS7a/yqJhN2v2I1BnyXKw=",
       "dev": true
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "abbrev": {
       "version": "1.1.0",
@@ -556,7 +569,7 @@
     "acorn": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+      "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
@@ -731,7 +744,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -756,7 +769,7 @@
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
       "dev": true
     },
     "are-we-there-yet": {
@@ -778,7 +791,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -793,7 +806,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -822,7 +835,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-find-index": {
@@ -918,7 +931,7 @@
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -1088,7 +1101,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "backo2": {
       "version": "1.0.2",
@@ -1111,7 +1124,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
       "dev": true
     },
     "base64id": {
@@ -1198,7 +1211,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
@@ -1624,7 +1637,7 @@
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -1635,7 +1648,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -1650,7 +1663,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1678,7 +1691,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -1904,7 +1917,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "common-tags": {
@@ -2006,7 +2019,7 @@
     "connect": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
-      "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
+      "integrity": "sha1-9zINRqJbS+e0g6IjZRfySx4n4wE=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -2093,7 +2106,7 @@
     "cosmiconfig": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -2171,7 +2184,7 @@
     "crypto-browserify": {
       "version": "3.11.1",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -2619,7 +2632,7 @@
     "diff": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+      "integrity": "sha1-BWaVFQ16qTI3yn43isOxaCt5Y7k=",
       "dev": true
     },
     "diffie-hellman": {
@@ -2676,7 +2689,7 @@
     "dns-packet": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
-      "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+      "integrity": "sha1-qKJr7HZGQ4lj/Ibgb4+LFtbIv3o=",
       "dev": true,
       "requires": {
         "ip": "1.1.5",
@@ -2999,7 +3012,7 @@
     "es5-ext": {
       "version": "0.10.27",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
-      "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
+      "integrity": "sha1-v5JrBYxisctd4aiHkwZztqptmmY=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -3357,7 +3370,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk=",
           "dev": true
         }
       }
@@ -3510,7 +3523,7 @@
     "finalhandler": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "integrity": "sha1-GFdPLnxLmLiuOyMMIfIB8xvbP7c=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -3625,7 +3638,7 @@
     "fsevents": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4391,6 +4404,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4399,14 +4420,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4661,7 +4674,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -4694,7 +4707,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -4867,7 +4880,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -4939,7 +4952,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "hpack.js": {
@@ -4963,7 +4976,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -4978,7 +4991,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -5001,7 +5014,7 @@
     "html-minifier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
-      "integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
+      "integrity": "sha1-SideOxoWY5q7ebTBEZH/DQ/PGrk=",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
@@ -5153,7 +5166,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
       "dev": true
     },
     "icss-replace-symbols": {
@@ -5180,7 +5193,7 @@
         "postcss": {
           "version": "6.0.9",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
-          "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+          "integrity": "sha1-VIGXZnhKUcZbHsTVTC+TdlQ4w1o=",
           "dev": true,
           "requires": {
             "chalk": "2.1.0",
@@ -5191,7 +5204,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5490,7 +5503,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -5624,13 +5637,13 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-      "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+      "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
       "dev": true,
       "requires": {
         "append-transform": "0.4.0"
@@ -5654,7 +5667,7 @@
     "istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+      "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.1",
@@ -5666,7 +5679,7 @@
     "istanbul-lib-source-maps": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-      "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+      "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -5679,7 +5692,7 @@
     "istanbul-reports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-      "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+      "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
       "dev": true,
       "requires": {
         "handlebars": "4.0.10"
@@ -5858,7 +5871,7 @@
     "jschardet": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k=",
       "dev": true
     },
     "jsesc": {
@@ -5870,7 +5883,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
       "dev": true
     },
     "json-schema": {
@@ -5960,6 +5973,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsts/-/jsts-1.3.0.tgz",
       "integrity": "sha1-6Tp2+XrJvafUYl2dZHDw1grIDkU="
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "karma": {
       "version": "1.7.0",
@@ -6352,7 +6370,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -6368,7 +6386,7 @@
     "magic-string": {
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
-      "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+      "integrity": "sha1-MQObTkA2Y5VhjB1s+Bk8U5F0df8=",
       "dev": true,
       "requires": {
         "vlq": "0.2.2"
@@ -6489,7 +6507,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -6504,7 +6522,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -6623,7 +6641,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -6731,7 +6749,7 @@
     "ngx-bootstrap": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.1.tgz",
-      "integrity": "sha512-AiV26G4pEp6K7oX59fg+ywTI7i6kVnbzOPkX9DroakVYyXkBPMJGYcDI4T+5L+P/kQXzukDjKrO9ojGfGVkLPQ=="
+      "integrity": "sha1-Ce0G2Qj187sj+CGg+0UumhfXZls="
     },
     "no-case": {
       "version": "2.3.1",
@@ -6826,7 +6844,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -6841,7 +6859,7 @@
             "string_decoder": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -6948,7 +6966,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -6996,7 +7014,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -7122,7 +7140,7 @@
     "opn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+      "integrity": "sha1-cs4jBqF9vqWP8QQYUzUrSo/HdRk=",
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
@@ -7404,7 +7422,7 @@
     "pbkdf2": {
       "version": "3.0.13",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+      "integrity": "sha1-w30pVTHnhrHaPj6tyEBCasywriU=",
       "dev": true,
       "requires": {
         "create-hash": "1.1.3",
@@ -7729,7 +7747,7 @@
         "postcss": {
           "version": "6.0.9",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
-          "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+          "integrity": "sha1-VIGXZnhKUcZbHsTVTC+TdlQ4w1o=",
           "dev": true,
           "requires": {
             "chalk": "2.1.0",
@@ -7740,7 +7758,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7767,7 +7785,7 @@
         "postcss": {
           "version": "6.0.9",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
-          "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+          "integrity": "sha1-VIGXZnhKUcZbHsTVTC+TdlQ4w1o=",
           "dev": true,
           "requires": {
             "chalk": "2.1.0",
@@ -7778,7 +7796,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7805,7 +7823,7 @@
         "postcss": {
           "version": "6.0.9",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
-          "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+          "integrity": "sha1-VIGXZnhKUcZbHsTVTC+TdlQ4w1o=",
           "dev": true,
           "requires": {
             "chalk": "2.1.0",
@@ -7816,7 +7834,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7843,7 +7861,7 @@
         "postcss": {
           "version": "6.0.9",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
-          "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+          "integrity": "sha1-VIGXZnhKUcZbHsTVTC+TdlQ4w1o=",
           "dev": true,
           "requires": {
             "chalk": "2.1.0",
@@ -7854,7 +7872,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8030,7 +8048,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8270,7 +8288,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -8311,7 +8329,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -8407,7 +8425,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -8422,7 +8440,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -8475,7 +8493,7 @@
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE=",
       "dev": true
     },
     "regex-cache": {
@@ -8625,7 +8643,7 @@
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -8679,7 +8697,7 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "integrity": "sha1-LpZJFZmpbN4bUV1WdKj3qRRSkmo=",
       "dev": true
     },
     "run-async": {
@@ -8714,7 +8732,7 @@
     "rxjs": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "integrity": "sha1-B1jN3uYDPWjg/VNnbw81ls49SD8=",
       "requires": {
         "symbol-observable": "1.0.4"
       }
@@ -8722,7 +8740,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -8739,7 +8757,7 @@
     "sass-loader": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
-      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "integrity": "sha1-6dXmwfFV+qMqSybXqbcQfCJeQPk=",
       "dev": true,
       "requires": {
         "async": "2.5.0",
@@ -8769,7 +8787,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "schema-utils": {
@@ -8857,7 +8875,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "semver-dsl": {
@@ -9359,7 +9377,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -9374,7 +9392,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -9517,7 +9535,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -9532,7 +9550,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -9559,7 +9577,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -9574,7 +9592,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -9585,7 +9603,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -9604,7 +9622,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -9619,7 +9637,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -9633,10 +9651,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -9659,11 +9682,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -9904,7 +9922,7 @@
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "integrity": "sha1-lspT9LeUpefA4b18yIo3Ipj6AeY=",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -10135,7 +10153,7 @@
     "uglify-js": {
       "version": "3.0.27",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
-      "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+      "integrity": "sha1-qX24yLprnbpOL4jYaqlUj6YyADQ=",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
@@ -10346,7 +10364,7 @@
     "url-loader": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+      "integrity": "sha1-zI/qgse5Bud3cBklCGnlaemVwpU=",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -10432,12 +10450,12 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "v8flags": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
-      "integrity": "sha512-AGl+C+4qpeSu2g3JxCD/mGFFOs/vVZ3XREkD3ibQXEqr4Y4zgIrPWW124/IKJFHOIVFIoH8miWrLf0o84HYjwA==",
+      "integrity": "sha1-S+lgRIjgxBI2Rd73BbGEjRa44B8=",
       "dev": true,
       "requires": {
         "user-home": "1.1.1"
@@ -10517,7 +10535,7 @@
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+      "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
       "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2",
@@ -10663,7 +10681,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -10710,7 +10728,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -10876,7 +10894,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "integrity": "sha1-xzVkNqTRMSO+LiQmoF0drZy+Zc8=",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
@@ -10931,7 +10949,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -10946,7 +10964,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -11049,7 +11067,7 @@
     "xml2js": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.18.tgz",
-      "integrity": "sha512-MMUtkwryoXmYoFUBT32tf7vYPHr98h6VtRLVbsjfmS5hqpp/deRMUNLZNQUHEAY4ChwyBEkisDYhH/EP15X6oA==",
+      "integrity": "sha1-oRfsgVOu6yL5VBv76IBeNdrnuWk=",
       "dev": true,
       "requires": {
         "sax": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
+    "@mapbox/sphericalmercator": "^1.0.5",
+    "@mapbox/vector-tile": "^1.3.0",
     "@turf/bbox": "^4.7.3",
+    "@turf/inside": "^4.7.3",
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.39.5",
@@ -31,6 +34,7 @@
     "lodash.isequal": "^4.5.0",
     "mapbox-gl": "^0.40.1",
     "ngx-bootstrap": "^1.9.1",
+    "pbf": "^3.1.0",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14"
   },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,8 +4,9 @@
             <img src="./assets/logo.png" class="header-logo" />
             <app-predictive-search
                 class="search"
-                [options]="map.mapFeatures"
-                optionField="properties.n"
+                [(selected)]="search.query"
+                [options]="search.results"
+                optionField="properties.name"
                 (selectionChange)="onSearchSelect($event)">
             </app-predictive-search>
             <app-ui-select

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,9 +2,11 @@ import { TestBed, async } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
 import { MapModule } from './map/map.module';
+import { HttpModule } from '@angular/http';
 import { DataPanelModule } from './data-panel/data-panel.module';
 import { MapUiModule } from './map-ui/map-ui.module';
 import { PlatformService } from './platform.service';
+import { SearchService } from './search/search.service';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -15,12 +17,13 @@ describe('AppComponent', () => {
       imports: [
         MapUiModule,
         MapModule,
-        DataPanelModule
+        DataPanelModule,
+        HttpModule
       ],
       declarations: [
         AppComponent
       ],
-      providers: [ PlatformService ]
+      providers: [ PlatformService, SearchService ]
     }).compileComponents();
   }));
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,21 +1,24 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { HttpModule } from '@angular/http';
 
 import { AppComponent } from './app.component';
 import { MapModule } from './map/map.module';
 import { MapUiModule } from './map-ui/map-ui.module';
 import { DataPanelModule } from './data-panel/data-panel.module';
 import { PlatformService } from './platform.service';
+import { SearchService } from './search/search.service';
 
 @NgModule({
   declarations: [ AppComponent ],
   imports: [
+    HttpModule,
     MapUiModule,
     DataPanelModule,
     BrowserModule,
     MapModule
   ],
-  providers: [ PlatformService ],
+  providers: [ PlatformService, SearchService ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule { }

--- a/src/app/data/data-attributes.ts
+++ b/src/app/data/data-attributes.ts
@@ -11,12 +11,12 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [50000, 'rgba(137, 140, 206, 0.8)'],
                 [100000, 'rgba(64, 71, 124, 0.9)']
             ],
-            'blockgroups': [
+            'block-groups': [
                 [0, 'rgba(238, 226, 239, 0.7)'],
                 [2500, 'rgba(137, 140, 206, 0.8)'],
                 [5000, 'rgba(64, 71, 124, 0.9)']
             ],
-            'zipcodes': [
+            'zip-codes': [
                 [0, 'rgba(238, 226, 239, 0.7)'],
                 [5000, 'rgba(137, 140, 206, 0.8)'],
                 [10000, 'rgba(64, 71, 124, 0.9)']

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -24,13 +24,13 @@ export const DataLevels: Array<MapLayerGroup> = [
         'zoom': [6, 8]
     },
     {
-        'id': 'zipcodes',
+        'id': 'zip-codes',
         'name': 'Zip Codes',
         'layerIds': [
-            'zipcodes',
-            'zipcodes_stroke',
-            'zipcodes_bubbles',
-            'zipcodes_text'
+            'zip-codes',
+            'zip-codes_stroke',
+            'zip-codes_bubbles',
+            'zip-codes_text'
         ],
         'zoom': [9, 10]
     },
@@ -56,13 +56,13 @@ export const DataLevels: Array<MapLayerGroup> = [
         'zoom': [8, 9]
     },
     {
-       'id': 'blockgroups',
+       'id': 'block-groups',
        'name': 'Block Groups',
        'layerIds': [
-          'blockgroups',
-          'blockgroups_stroke',
-          'blockgroups_bubbles',
-          'blockgroups_text'
+          'block-groups',
+          'block-groups_stroke',
+          'block-groups_bubbles',
+          'block-groups_text'
        ],
        'zoom': [ 10, 16 ]
     }

--- a/src/app/map-ui/predictive-search/predictive-search.component.html
+++ b/src/app/map-ui/predictive-search/predictive-search.component.html
@@ -1,10 +1,12 @@
 <div class="search-container">
   <span class="glyphicon glyphicon-search"></span>
-  <input [(ngModel)]="selected" 
+  <input [ngModel]="selected"
+         (ngModelChange)="selectedTextChange($event)"
          [typeahead]="options || []" 
          [typeaheadOptionField]="optionField ? optionField : null"
          [typeaheadOptionsLimit]="optionsLimit"
          (typeaheadOnSelect)="updateSelection($event)"
+         [typeaheadWaitMs]="waitMs"
          placeholder="Search for..."
          class="form-control">
   <span class="clear"

--- a/src/app/map-ui/predictive-search/predictive-search.component.ts
+++ b/src/app/map-ui/predictive-search/predictive-search.component.ts
@@ -8,15 +8,26 @@ import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
   styleUrls: ['./predictive-search.component.scss']
 })
 export class PredictiveSearchComponent implements OnInit {
-  public selected: Object;
+  @Input() selected: any;
   @Input() optionField: string;
   @Input() options: Object[];
   @Input() optionsLimit = 5;
+  @Input() waitMs = 500;
+  @Output() selectedChange = new EventEmitter();
   @Output() selectionChange: EventEmitter<Object> = new EventEmitter<Object>();
 
   constructor() { }
 
   ngOnInit() { }
+
+  /**
+   * Updates the ngModel value and emits it for parent components
+   * @param selectedText updated ngModel value
+   */
+  selectedTextChange(selectedText) {
+    this.selected = selectedText;
+    this.selectedChange.emit(selectedText);
+  }
 
   /**
    * Emit the selection object on typeahead select

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -51,7 +51,7 @@ export class MapComponent {
   };
   legend;
   mapEventLayers: Array<string> =
-    [ 'states', 'cities', 'tracts', 'blockgroups', 'zipcodes', 'counties' ];
+    [ 'states', 'cities', 'tracts', 'block-groups', 'zip-codes', 'counties' ];
   mapLoading = false;
   private _bounds;
 
@@ -76,6 +76,15 @@ export class MapComponent {
     });
     // Reset the hover layer
     this.map.setSourceData('hover');
+  }
+
+  /**
+   * Set data level based on layer ID string input
+   * @param layerId layer ID string
+   */
+  setDataLevelFromLayer(layerId: string) {
+    const dataLevel = this.dataLevels.filter(l => l.id === layerId)[0];
+    this.setGroupVisibility(dataLevel);
   }
 
   /**

--- a/src/app/search/search.service.spec.ts
+++ b/src/app/search/search.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SearchService]
+    });
+  });
+
+  it('should be created', inject([SearchService], (service: SearchService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/search/search.service.spec.ts
+++ b/src/app/search/search.service.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed, inject } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
 
 import { SearchService } from './search.service';
 
 describe('SearchService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [HttpModule],
       providers: [SearchService]
     });
   });

--- a/src/app/search/search.service.ts
+++ b/src/app/search/search.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Http, ResponseContentType } from '@angular/http';
+import { MapFeature } from '../map/map-feature';
+import * as SphericalMercator from '@mapbox/sphericalmercator';
+import * as vt from '@mapbox/vector-tile';
+import * as Protobuf from 'pbf';
+import * as inside from '@turf/inside';
+import * as bbox from '@turf/bbox';
+
+const MapzenLayerMap = {
+  'region': 'states',
+  'county': 'counties',
+  'locality': 'cities',
+  'localadmin': 'cities',
+  'postalcode': 'zip-codes'
+};
+
+@Injectable()
+export class SearchService {
+  apiKey = 'mapzen-FgUaZ97';
+  mapzenParams = [
+    'sources=whosonfirst',
+    'layers=localadmin,locality,county,region,postalcode',
+    'boundary.country=USA',
+    'api_key=' + this.apiKey
+  ];
+  mapzenBase = 'https://search.mapzen.com/v1/autocomplete?';
+  tileBase = 'https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/';
+  maxZoom = 10;
+  mercator = new SphericalMercator({ size: 256 });
+  query: string;
+  private _results = new BehaviorSubject<Object[]>([]);
+  results: Observable<Object[]>;
+
+  constructor(private http: Http) {
+    this.results = Observable.create((observer: any) => {
+      this.queryGeocoder(this.query)
+        .subscribe((results: Object[]) => {
+          observer.next(results);
+        });
+    });
+  }
+
+  /**
+   * Queries Mapzen geocoder and returns an observable with results
+   * @param query string to be sent to Mapzen API
+   */
+  queryGeocoder(query: string): Observable<Object[]> {
+    return this.http.get(`${this.mapzenBase}text=${query}&${this.mapzenParams.join('&')}`)
+      .map(res => res.json().features);
+  }
+
+  /**
+   * Accepts a Mapzen layer string, returns the name of the tile layer to query
+   * @param layerStr Mapzen layer name
+   */
+  getLayerName(layerStr: string) {
+    return MapzenLayerMap.hasOwnProperty(layerStr) ? MapzenLayerMap[layerStr] : 'block-groups';
+  }
+
+  /**
+   * Takes the layer to be queried and coordinates for an object,
+   * determines which tile to request, parses it, and then returns
+   * the first feature that the includes the coordinate point
+   *
+   * @param layerId ID of layer to query for tile data
+   * @param lonLat array of [lon, lat]
+   */
+  getTileData(layerId: string, lonLat: number[]): Observable<MapFeature> {
+    const point = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: lonLat },
+      properties: {}
+    } as GeoJSON.Feature<GeoJSON.Point>;
+    const coords = this.mercator.xyz([lonLat[0], lonLat[1], lonLat[0], lonLat[1]], this.maxZoom);
+
+    return this.http.get(
+      `${this.tileBase}evictions-${layerId}/${this.maxZoom}/${coords.maxX}/${coords.maxY}.pbf`,
+      { responseType: ResponseContentType.ArrayBuffer }
+    ).map(res => {
+      const tile = new vt.VectorTile(new Protobuf(res.arrayBuffer()));
+      const layer = tile.layers[layerId];
+      for (let i = 0; i < layer.length; ++i) {
+        // console.log(layer.feature(i));
+        const feat = layer.feature(i).toGeoJSON(coords.maxX, coords.maxY, this.maxZoom);
+        if (inside(point, feat)) {
+          feat.properties.bbox = bbox(feat);
+          return feat;
+        }
+      }
+      // Return empty object if nothing found for now
+      return {};
+    });
+  }
+
+}

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1433,7 +1433,7 @@
       }
     },
     {
-      "id": "blockgroups",
+      "id": "block-groups",
       "type": "fill",
       "source": "us-block-groups",
       "source-layer": "block-groups",
@@ -1445,7 +1445,7 @@
       }
     },
     {
-      "id": "blockgroups_stroke",
+      "id": "block-groups_stroke",
       "type": "line",
       "source": "us-block-groups",
       "source-layer": "block-groups",
@@ -1479,7 +1479,7 @@
       }
     },
     {
-      "id": "zipcodes",
+      "id": "zip-codes",
       "type": "fill",
       "source": "us-zip-codes",
       "source-layer": "zip-codes",
@@ -1491,7 +1491,7 @@
       }
     },
     {
-      "id": "zipcodes_stroke",
+      "id": "zip-codes_stroke",
       "type": "line",
       "source": "us-zip-codes",
       "source-layer": "zip-codes",
@@ -2304,7 +2304,7 @@
       }
     },
     {
-      "id": "blockgroups_bubbles",
+      "id": "block-groups_bubbles",
       "type": "circle",
       "source": "us-block-groups",
       "source-layer": "block-groups-centers",
@@ -2547,7 +2547,7 @@
       }
     },
     {
-      "id": "blockgroups_text",
+      "id": "block-groups_text",
       "type": "symbol",
       "source": "us-block-groups",
       "source-layer": "block-groups-centers",
@@ -3768,7 +3768,7 @@
       }
     },
     {
-      "id": "zipcodes_bubbles",
+      "id": "zip-codes_bubbles",
       "type": "circle",
       "source": "us-zip-codes",
       "source-layer": "zip-codes-centers",
@@ -3941,7 +3941,7 @@
       }
     },
     {
-      "id": "zipcodes_text",
+      "id": "zip-codes_text",
       "type": "symbol",
       "source": "us-zip-codes",
       "source-layer": "zip-codes-centers",


### PR DESCRIPTION
Added Mapzen geocoding with the search service. Had to modify the predictive search component to use the `waitMs` parameter and debounce searches as well as emit changes to search text to parent component. Also fixed inconsistences in naming in style.json (block groups was `block-groups` everywhere but there), to search layer selection work. 

Not sure if the way the app component is changing the layer on the map (`setDataLevelFromLayer`) is the best, but it's a placeholder for now. Also not sure about the best way of testing the service, other than stubbing requests.