### PR TITLE
Restrict layers by zoom level

### DIFF
--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -10,6 +10,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'states_bubbles',
             'states_text'
         ],
+        'minzoom': 0,
         'zoom': [0, 7]
     },
     {
@@ -21,6 +22,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'counties_bubbles',
             'counties_text'
         ],
+        'minzoom': 0,
         'zoom': [7, 9]
     },
     {
@@ -32,6 +34,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'zip-codes_bubbles',
             'zip-codes_text'
         ],
+        'minzoom': 6,
         'zoom': [9, 11]
     },
     {
@@ -42,7 +45,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'cities_stroke',
             'cities_bubbles',
             'cities_text'
-        ]
+        ],
+        'minzoom': 7
     },
     {
         'id': 'tracts',
@@ -53,6 +57,7 @@ export const DataLevels: Array<MapLayerGroup> = [
             'tracts_bubbles',
             'tracts_text'
         ],
+        'minzoom': 7,
         'zoom': [11, 13]
     },
     {
@@ -64,6 +69,7 @@ export const DataLevels: Array<MapLayerGroup> = [
           'block-groups_bubbles',
           'block-groups_text'
        ],
+       'minzoom': 7,
        'zoom': [ 13, 16 ]
     }
  ];

--- a/src/app/map/map-layer-group.ts
+++ b/src/app/map/map-layer-group.ts
@@ -5,4 +5,5 @@ export interface MapLayerGroup extends MapDataObject {
     name: string;
     layerIds?: string[];
     zoom?: Array<number>;
+    minzoom: number;
 }

--- a/src/app/map/map/map.component.html
+++ b/src/app/map/map/map.component.html
@@ -25,20 +25,20 @@
       ></app-ui-select>
       <app-ui-select
           tabindex="5"
+          class="highlight-select"
+          label="Highlight"
+          labelProperty="name"
+          [values]="attributes"
+          (change)="setDataHighlight($event)">
+      </app-ui-select>
+      <app-ui-select
+          tabindex="6"
           class="layer-select"
           label="Display"
           labelProperty="name"
           [selectedValue]="activeDataLevel"
           [values]="selectDataLevels" 
           (change)="setGroupVisibility($event)">
-      </app-ui-select>
-      <app-ui-select
-          tabindex="6"
-          class="highlight-select"
-          label="Highlight"
-          labelProperty="name"
-          [values]="attributes"
-          (change)="setDataHighlight($event)">
       </app-ui-select>
       <div *ngIf="activeDataHighlight && activeDataHighlight.name !== 'None'" class="map-legend" [style.background]="getLegendGradient()">
           <span class="legend-start">{{legend[0][0]}}</span>

--- a/src/app/map/map/map.component.html
+++ b/src/app/map/map/map.component.html
@@ -29,7 +29,7 @@
           label="Display"
           labelProperty="name"
           [selectedValue]="activeDataLevel"
-          [values]="dataLevels" 
+          [values]="selectDataLevels" 
           (change)="setGroupVisibility($event)">
       </app-ui-select>
       <app-ui-select

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -39,6 +39,7 @@ export class MapComponent {
   dataYear = 2010;
   censusYear = 2010;
   dataLevels: Array<MapLayerGroup> = DataLevels;
+  selectDataLevels: Array<MapLayerGroup> = DataLevels.filter(l => l.minzoom < 3);
   attributes: Array<MapDataAttribute> = DataAttributes;
   bubbleAttributes: Array<MapDataAttribute> = BubbleAttributes;
   mapFeatures: Observable<Object>;
@@ -213,6 +214,10 @@ export class MapComponent {
    */
   onMapZoom(zoom) {
     this.zoom = zoom;
+    this.selectDataLevels = DataLevels.filter((l) => l.minzoom <= zoom);
+    if (this.activeDataLevel.minzoom > zoom) {
+      this.autoSwitch = true;
+    }
     if (this.autoSwitch) {
       const visibleGroups = this.map.filterLayerGroupsByZoom(this.dataLevels, zoom);
       if (visibleGroups.length > 0) {


### PR DESCRIPTION
Updated version of #68. `MapLayerGroup`s now have a `minzoom` property that sets the minimum zoom level for them to be displayed. If a layer with `minzoom` is being viewed, and the users zooms out past the `minzoom`, auto switching of layers is turned back on to handle the currently displayed layer.