### PR TITLE
Fix dots with stroke for none bubbles

### DIFF
--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -122,7 +122,7 @@ export class MapComponent {
     // Not used yet, but will be in future
     this.updateLegend();
     this.mapEventLayers.forEach((layerId) => {
-      ['circle-radius', 'circle-color'].forEach(prop => {
+      ['circle-radius', 'circle-color', 'circle-stroke-color'].forEach(prop => {
         this.map.setLayerDataProperty(`${layerId}_bubbles`, prop, attr.id);
       });
     });

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -2490,7 +2490,16 @@
         "visibility": "none"
       },
       "paint": {
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [
+              0,
+              "rgba(255, 255, 255, 1)"
+            ]
+          ]
+        },
         "circle-stroke-width": {
           "default": 1,
           "stops": [
@@ -2748,7 +2757,16 @@
             ]
           ]
         },
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [
+              0,
+              "rgba(255, 255, 255, 1)"
+            ]
+          ]
+        },
         "circle-stroke-width": { 
           "default": 1,
           "stops": [
@@ -3049,7 +3067,16 @@
             ]
           ]
         },
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [
+              0,
+              "rgba(255, 255, 255, 1)"
+            ]
+          ]
+        },
         "circle-stroke-width": { 
           "default": 1,
           "stops": [
@@ -3400,7 +3427,16 @@
             ]
           ]
         },
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [
+              0,
+              "rgba(255, 255, 255, 1)"
+            ]
+          ]
+        },
         "circle-stroke-width": 2,
         "circle-radius": {
           "property": "er-10",
@@ -3605,7 +3641,16 @@
             ]
           ]
         },
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [
+              0,
+              "rgba(255, 255, 255, 1)"
+            ]
+          ]
+        },
         "circle-stroke-width": {
           "default": 1,
           "stops": [
@@ -4129,7 +4174,13 @@
             ]
           ]
         },
-        "circle-stroke-color": "rgba(255, 255, 255, 1)",
+        "circle-stroke-color": {
+          "property": "er-10",
+          "default": "rgba(0, 0, 0, 0)",
+          "stops": [
+            [0, "rgba(255, 255, 255, 1)"]
+          ]
+        },
         "circle-radius": {
           "property": "er-10",
           "default": 0,


### PR DESCRIPTION
When the bubble layer is set to None, white dots still display for each point because `circle-stroke-color` has a default . value. Added a property function for `circle-stroke-color` for all bubble layers that really just checks for the existence of the property.

Noticed this while trying to get a screenshot of the stripe fill, so here's an example
![screen shot 2017-10-30 at 11 49 59 am](https://user-images.githubusercontent.com/8291663/32185395-f6e476c2-bd6c-11e7-86af-265bb0e0971a.png)
