### PR TITLE
Styling for missing data in layers

### DIFF
--- a/src/app/data/data-attributes.ts
+++ b/src/app/data/data-attributes.ts
@@ -2,7 +2,7 @@ import { MapDataAttribute } from '../map/map-data-attribute';
 
 export const DataAttributes: Array<MapDataAttribute> = [
     {
-        'id': 'e',
+        'id': 'none',
         'name': 'None',
         'default': 'rgba(0, 0, 0, 0)',
         'fillStops': {
@@ -17,11 +17,13 @@ export const DataAttributes: Array<MapDataAttribute> = [
         'default': 'rgba(0, 0, 0, 0)',
         'fillStops': {
             'default': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(238, 226, 239, 0.7)'],
                 [50000, 'rgba(137, 140, 206, 0.8)'],
                 [100000, 'rgba(64, 71, 124, 0.9)']
             ],
             'block-groups': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [1250, 'rgba(170, 191, 226, 0.75)'],
                 [2500, 'rgba(133, 157, 204, 0.8)'],
@@ -29,6 +31,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [5000, 'rgba(37, 51, 132, 0.9)']
             ],
             'zip-codes': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [2500, 'rgba(170, 191, 226, 0.75)'],
                 [5000, 'rgba(133, 157, 204, 0.8)'],
@@ -36,6 +39,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [10000, 'rgba(37, 51, 132, 0.9)']
             ],
             'tracts': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [2500, 'rgba(170, 191, 226, 0.75)'],
                 [5000, 'rgba(133, 157, 204, 0.8)'],
@@ -43,6 +47,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [10000, 'rgba(37, 51, 132, 0.9)']
             ],
             'cities': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [12500, 'rgba(170, 191, 226, 0.75)'],
                 [25000, 'rgba(133, 157, 204, 0.8)'],
@@ -50,6 +55,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [50000, 'rgba(37, 51, 132, 0.9)']
             ],
             'counties': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [10000, 'rgba(170, 191, 226, 0.75)'],
                 [75000, 'rgba(133, 157, 204, 0.8)'],
@@ -57,6 +63,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
                 [900000, 'rgba(37, 51, 132, 0.9)']
             ],
             'states': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0, 'rgba(215, 227, 244, 0.7)'],
                 [250000, 'rgba(170, 191, 226, 0.75)'],
                 [500000, 'rgba(133, 157, 204, 0.8)'],
@@ -71,6 +78,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
         'default': 'rgba(0, 0, 0, 0)',
         'fillStops': {
             'default': [
+                [-1.0, 'rgba(198, 204, 207, 0.6)'],
                 [0.0, 'rgba(215, 227, 244, 0.7)'],
                 [0.07, 'rgba(170, 191, 226, 0.75)'],
                 [0.13, 'rgba(133, 157, 204, 0.8)'],
@@ -82,6 +90,10 @@ export const DataAttributes: Array<MapDataAttribute> = [
 ];
 
 export const BubbleAttributes: Array<MapDataAttribute> = [
+    {
+        'id': 'none',
+        'name': 'None'
+    },
     {
         'id': 'er',
         'name': 'Judgments'

--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -8,7 +8,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'states',
             'states_stroke',
             'states_bubbles',
-            'states_text'
+            'states_text',
+            'states_null'
         ],
         'zoom': [0, 7]
     },
@@ -19,7 +20,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'counties',
             'counties_stroke',
             'counties_bubbles',
-            'counties_text'
+            'counties_text',
+            'counties_null'
         ],
         'zoom': [7, 9]
     },
@@ -30,7 +32,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'zip-codes',
             'zip-codes_stroke',
             'zip-codes_bubbles',
-            'zip-codes_text'
+            'zip-codes_text',
+            'zip-codes_null'
         ],
         'zoom': [9, 11]
     },
@@ -41,7 +44,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'cities',
             'cities_stroke',
             'cities_bubbles',
