### PR TITLE
Check for negative NA value in cards

### DIFF
--- a/src/app/location-cards/location-cards.component.html
+++ b/src/app/location-cards/location-cards.component.html
@@ -7,7 +7,7 @@
     <ul class="card-stats">
       <li *ngFor="let propName of cardPropertyKeys; let i = index;">
         <span class="card-stat-label">{{ cardProperties[propName] }}</span>
-        <span class="card-stat-value">{{ (f.properties[propName + '-' + abbrYear]) || 'Unavailable' }}</span>
+        <span class="card-stat-value">{{ f.properties[propName + '-' + abbrYear] >= 0 ? (f.properties[propName + '-' + abbrYear]) : 'Unavailable' }}</span>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Updating the tiles to use -1.0 as an NA value. This will reduce the tile size a bit because the protobufs will be able to use a "Number" type rather than mixed, and it'll also make it easier to distinguish between 0 and null.

For now it looks like the location cards are the main place displaying the values, but I'm not sure about the best way of checking for this in the graph component. Any ideas?