### PR TITLE
Clear search on select in cards

### DIFF
--- a/src/app/location-cards/location-cards.component.html
+++ b/src/app/location-cards/location-cards.component.html
@@ -23,7 +23,7 @@
         [(selected)]="search.query"
         [options]="search.results"
         optionField="properties.label"
-        (selectionChange)="locationAdded.emit($event)">
+        (selectionChange)="search.query = null; locationAdded.emit($event);">
     </app-predictive-search>
   </div>
 </div>


### PR DESCRIPTION
Location cards currently keep the same input in the predictive search component even after the user selects an option. This just clears the search after select to make input easier, and only in the location cards search in the data panel