### PR TITLE
Add basic mailto and social share functionality, metadata

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -63,12 +63,14 @@
                 <path d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" />
               </svg>
             </button>
-            <button class="btn btn-social-icon btn-email">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
-                <path d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
-                />
-              </svg>
-            </button>
+            <a [href]="'mailto:?subject=Eviction Lab&body=' + getCurrentUrl()">
+              <button class="btn btn-social-icon btn-email">
+                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  />
+                </svg>
+              </button>
+            </a>
             <button class="btn btn-social-icon btn-link">
               <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
                 <path d="M16,6H13V7.9H16C18.26,7.9 20.1,9.73 20.1,12A4.1,4.1 0 0,1 16,16.1H13V18H16A6,6 0 0,0 22,12C22,8.68 19.31,6 16,6M3.9,12C3.9,9.73 5.74,7.9 8,7.9H11V6H8A6,6 0 0,0 2,12A6,6 0 0,0 8,18H11V16.1H8C5.74,16.1 3.9,14.26 3.9,12M8,13H16V11H8V13Z"

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -52,17 +52,21 @@
       <div class="data-panel-footer">
         <div class="action-wrapper">
           <div class="social-icons">
-            <button class="btn btn-social-icon btn-twitter">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
-                <path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"
-                />
-              </svg>
-            </button>
-            <button class="btn btn-social-icon btn-facebook">
-              <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
-                <path d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" />
-              </svg>
-            </button>
+            <a appSocialSharePopup [href]="'http://twitter.com/intent/tweet?status=Eviction Lab+' + getCurrentUrl()">
+              <button class="btn btn-social-icon btn-twitter">
+                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a appSocialSharePopup [href]="'https://www.facebook.com/sharer.php?u=' + getCurrentUrl()">
+              <button class="btn btn-social-icon btn-facebook">
+                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" />
+                </svg>
+              </button>
+            </a>
             <a [href]="'mailto:?subject=Eviction Lab&body=' + getCurrentUrl()">
               <button class="btn btn-social-icon btn-email">
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -219,6 +219,11 @@ app-location-cards {
 
 .data-panel-footer .action-wrapper .social-icons {
   text-align: center;
+
+  a:hover {
+    text-decoration: none;
+  }
+
   .btn {
     display: inline-block;
     width: 40px;

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -148,6 +148,13 @@ export class DataPanelComponent implements OnChanges {
   }
 
   /**
+   * Adding method because calling window directly in the template doesn't work
+   */
+  getCurrentUrl() {
+    return window.location.href;
+  }
+
+  /**
    * Genrates line graph data from the features in `locations`
    */
   private createLineGraphData() {

--- a/src/app/map-tool/data-panel/data-panel.module.ts
+++ b/src/app/map-tool/data-panel/data-panel.module.ts
@@ -6,6 +6,7 @@ import { UiModule } from '../../ui/ui.module';
 
 import { DataPanelComponent } from './data-panel.component';
 import { DownloadFormComponent } from './download-form/download-form.component';
+import { SocialSharePopupDirective } from './social-share-popup.directive';
 
 @NgModule({
   exports: [ DataPanelComponent ],
@@ -15,7 +16,7 @@ import { DownloadFormComponent } from './download-form/download-form.component';
     UiModule,
     GraphModule.forRoot()
   ],
-  declarations: [ DataPanelComponent, DownloadFormComponent ],
+  declarations: [ DataPanelComponent, DownloadFormComponent, SocialSharePopupDirective ],
   entryComponents: [ DataPanelComponent, DownloadFormComponent ]
 })
 export class DataPanelModule { }

--- a/src/app/map-tool/data-panel/social-share-popup.directive.spec.ts
+++ b/src/app/map-tool/data-panel/social-share-popup.directive.spec.ts
@@ -1,0 +1,10 @@
+import { ElementRef } from '@angular/core';
+import { SocialSharePopupDirective } from './social-share-popup.directive';
+
+describe('SocialSharePopupDirective', () => {
+  it('should create an instance', () => {
+    const el = new ElementRef(null);
+    const directive = new SocialSharePopupDirective(el);
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/map-tool/data-panel/social-share-popup.directive.ts
+++ b/src/app/map-tool/data-panel/social-share-popup.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[appSocialSharePopup]'
+})
+export class SocialSharePopupDirective {
+
+  constructor(private el: ElementRef) { }
+
+  @HostListener('click', ['$event']) onClick(e) {
+    e.preventDefault();
+    const href = this.el.nativeElement.getAttribute('href');
+    window.open(href, 'Social Share', 'height=285,width=550,resizable=1');
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,26 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+
+  <!-- General metadata -->
+  <meta name="description" content="We're building the nation's first dataset of evictions, and making everything public and accessible." />
+  <meta name='author' content='Eviction Lab' />
+
+  <!-- Facebook metadata -->
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="The Eviction Lab: Coming Soon" />
+  <meta property="og:description" content="We're building the nation's first dataset of evictions, and making everything public and accessible. Big data about residential insecurity in your community is coming soon." />
+  <meta property="og:url" content="https://preview.evictionlab.org/" />
+  <meta property="og:site_name" content="Eviction Lab" />
+  <meta property="og:image" content="https://qgc0xnya6w-flywheel.netdna-ssl.com/wp-content/uploads/2017/09/eviction-michael-kienitz-facebook.jpg" />
+  <meta property="og:image:secure_url" content="https://qgc0xnya6w-flywheel.netdna-ssl.com/wp-content/uploads/2017/09/eviction-michael-kienitz-facebook.jpg" />
+
+  <!-- Twitter metadata -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:description" content="We're building the nation's first dataset of evictions, and making everything public and accessible. Big data about residential insecurity in your community is coming soon." />
+  <meta name="twitter:title" content="The Eviction Lab: Coming Soon" />
+  <meta name="twitter:image" content="https://qgc0xnya6w-flywheel.netdna-ssl.com/wp-content/uploads/2017/09/eviction-michael-kienitz-edit.jpg" />
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
Progress on #121, #119, and #118. Adds basic functionality for a `mailto` link as well as a directive for opening social share popups. Creates the `getCurrentUrl` method, which I'm assuming shouldn't be dependent on the router, but is needed because `window` can't be used in the template. 

Facebook's social share doesn't work locally because it actually tries to pull metadata from the supplied URL, but it works when provided an external link. I also added some sample metadata from the preview site that we can change. As for adding a dynamic image, it looks like it's pulling from the page directly, so that might be more trouble than it's worth (this StackOverflow answer seems to confirm that https://stackoverflow.com/a/29515024)