-            'cities_text'
+            'cities_text',
+            'cities_null'
         ]
     },
     {
@@ -51,7 +55,8 @@ export const DataLevels: Array<MapLayerGroup> = [
             'tracts',
             'tracts_stroke',
             'tracts_bubbles',
-            'tracts_text'
+            'tracts_text',
+            'tracts_null'
         ],
         'zoom': [11, 13]
     },
@@ -62,7 +67,8 @@ export const DataLevels: Array<MapLayerGroup> = [
           'block-groups',
           'block-groups_stroke',
           'block-groups_bubbles',
-          'block-groups_text'
+          'block-groups_text',
+          'block-groups_null'
        ],
        'zoom': [ 13, 16 ]
     }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -131,6 +131,17 @@ export class MapService {
   }
 
   /**
+   * Updates the data property used in filters. Mostly used for updating null layers
+   * @param layerId
+   * @param property
+   */
+  setLayerFilterProperty(layerId: string, property: string) {
+    const layerFilter = this.map.getFilter(layerId);
+    layerFilter[1] = property;
+    this.map.setFilter(layerId, layerFilter);
+  }
+
+  /**
    * Queries a layer for all features matching the name and parent-location of
    * a supplied feature, returns a GeoJSON feature combining the geographies of
    * all matching features. Used to consolidate GeoJSON features split by tiling

--- a/src/app/map/map/map.component.html
+++ b/src/app/map/map/map.component.html
@@ -41,7 +41,7 @@
           (change)="setDataHighlight($event)">
       </app-ui-select>
       <div *ngIf="activeDataHighlight && activeDataHighlight.name !== 'None'" class="map-legend" [style.background]="getLegendGradient()">
-          <span class="legend-start">{{legend[0][0]}}</span>
+          <span class="legend-start">{{legend[1][0]}}</span>
           <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
       </div>
       <app-ui-hint 

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -107,16 +107,23 @@ export class MapComponent {
           dataAttr.fillStops[layerId] : dataAttr.fillStops['default'])
       };
       this.map.setLayerStyle(layerId, 'fill-color', newFill);
+      this.map.setLayerFilterProperty(`${layerId}_null`, dataAttr.id);
     });
   }
 
+  /**
+   * Similar to setDataHighlight, but specific to bubble layers
+   * @param attr map data attribute to set bubble properties
+   */
   setBubbleHighlight(attr: MapDataAttribute) {
     const bubbleAttr: MapDataAttribute = this.addYearToObject(attr, this.dataYear);
     this.activeBubbleHighlight = bubbleAttr;
     // Not used yet, but will be in future
     this.updateLegend();
     this.mapEventLayers.forEach((layerId) => {
-      this.map.setLayerDataProperty(`${layerId}_bubbles`, 'circle-radius', attr.id);
+      ['circle-radius', 'circle-color'].forEach(prop => {
+        this.map.setLayerDataProperty(`${layerId}_bubbles`, prop, attr.id);
+      });
     });
   }
 
@@ -152,14 +159,9 @@ export class MapComponent {
       this.map.updateCensusSource(this.dataLevels, ('' + this.censusYear).slice(2));
     }
 
-    this.setDataHighlight(this.addYearToObject(this.activeDataHighlight, this.dataYear));
+    this.setDataHighlight(this.activeDataHighlight);
+    this.setBubbleHighlight(this.activeBubbleHighlight);
     this.setGroupVisibility(this.activeDataLevel);
-    this.mapEventLayers.forEach((layer) => {
-      this.map.setLayerDataProperty(
-        `${layer}_bubbles`, 'circle-radius',
-        this.addYearToObject(this.activeBubbleHighlight, this.dataYear).id
-      );
-    });
     this.updateLegend();
   }
 
@@ -168,7 +170,7 @@ export class MapComponent {
    */
   getLegendGradient() {
     return this._sanitizer.bypassSecurityTrustStyle(
-      `linear-gradient(to right, ${this.legend[0][1]}, ${this.legend[this.legend.length - 1][1]})`
+      `linear-gradient(to right, ${this.legend[1][1]}, ${this.legend[this.legend.length - 1][1]})`
     );
   }
 

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -2,6 +2,7 @@
   "version": 8,
   "id": "eviction-lab",
   "name": "Natural Earth",
+  "sprite": "https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/sprites/stripes",
   "sources": {
     "openmaptiles": {
       "type": "vector",
@@ -141,7 +142,6 @@
       }
     }
   },
