### PR TITLE
Replace turf with polylabel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,38 +260,6 @@
         "@turf/meta": "4.7.3"
       }
     },
-    "@turf/center": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-4.7.3.tgz",
-      "integrity": "sha1-dE5cZSp7G70OHuPwXjDd5D4qNaQ=",
-      "requires": {
-        "@turf/bbox": "4.7.3",
-        "@turf/helpers": "4.7.3"
-      }
-    },
-    "@turf/distance": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-4.7.3.tgz",
-      "integrity": "sha1-tatIoJpkJwbWXDm5GUM9XSzFcbE=",
-      "requires": {
-        "@turf/helpers": "4.7.3",
-        "@turf/invariant": "4.7.3"
-      }
-    },
-    "@turf/explode": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-4.7.3.tgz",
-      "integrity": "sha1-9+LvslrqA0EMzh6YFlhLqU/JGEY=",
-      "requires": {
-        "@turf/helpers": "4.7.3",
-        "@turf/meta": "4.7.3"
-      }
-    },
-    "@turf/helpers": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-4.7.3.tgz",
-      "integrity": "sha1-vDEqxDyrPFMqSDFRxMOCxWSUKek="
-    },
     "@turf/inside": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-4.7.3.tgz",
@@ -309,18 +277,6 @@
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.3.tgz",
       "integrity": "sha1-A4lwF46QyOQ899/tedV4IpihCA0="
-    },
-    "@turf/point-on-surface": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-surface/-/point-on-surface-4.7.3.tgz",
-      "integrity": "sha1-Jew2C+x/n6YS1wWAjPAxDXLCvl8=",
-      "requires": {
-        "@turf/center": "4.7.3",
-        "@turf/distance": "4.7.3",
-        "@turf/explode": "4.7.3",
-        "@turf/helpers": "4.7.3",
-        "@turf/inside": "4.7.3"
-      }
     },
     "@turf/union": {
       "version": "4.7.3",
@@ -7511,6 +7467,14 @@
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "polylabel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.0.2.tgz",
+      "integrity": "sha1-kMEWAvshemW3isIRCsX8sAtlJWA=",
+      "requires": {
+        "tinyqueue": "1.2.3"
       }
     },
     "portfinder": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@mapbox/vector-tile": "^1.3.0",
     "@turf/bbox": "^4.7.3",
     "@turf/inside": "^4.7.3",
-    "@turf/point-on-surface": "^4.7.3",
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.39.5",
@@ -38,6 +37,7 @@
     "ng2-page-scroll": "^4.0.0-beta.11",
     "ngx-bootstrap": "^1.9.1",
     "pbf": "^3.1.0",
+    "polylabel": "^1.0.2",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14"
   },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { DOCUMENT } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
 import * as bbox from '@turf/bbox';
-import * as pointOnSurface from '@turf/point-on-surface';
+import * as polylabel from 'polylabel';
 import * as _isEqual from 'lodash.isequal';
 import { PageScrollConfig, PageScrollService, PageScrollInstance } from 'ng2-page-scroll';
 import Debounce from 'debounce-decorator';
@@ -84,7 +84,9 @@ export class AppComponent {
    * @param feature returned from featureClick event
    */
   onFeatureSelect(feature: MapFeature) {
-    const featureLonLat = pointOnSurface(feature).geometry['coordinates'];
+    const coords = feature.geometry['type'] === 'MultiPolygon' ?
+      feature.geometry['coordinates'][0] : feature.geometry['coordinates'];
+    const featureLonLat = polylabel(coords, 1.0);
     this.search.getTileData(feature['layer']['id'], featureLonLat, true)
       .subscribe(data => this.addLocation(data));
   }


### PR DESCRIPTION
Noticed that for some features bordering water the `getTileData` command would fail on click. It looks like it's because the `turf` function I was using would get a random point inside the feature, but the GeoJSON features it was using were generalized so sometimes the point would end up in the water. The `polylabel` package that we're using to generate the bubble locations works here because it returns the center of a polygon which should be safe