### PR TITLE
Refactor/data service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,7 +10,7 @@ import { MapToolModule } from './map-tool/map-tool.module';
 import { MapToolComponent } from './map-tool/map-tool.component';
 
 const appRoutes: Routes = [
-  { path: '', component: MapToolComponent },
+  { path: '', component: MapToolComponent }
 ];
 
 @NgModule({

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -10,14 +10,12 @@ import * as bbox from '@turf/bbox';
 import 'rxjs/add/observable/forkJoin';
 import * as _isEqual from 'lodash.isequal';
 
-
 import { MapDataAttribute } from '../map-tool/map/map-data-attribute';
 import { MapLayerGroup } from '../map-tool/map/map-layer-group';
 import { MapDataObject } from '../map-tool/map/map-data-object';
 import { MapFeature } from '../map-tool/map/map-feature';
 import { DataAttributes, BubbleAttributes } from './data-attributes';
 import { DataLevels } from './data-levels';
-
 
 @Injectable()
 export class DataService {
@@ -27,23 +25,15 @@ export class DataService {
   activeYear = 2015;
   activeFeatures: MapFeature[] = [];
   activeDataLevel: MapLayerGroup = DataLevels[0];
-  get activeDataHighlight(): MapDataAttribute {
-    return this.data.highlight || DataAttributes[0];
-  }
-  set activeDataHighlight(newValue: MapDataAttribute) {
-    this.data.highlight = newValue;
-  }
-  get activeBubbleHighlight(): MapDataAttribute {
-    return this.data.bubble || BubbleAttributes[0];
-  }
-  set activeBubbleHighlight(newValue: MapDataAttribute) {
-    this.data.bubble = newValue;
-  }
+  activeDataHighlight: MapDataAttribute = DataAttributes[0];
+  activeBubbleHighlight: MapDataAttribute = BubbleAttributes[0];
   mapView;
-  private data = {
-    bubble: null,
-    level: null,
-    highlight: null
+  mapConfig = {
+    style: './assets/style.json',
+    center: [-98.5556199, 39.8097343],
+    zoom: 3,
+    minZoom: 3,
+    maxZoom: 14
   };
   private mercator = new SphericalMercator({ size: 256 });
   private tileBase = 'https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/';
@@ -78,34 +68,6 @@ export class DataService {
         this.activeFeatures = [ ...this.activeFeatures, feature ];
       }
     }
-  }
-
-  setActiveBubbleAttribute(newValue: MapDataAttribute) {
-    this.activeBubbleHighlight = newValue;
-    return this.activeBubbleHighlight;
-  }
-
-  setActiveDataHighlight(newValue: MapDataAttribute) {
-    this.activeDataHighlight = newValue;
-    return this.activeDataHighlight;
-  }
-
-  setActiveDataLevel(newValue: MapLayerGroup) {
-    this.activeDataLevel = newValue;
-  }
-
-  setActiveYear(newValue: number) {
-    this.activeYear = newValue;
-  }
-
-  getMapConfig() {
-    return {
-      style: './assets/style.json',
-      center: [-98.5556199, 39.8097343],
-      zoom: 3,
-      minZoom: 3,
-      maxZoom: 14
-    };
   }
 
   /**
@@ -201,30 +163,5 @@ export class DataService {
       { responseType: ResponseContentType.ArrayBuffer }
     );
   }
-
-  /**
-   * Gets the currently active data attribute with the year appended
-   * @param type either 'choropleth' or 'bubble'
-   */
-  getAttributeWithYear(type: string) {
-    const data = (type === 'choropleth') ? this.activeDataHighlight : this.activeBubbleHighlight;
-    return this.addYearToObject(data, this.activeYear);
-  }
-
-  /**
-   * Add year to data attribute or level from selector
-   * @param dataObject
-   * @param year
-   */
-  private addYearToObject(dataObject: MapDataObject, year: number): MapDataObject {
-    if (!dataObject) { return null; }
-    if (/.*\d{2}.*/g.test(dataObject.id)) {
-      dataObject.id = dataObject.id.replace(/\d{2}/g, ('' + year).slice(2));
-    } else {
-      dataObject.id += '-' + ('' + year).slice(2);
-    }
-    return dataObject;
-  }
-
 
 }

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -2,22 +2,111 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Http, Response, ResponseContentType } from '@angular/http';
-import { MapFeature } from '../map-tool/map/map-feature';
 import * as SphericalMercator from '@mapbox/sphericalmercator';
 import * as vt from '@mapbox/vector-tile';
 import * as Protobuf from 'pbf';
 import * as inside from '@turf/inside';
 import * as bbox from '@turf/bbox';
 import 'rxjs/add/observable/forkJoin';
+import * as _isEqual from 'lodash.isequal';
+
+
+import { MapDataAttribute } from '../map-tool/map/map-data-attribute';
+import { MapLayerGroup } from '../map-tool/map/map-layer-group';
+import { MapDataObject } from '../map-tool/map/map-data-object';
+import { MapFeature } from '../map-tool/map/map-feature';
+import { DataAttributes, BubbleAttributes } from './data-attributes';
+import { DataLevels } from './data-levels';
+
 
 @Injectable()
 export class DataService {
-  mercator = new SphericalMercator({ size: 256 });
-  tileBase = 'https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/';
-  tilePrefix = 'evictions-';
-  tilesetYears = ['90', '00', '10'];
-  maxZoom = 10;
+  get dataLevels() { return DataLevels; }
+  get dataAttributes() { return DataAttributes; }
+  get bubbleAttributes() { return BubbleAttributes; }
+  activeYear = 2015;
+  activeFeatures: MapFeature[] = [];
+  activeDataLevel: MapLayerGroup = DataLevels[0];
+  get activeDataHighlight(): MapDataAttribute {
+    return this.data.highlight || DataAttributes[0];
+  }
+  set activeDataHighlight(newValue: MapDataAttribute) {
+    this.data.highlight = newValue;
+  }
+  get activeBubbleHighlight(): MapDataAttribute {
+    return this.data.bubble || BubbleAttributes[0];
+  }
+  set activeBubbleHighlight(newValue: MapDataAttribute) {
+    this.data.bubble = newValue;
+  }
+  mapView;
+  private data = {
+    bubble: null,
+    level: null,
+    highlight: null
+  };
+  private mercator = new SphericalMercator({ size: 256 });
+  private tileBase = 'https://s3.us-east-2.amazonaws.com/eviction-lab-tilesets/fixtures/';
+  private tilePrefix = 'evictions-';
+  private tilesetYears = ['90', '00', '10'];
+  private maxZoom = 10;
   constructor(private http: Http) { }
+
+  /**
+   * Removes a location from the cards and data panel
+   */
+  removeLocation(feature) {
+    const featuresCopy = this.activeFeatures.slice();
+    const i = featuresCopy.findIndex((f) => _isEqual(f, feature));
+    if (i > -1) {
+      featuresCopy.splice(i, 1);
+      this.activeFeatures = featuresCopy;
+    }
+  }
+
+  /**
+   * Adds a location to the cards and data panel
+   * @param feature the feature for the corresponding location to add
+   */
+  addLocation(feature) {
+    if (this.activeFeatures.length < 3) {
+      const i = this.activeFeatures.findIndex((f) => {
+        return f.properties.n === feature.properties.n &&
+          f.properties.pl === feature.properties.pl;
+      });
+      if (!(i > -1)) {
+        this.activeFeatures = [ ...this.activeFeatures, feature ];
+      }
+    }
+  }
+
+  setActiveBubbleAttribute(newValue: MapDataAttribute) {
+    this.activeBubbleHighlight = newValue;
+    return this.activeBubbleHighlight;
+  }
+
+  setActiveDataHighlight(newValue: MapDataAttribute) {
+    this.activeDataHighlight = newValue;
+    return this.activeDataHighlight;
+  }
+
+  setActiveDataLevel(newValue: MapLayerGroup) {
+    this.activeDataLevel = newValue;
+  }
+
+  setActiveYear(newValue: number) {
+    this.activeYear = newValue;
+  }
+
+  getMapConfig() {
+    return {
+      style: './assets/style.json',
+      center: [-98.5556199, 39.8097343],
+      zoom: 3,
+      minZoom: 3,
+      maxZoom: 14
+    };
+  }
 
   /**
    * Takes the layer to be queried and coordinates for an object,
@@ -111,6 +200,30 @@ export class DataService {
       `${tilesetUrl}/${this.maxZoom}/${coords.x}/${coords.y}.pbf`,
       { responseType: ResponseContentType.ArrayBuffer }
     );
+  }
+
+  /**
+   * Gets the currently active data attribute with the year appended
+   * @param type either 'choropleth' or 'bubble'
+   */
+  getAttributeWithYear(type: string) {
+    const data = (type === 'choropleth') ? this.activeDataHighlight : this.activeBubbleHighlight;
+    return this.addYearToObject(data, this.activeYear);
+  }
+
+  /**
+   * Add year to data attribute or level from selector
+   * @param dataObject
+   * @param year
+   */
+  private addYearToObject(dataObject: MapDataObject, year: number): MapDataObject {
+    if (!dataObject) { return null; }
+    if (/.*\d{2}.*/g.test(dataObject.id)) {
+      dataObject.id = dataObject.id.replace(/\d{2}/g, ('' + year).slice(2));
+    } else {
+      dataObject.id += '-' + ('' + year).slice(2);
+    }
+    return dataObject;
   }
 
 

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -20,10 +20,17 @@
         </div>
     </div>
     <app-map
-        [autoSwitch]="autoSwitchLayers"
-        [boundingBox]="mapBounds"
-        (featureClick)="onFeatureSelect($event)"
-        (yearChange)="dataService.setActiveYear($event)"
+      [mapConfig]="dataService.mapConfig"
+      [autoSwitch]="autoSwitchLayers"
+      [bubbleOptions]="dataService.bubbleAttributes"
+      [layerOptions]="dataService.dataLevels"
+      [choroplethOptions]="dataService.dataAttributes"
+      [(boundingBox)]="dataService.mapView"
+      [(year)]="dataService.activeYear"
+      [(selectedBubble)]="dataService.activeBubbleHighlight"
+      [(selectedChoropleth)]="dataService.activeDataHighlight"
+      [(selectedLayer)]="dataService.activeDataLevel"
+      (featureClick)="onFeatureSelect($event)"
     ></app-map>
     <app-location-cards 
         *ngIf="dataService.activeFeatures.length > 0" 

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,4 +1,8 @@
-<div id="top" class="app-wrapper" [class.map-active]="activeFeatures.length === 0" [class.data-active]="activeFeatures.length > 0">
+<div id="top" 
+  class="app-wrapper" 
+  [class.map-active]="dataService.activeFeatures.length === 0" 
+  [class.data-active]="dataService.activeFeatures.length > 0"
+>
     <div class="header-wrapper">
         <div class="header-content">
             <img src="./assets/logo.png" class="header-logo" />
@@ -19,21 +23,21 @@
         [autoSwitch]="autoSwitchLayers"
         [boundingBox]="mapBounds"
         (featureClick)="onFeatureSelect($event)"
-        (yearChange)="setYear($event)"
+        (yearChange)="dataService.setActiveYear($event)"
     ></app-map>
     <app-location-cards 
-        *ngIf="activeFeatures.length > 0" 
-        [features]="activeFeatures"
-        [year]="year"
+        *ngIf="dataService.activeFeatures.length > 0" 
+        [features]="dataService.activeFeatures"
+        [year]="dataService.activeYear"
         (viewMore)="goToDataPanel($event)"
-        (dismissedCard)="removeLocation($event)"
+        (dismissedCard)="dataService.removeLocation($event)"
     ></app-location-cards>
     <app-data-panel
         id="data-panel"
-        *ngIf="activeFeatures.length > 0"
-        [year]="year"
-        [locations]="activeFeatures" 
-        (locationRemoved)="removeLocation($event)"
+        *ngIf="dataService.activeFeatures.length > 0"
+        [year]="dataService.activeYear"
+        [locations]="dataService.activeFeatures" 
+        (locationRemoved)="dataService.removeLocation($event)"
         (locationAdded)="onSearchSelect($event, false)"
     ></app-data-panel>
     <div class="footer">

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
 import { MapToolComponent } from './map-tool.component';
 import { MapModule } from './map/map.module';
@@ -15,8 +15,15 @@ describe('MapToolComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ MapToolComponent ],
-      imports: [ UiModule, DataPanelModule, MapModule, Ng2PageScrollModule, HttpModule ],
-      providers: [ {provide: DataService, useValue: {} } ]
+      imports: [
+        UiModule,
+        DataPanelModule,
+        MapModule,
+        Ng2PageScrollModule,
+        HttpModule,
+        RouterTestingModule
+      ],
+      providers: [DataService]
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -35,7 +35,6 @@ export class MapToolComponent implements OnInit {
 
   ngOnInit() {
     this.configurePageScroll();
-    console.log('init');
     this.route.paramMap.subscribe(this.setRouteParams.bind(this));
   }
 
@@ -78,7 +77,8 @@ export class MapToolComponent implements OnInit {
           if (data === {}) {
             console.log('could not find feature');
           }
-          this.map.setDataLevelFromLayer(layerId);
+          const dataLevel = this.dataService.dataLevels.filter(l => l.id === layerId)[0];
+          this.map.setGroupVisibility(dataLevel);
           this.dataService.addLocation(data);
           if (updateMap) {
             if (feature.hasOwnProperty('bbox')) {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -20,7 +20,6 @@ import { DataService } from '../data/data.service';
 })
 export class MapToolComponent implements OnInit {
   title = 'Eviction Lab';
-  mapBounds;
   autoSwitchLayers = true;
   verticalOffset;
   enableZoom;
@@ -83,7 +82,7 @@ export class MapToolComponent implements OnInit {
           this.dataService.addLocation(data);
           if (updateMap) {
             if (feature.hasOwnProperty('bbox')) {
-              this.mapBounds = feature['bbox'];
+              this.dataService.mapView = feature['bbox'];
             } else {
               this.map.zoomToPointFeature(feature);
             }

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -6,7 +6,6 @@
       (zoom)="onMapZoom($event)"
       (featureClick)="onFeatureClick($event)"
       (hoverChanged)="onFeatureHover($event)"
-      (render)="onMapRender($event)"
       (moveEnd)="onMapMoveEnd($event)"
   >
   </app-mapbox>
@@ -19,29 +18,29 @@
           class="eviction-select"
           label="Eviction"
           labelProperty="name"
-          [selectedValue]="dataService.activeBubbleHighlight"
-          [values]="dataService.bubbleAttributes"
-          (change)="tmpSetBubble($event)"
+          [selectedValue]="selectedBubble"
+          [values]="bubbleOptions"
+          (change)="selectedBubble = $event"
       ></app-ui-select>
       <app-ui-select
           tabindex="5"
           class="highlight-select"
           label="Census Data"
           labelProperty="name"
-          [values]="dataService.dataAttributes"
-          (change)="tmpSetChoropleth($event)">
+          [values]="choroplethOptions"
+          (change)="selectedChoropleth = $event">
       </app-ui-select>
       <app-ui-select
           tabindex="6"
           class="layer-select"
           label="Map Level"
           labelProperty="name"
-          [selectedValue]="dataService.activeDataLevel"
+          [selectedValue]="selectedLayer"
           [values]="selectDataLevels" 
           (change)="setGroupVisibility($event)">
       </app-ui-select>
       <div 
-        *ngIf="dataService.activeDataHighlight && dataService.activeDataHighlight.name !== 'None'" 
+        *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None'" 
         class="map-legend" 
         [style.background]="getLegendGradient()"
       >
@@ -49,19 +48,19 @@
           <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
       </div>
       <app-ui-hint 
-          *ngIf="dataService.activeDataHighlight && dataService.activeDataHighlight.name !== 'None'"
+          *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None'"
           class="legend-hint"
-          [hint]="'The colored ' + dataService.activeDataLevel['name'] + ' on the map represent ' + dataService.activeDataHighlight['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
+          [hint]="'The colored ' + selectedLayer['name'] + ' on the map represent ' + selectedChoropleth['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
           placement="bottom"
       ></app-ui-hint>
   </div>
   <div class="year-slider-container">
     <app-ui-slider tabindex="9"
       class="year-slider"
-      [currentValue]="dataService.activeYear" 
+      [currentValue]="year" 
       [min]="1990" 
       [max]="2016" 
-      (change)="setDataYear($event)"
+      (change)="year=$event"
     ></app-ui-slider>
   </div>
   

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -19,42 +19,46 @@
           class="eviction-select"
           label="Eviction"
           labelProperty="name"
-          [selectedValue]="activeBubbleHighlight"
-          [values]="bubbleAttributes"
-          (change)="setBubbleHighlight($event)"
+          [selectedValue]="dataService.activeBubbleHighlight"
+          [values]="dataService.bubbleAttributes"
+          (change)="tmpSetBubble($event)"
       ></app-ui-select>
       <app-ui-select
           tabindex="5"
           class="highlight-select"
           label="Census Data"
           labelProperty="name"
-          [values]="attributes"
-          (change)="setDataHighlight($event)">
+          [values]="dataService.dataAttributes"
+          (change)="tmpSetChoropleth($event)">
       </app-ui-select>
       <app-ui-select
           tabindex="6"
           class="layer-select"
           label="Map Level"
           labelProperty="name"
-          [selectedValue]="activeDataLevel"
+          [selectedValue]="dataService.activeDataLevel"
           [values]="selectDataLevels" 
           (change)="setGroupVisibility($event)">
       </app-ui-select>
-      <div *ngIf="activeDataHighlight && activeDataHighlight.name !== 'None'" class="map-legend" [style.background]="getLegendGradient()">
+      <div 
+        *ngIf="dataService.activeDataHighlight && dataService.activeDataHighlight.name !== 'None'" 
+        class="map-legend" 
+        [style.background]="getLegendGradient()"
+      >
           <span class="legend-start">{{legend[1][0]}}</span>
           <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
       </div>
       <app-ui-hint 
-          *ngIf="activeDataLevel && activeDataHighlight.name !== 'None'"
+          *ngIf="dataService.activeDataHighlight && dataService.activeDataHighlight.name !== 'None'"
           class="legend-hint"
-          [hint]="'The colored ' + activeDataLevel['name'] + ' on the map represent ' + activeDataHighlight['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
+          [hint]="'The colored ' + dataService.activeDataLevel['name'] + ' on the map represent ' + dataService.activeDataHighlight['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
           placement="bottom"
       ></app-ui-hint>
   </div>
   <div class="year-slider-container">
     <app-ui-slider tabindex="9"
       class="year-slider"
-      [currentValue]="dataYear" 
+      [currentValue]="dataService.activeYear" 
       [min]="1990" 
       [max]="2016" 
       (change)="setDataYear($event)"

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MapComponent } from './map.component';
 import { MapboxComponent } from '../mapbox/mapbox.component';
 import { UiModule } from '../../../ui/ui.module';
-
+import { MapService } from '../map.service';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -12,7 +12,8 @@ describe('MapComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ MapComponent, MapboxComponent ],
-      imports: [ UiModule ]
+      imports: [ UiModule ],
+      providers: [ { provide: MapService, useValue: { updateCensusSource: () => {} } } ]
     })
     .compileComponents();
   }));
@@ -20,6 +21,34 @@ describe('MapComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MapComponent);
     component = fixture.componentInstance;
+    component.choroplethOptions = [{
+      'id': 'none',
+      'name': 'None',
+      'default': 'rgba(0, 0, 0, 0)',
+      'fillStops': {
+        'default': [
+          [0, 'rgba(0, 0, 0, 0)']
+        ]
+      }
+    }];
+    component.layerOptions = [{
+      'id': 'states',
+      'name': 'States',
+      'layerIds': ['states'],
+      'minzoom': 0,
+      'zoom': [0, 7]
+    },
+    {
+      'id': 'counties',
+      'name': 'Counties',
+      'layerIds': ['counties'],
+      'minzoom': 0,
+      'zoom': [7, 9]
+    }];
+    component.bubbleOptions = [{
+      'id': 'none',
+      'name': 'None'
+    }];
     fixture.detectChanges();
   });
 

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -60,20 +60,22 @@ export class MapComponent implements OnInit {
   @Input()
   set year(newYear: number) {
     this._store.year = newYear;
-    this.yearChange.emit(newYear);
-    this.updateCensusYear();
-    this.updateMapData();
+    if (newYear) {
+      this.yearChange.emit(newYear);
+      this.updateCensusYear();
+      this.updateMapData();
+    }
   }
   get year() { return this._store.year; }
 
   /** Mapboxgl map configuration */
   @Input() mapConfig;
   /** Options available for bubbles */
-  @Input() bubbleOptions: MapDataAttribute[];
+  @Input() bubbleOptions: MapDataAttribute[] = [];
   /** Options available for choropleths */
-  @Input() choroplethOptions: MapDataAttribute[];
+  @Input() choroplethOptions: MapDataAttribute[] = [];
   /** Available layers to toggle between */
-  @Input() layerOptions: MapLayerGroup[];
+  @Input() layerOptions: MapLayerGroup[] = [];
   /** Toggle for auto switch between layerOptions based on min / max zooms */
   @Input() autoSwitch = true;
   @Output() featureClick: EventEmitter<any> = new EventEmitter();
@@ -127,24 +129,6 @@ export class MapComponent implements OnInit {
       // Reset the hover layer
       this.map.setSourceData('hover');
     }
-  }
-
-  /**
-   * Set data level based on layer ID string input
-   * @param layerId layer ID string
-   */
-  setDataLevelFromLayer(layerId: string) {
-    const dataLevel = this.layerOptions.filter(l => l.id === layerId)[0];
-    this.setGroupVisibility(dataLevel);
-  }
-
-  /**
-   * Updates the bubbles and choropleths on the map with the currently
-   * selected layer, bubble, choropleth, and year.
-   */
-  updateMapData() {
-    this.updateMapBubbles();
-    this.updateMapChoropleths();
   }
 
   /**
@@ -257,7 +241,7 @@ export class MapComponent implements OnInit {
    * Gets the currently active data attribute with the year appended
    * @param type either 'choropleth' or 'bubble'
    */
-  getAttributeWithYear(type: string) {
+  private getAttributeWithYear(type: string) {
     const data = (type === 'choropleth') ? this.selectedChoropleth : this.selectedBubble;
     return this.addYearToObject(data, this.year);
   }
@@ -337,5 +321,14 @@ export class MapComponent implements OnInit {
         });
       }
     }
+  }
+
+  /**
+   * Updates the bubbles and choropleths on the map with the currently
+   * selected layer, bubble, choropleth, and year.
+   */
+  private updateMapData() {
+    this.updateMapBubbles();
+    this.updateMapChoropleths();
   }
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -91,7 +91,7 @@ export class MapComponent implements OnInit {
   censusYear = 2010;
   legend;
   mapLoading = false;
-  private mapEventLayers: Array<string>;
+  mapEventLayers: Array<string>;
   private zoom = 3;
   private _store = {
     layer: null,

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Eviction Maps</title>
-  <base href="./">
+  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
Some more refactoring to support routes.  This refactor makes the `data.service` responsible for storing the latest state with:

  - year
  - geography layer selection
  - bubble selection
  - choropleth selection
  - active features
  - map view (bounds)

This will allow us to set / get values on the data service for easy restoration / retrieval of state.

Also, it looks like routes will only work with `<base href='/'>`, which would break future prototypes.  Will need to look into it further to see if there's an easy fix for that.