-  "sprite": "https://openmaptiles.github.io/positron-gl-style/sprite",
   "glyphs": "https://free.tilehosting.com/fonts/{fontstack}/{range}.pbf?key=JgNOMnZWmIN2iBSFGgsi",
   "layers": [
     {
@@ -1529,6 +1529,23 @@
       }
     },
     {
+      "id": "block-groups_null",
+      "type": "fill",
+      "source": "us-block-groups-10",
+      "source-layer": "block-groups",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
+      }
+    },
+    {
       "id": "block-groups_stroke",
       "type": "line",
       "source": "us-block-groups-10",
@@ -1568,6 +1585,23 @@
       },
       "paint": {
         "fill-color": "rgba(67,72,120,0.7)"
+      }
+    },
+    {
+      "id": "zip-codes_null",
+      "type": "fill",
+      "source": "us-zip-codes-10",
+      "source-layer": "zip-codes",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
       }
     },
     {
@@ -1638,6 +1672,23 @@
       }
     },
     {
+      "id": "tracts_null",
+      "type": "fill",
+      "source": "us-tracts-10",
+      "source-layer": "tracts",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
+      }
+    },
+    {
       "id": "tracts_stroke",
       "type": "line",
       "source": "us-tracts-10",
@@ -1677,6 +1728,23 @@
       },
       "paint": {
         "fill-color": "rgba(0,0,0,0)"
+      }
+    },
+    {
+      "id": "counties_null",
+      "type": "fill",
+      "source": "us-counties-10",
+      "source-layer": "counties",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
       }
     },
     {
@@ -1723,6 +1791,23 @@
       },
       "paint": {
         "fill-color": "rgba(67,72,120,0.7)"
+      }
+    },
+    {
+      "id": "states_null",
+      "type": "fill",
+      "source": "us-states-10",
+      "source-layer": "states",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
       }
     },
     {
@@ -2367,6 +2452,23 @@
       }
     },
     {
+      "id": "cities_null",
+      "type": "fill",
+      "source": "us-cities-10",
+      "source-layer": "cities",
+      "layout": {
+        "visibility": "none"
+      },
+      "filter": [
+        "<",
+        "none-10",
+        0
+      ],
+      "paint": {
+        "fill-pattern": "stripes"
+      }
+    },
+    {
       "id": "cities_stroke",
       "type": "line",
       "source": "us-cities-10",
@@ -2429,8 +2531,13 @@
           ]
         },
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
+            [
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
             [
               0,
               "rgba(255,120,119,0.8)"
@@ -2647,10 +2754,15 @@
       },
       "paint": {
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
             [
-              7,
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
+            [
+              0,
               "rgba(255,120,119,0.8)"
             ],
             [
@@ -2944,8 +3056,13 @@
       },
       "paint": {
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
+            [
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
             [
               0,
               "rgba(255,120,119,0.8)"
@@ -3291,8 +3408,13 @@
       },
       "paint": {
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
+            [
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
             [
               0,
               "rgba(255,120,119,0.8)"
@@ -3493,8 +3615,13 @@
       },
       "paint": {
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
+            [
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
             [
               0,
               "rgba(255,120,119,0.8)"
@@ -3997,8 +4124,13 @@
       },
       "paint": {
         "circle-color": {
+          "property": "er-10",
           "default": "rgba(0,0,0,0)",
           "stops": [
+            [
+              -1,
+              "rgba(198,204,207,0.8)"
+            ],
             [
               0,
               "rgba(255,120,119,0.8)"


### PR DESCRIPTION
Supports styling of gray bubbles and gray cross-hatch striped shapes when data is missing (-1). Also adds the "None" option to the bubble selector. Adds `_null` layers for each shape layer because `fill-pattern` doesn't seem to support boolean expressions, and sprite is generated for the fill which is filtered by the current data property being less than 0.