### PR TITLE
Update hover feature on zoomend

### DIFF
--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -250,7 +250,7 @@ export class MapComponent {
    */
   onFeatureHover(feature) {
     this.featureHover.emit(feature);
-    if (feature) {
+    if (feature && feature.layer.id === this.activeDataLevel.id) {
       const union = this.map.getUnionFeature(this.activeDataLevel.id, feature);
       this.map.setSourceData('hover', union);
     } else {

--- a/src/app/map/mapbox/mapbox.component.ts
+++ b/src/app/map/mapbox/mapbox.component.ts
@@ -96,6 +96,12 @@ export class MapboxComponent implements AfterViewInit {
     // Emit all zoom end events from map
     this.map.on('moveend', (e) => { this.moveEnd.emit(e); });
     this.map.on('zoom', (zoomEvent) => { this.zoom.emit(this.map.getZoom()); });
+    // Emit feature on zoom end to account for geography details changing across zooms
+    this.map.on('zoomend', () => {
+      if (this.activeFeature) {
+        this.hoverChanged.emit(this.activeFeature);
+      }
+    });
     this.map.on('render', (e) => {
       this.render.emit(e);
       this.mapService.setLoading(!this.map.loaded());


### PR DESCRIPTION
I've been noticing that when you zoom in while still hovering on the same feature, it becomes really obvious how much they're generalized at lower zooms. Emitting `activeFeature`, if it exists, on `zoomend` to update the geography. Also checking that `activeFeature` is part of the current layer in the map component if the layer automatically changes in between zoom.