### PR TITLE
Feature/deeplinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,47 @@ Before running the tests make sure you are serving the app via `ng serve`.
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
+# Deep Linking
+
+The following options can be set through app routes or URL parameters:
+
+  - Locations
+  - Map Bounds
+  - Eviction Type
+  - Choropleth Highlight
+  - Geography Layer
+
+## Routes
+
+Routes for the app are as follows:
+
+http://{{BASE_URL}}/:locations/:year/:geography/:type/:choropleth/:bounds
+
+With the following options
+
+  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{x}},{{y}}`.  Set to `none` for no active locations.
+    - e.g. `states,257,381+counties,230,385` would activate Illinois and Kearney County
+  - `:year`: a year anywhere from 1990 to 2016
+  - `:geography`: `states`, `counties`, `cities`, `zip-codes`, `tracts`, or `block-groups`. 
+  - `:type`: an ID for the corresponding `BubbleAttribute` (`er` or `efr`)
+  - `:choropleth`: an ID for the corresponding choropleth `DataAttribute` (`p` or `pr`, more to come)
+  - `:bounds` a comma separated bounding box for the map to zoom to `{{west}},{{south}},{{east}},{{north}}`
+
+Data must be set through routes in this order `:locations/:year/:geography/:type/:choropleth/:bounds`.  If you want to set only one of these parameters, use the URL Parameters.
+
+## URL Parameters
+
+Map settings can also be set through URL parameters instead of routes, with the following format:
+
+http://{{BASE_URL}}/link;locations={{locations}};year={{year}};geography={{geography}};type={{type}};choropleth={{choropleth}};bounds={{bounds}}
+
+All settings are optional, so you could set only the year, eviction rate bubbles, and bounds with:
+
+http://{{BASE_URL}}/link;year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76
+
+### Getting the Current URL Parameters
+
+A string of the URL parameters based on the current view is available using `DataService.getUrlParameters()`, which returns a string of parameters based on the current view.  (e.g. `year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76`).
 
 # App Components 
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ All settings are optional, so you could set only the year, eviction rate bubbles
 
 http://{{BASE_URL}}/link;year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76
 
-### Getting the Current URL Parameters
+### Getting the Current URL Parameters / Route Array
 
 A string of the URL parameters based on the current view is available using `DataService.getUrlParameters()`, which returns a string of parameters based on the current view.  (e.g. `year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76`).
+
+An array containing all of the route parameter values is also available with `DataService.getRouteArray()`
 
 # App Components 
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ http://{{BASE_URL}}/:locations/:year/:geography/:type/:choropleth/:bounds
 
 With the following options
 
-  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{x}},{{y}}`.  Set to `none` for no active locations.
-    - e.g. `states,257,381+counties,230,385` would activate Illinois and Kearney County
+  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{lon}},{{lat}}`.  Set to `none` for no active locations.
+    - e.g. `states,-92.285,38.41+states,-93.34,42.163` would activate Missouri and Iowa
   - `:year`: a year anywhere from 1990 to 2016
   - `:geography`: `states`, `counties`, `cities`, `zip-codes`, `tracts`, or `block-groups`. 
   - `:type`: an ID for the corresponding `BubbleAttribute` (`er` or `efr`)

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,54 +9,66 @@ import { UiModule } from './ui/ui.module';
 import { MapToolModule } from './map-tool/map-tool.module';
 import { MapToolComponent } from './map-tool/map-tool.component';
 
-const mapConfig = {
-  style: './assets/style.json',
-  center: [-98.5556199, 39.8097343],
-  zoom: 3,
-  minZoom: 3,
-  maxZoom: 14
+const defaultData = {
+  mapConfig: {
+    style: './assets/style.json',
+    center: [-98.5556199, 39.8097343],
+    zoom: 3,
+    minZoom: 3,
+    maxZoom: 14
+  },
+  year: 2015,
+  locations: 'none',
+  geography: 'states',
+  types: 'none',
+  choropleth: 'none'
 };
 
 const appRoutes: Routes = [
   {
     path: ':locations/:year/:geography/:type/:choropleth/:bounds',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations/:year/:geography/:type/:choropleth',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations/:year/:geography/:type/:choropleth',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations/:year/:geography/:type',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations/:year/:geography',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations/:year',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: ':locations',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig }
+    data: defaultData
   },
   {
     path: 'link',
     component: MapToolComponent,
-    data: { mapConfig: mapConfig, year: 2015 }
+    data: defaultData
+  },
+  {
+    path: 'map',
+    component: MapToolComponent,
+    data: defaultData
   },
   {
     path: '',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,8 +9,50 @@ import { UiModule } from './ui/ui.module';
 import { MapToolModule } from './map-tool/map-tool.module';
 import { MapToolComponent } from './map-tool/map-tool.component';
 
+const mapConfig = {
+  style: './assets/style.json',
+  center: [-98.5556199, 39.8097343],
+  zoom: 3,
+  minZoom: 3,
+  maxZoom: 14
+};
+
 const appRoutes: Routes = [
-  { path: '', component: MapToolComponent }
+  {
+    path: ':geography/:year/:type/:choropleth/:locations',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: ':geography/:year/:type/:choropleth',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: ':geography/:year/:type',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: ':geography/:year',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: ':geography',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: 'map',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig, year: 2015 }
+  },
+  {
+    path: '',
+    redirectTo: '/map',
+    pathMatch: 'full'
+  }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ const appRoutes: Routes = [
   },
   {
     path: '',
-    redirectTo: '/none/2016/states/none/none/-136.80,20.68,-57.60,52.06', // default view
+    redirectTo: '/none/2016/auto/none/none/-136.80,20.68,-57.60,52.06', // default view
     pathMatch: 'full'
   }
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,16 +12,12 @@ import { MapToolComponent } from './map-tool/map-tool.component';
 const defaultData = {
   mapConfig: {
     style: './assets/style.json',
-    center: [-98.5556199, 39.8097343],
+    center: [-98.5795, 39.8283],
     zoom: 3,
     minZoom: 3,
     maxZoom: 14
   },
-  year: 2015,
-  locations: 'none',
-  geography: 'states',
-  types: 'none',
-  choropleth: 'none'
+  year: 2016
 };
 
 const appRoutes: Routes = [
@@ -31,48 +27,13 @@ const appRoutes: Routes = [
     data: defaultData
   },
   {
-    path: ':locations/:year/:geography/:type/:choropleth',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: ':locations/:year/:geography/:type/:choropleth',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: ':locations/:year/:geography/:type',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: ':locations/:year/:geography',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: ':locations/:year',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: ':locations',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: 'link',
-    component: MapToolComponent,
-    data: defaultData
-  },
-  {
-    path: 'map',
+    path: 'link', // optional path for URL parameters
     component: MapToolComponent,
     data: defaultData
   },
   {
     path: '',
-    redirectTo: '/map',
+    redirectTo: '/none/2016/states/none/none/-136.80,20.68,-57.60,52.06', // default view
     pathMatch: 'full'
   }
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,32 +19,42 @@ const mapConfig = {
 
 const appRoutes: Routes = [
   {
-    path: ':geography/:year/:type/:choropleth/:locations',
+    path: ':locations/:year/:geography/:type/:choropleth/:bounds',
     component: MapToolComponent,
     data: { mapConfig: mapConfig }
   },
   {
-    path: ':geography/:year/:type/:choropleth',
+    path: ':locations/:year/:geography/:type/:choropleth',
     component: MapToolComponent,
     data: { mapConfig: mapConfig }
   },
   {
-    path: ':geography/:year/:type',
+    path: ':locations/:year/:geography/:type/:choropleth',
     component: MapToolComponent,
     data: { mapConfig: mapConfig }
   },
   {
-    path: ':geography/:year',
+    path: ':locations/:year/:geography/:type',
     component: MapToolComponent,
     data: { mapConfig: mapConfig }
   },
   {
-    path: ':geography',
+    path: ':locations/:year/:geography',
     component: MapToolComponent,
     data: { mapConfig: mapConfig }
   },
   {
-    path: 'map',
+    path: ':locations/:year',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: ':locations',
+    component: MapToolComponent,
+    data: { mapConfig: mapConfig }
+  },
+  {
+    path: 'link',
     component: MapToolComponent,
     data: { mapConfig: mapConfig, year: 2015 }
   },

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -28,6 +28,7 @@ export class DataService {
   activeDataLevel: MapLayerGroup = DataLevels[0];
   activeDataHighlight: MapDataAttribute = DataAttributes[0];
   activeBubbleHighlight: MapDataAttribute = BubbleAttributes[0];
+  autoSwitchLayers = true;
   mapView;
   mapConfig;
   private mercator = new SphericalMercator({ size: 256 });
@@ -102,8 +103,8 @@ export class DataService {
    */
   getRouteArray() {
     const locations = this.activeFeatures.map((f, i, arr) => {
-      const xy = this.getFeatureXY(f);
-      return f.properties['layerId'] + ',' + xy.x + ',' + xy.y;
+      const lonLat = this.getFeatureLonLat(f).map(v => Math.round(v * 1000) / 1000);
+      return f.properties['layerId'] + ',' + lonLat[0] + ',' + lonLat[1];
     }).join('+');
     return [
       (locations === '' ? 'none' : locations),
@@ -145,20 +146,12 @@ export class DataService {
 
   /**
    * Gets a LonLat value for the center of the feature
-   * @param feature 
+   * @param feature
    */
-  getFeatureLonLat(feature) {
+  getFeatureLonLat(feature): Array<number> {
     const coords = feature.geometry['type'] === 'MultiPolygon' ?
     feature.geometry['coordinates'][0] : feature.geometry['coordinates'];
     return polylabel(coords, 1.0);
-  }
-
-  /**
-   * Gets the X/Y coords from a feature
-   * @param feature 
-   */
-  getFeatureXY(feature) {
-    return this.getXYFromLonLat(this.getFeatureLonLat(feature));
   }
 
   /**

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -11,23 +11,12 @@ import 'rxjs/add/observable/forkJoin';
 import * as _isEqual from 'lodash.isequal';
 import * as polylabel from 'polylabel';
 
-
 import { MapDataAttribute } from '../map-tool/map/map-data-attribute';
 import { MapLayerGroup } from '../map-tool/map/map-layer-group';
 import { MapDataObject } from '../map-tool/map/map-data-object';
 import { MapFeature } from '../map-tool/map/map-feature';
 import { DataAttributes, BubbleAttributes } from './data-attributes';
 import { DataLevels } from './data-levels';
-
-// maps GeoIds to their corresponding level
-// currently not compatible with zip codes
-const GEOID_MAP = {
-  2: 'states',
-  5: 'counties',
-  7: 'cities',
-  11: 'tracts',
-  12: 'block-groups'
-};
 
 @Injectable()
 export class DataService {
@@ -47,7 +36,9 @@ export class DataService {
   private tilesetYears = ['90', '00', '10'];
   private queryZoom = 10;
 
-  constructor(private http: Http) {}
+  constructor(private http: Http) {
+    setInterval(this.getUrlParameters.bind(this), 5000);
+  }
 
   /**
    * Sets the choropleth layer based on the provided `DataAttributes` ID
@@ -117,6 +108,7 @@ export class DataService {
     param += 'type=' + this.stripYearFromAttr(this.activeBubbleHighlight.id) + ';';
     param += 'geography=' + this.activeDataLevel.id + ';';
     param += 'choropleth=' + this.stripYearFromAttr(this.activeDataHighlight.id) + ';';
+    console.log('params', param);
     return param;
   }
 
@@ -148,12 +140,20 @@ export class DataService {
     }
   }
 
+  /**
+   * Gets a LonLat value for the center of the feature
+   * @param feature 
+   */
   getFeatureLonLat(feature) {
     const coords = feature.geometry['type'] === 'MultiPolygon' ?
     feature.geometry['coordinates'][0] : feature.geometry['coordinates'];
     return polylabel(coords, 1.0);
   }
 
+  /**
+   * Gets the X/Y coords from a feature
+   * @param feature 
+   */
   getFeatureXY(feature) {
     return this.getXYFromLonLat(this.getFeatureLonLat(feature));
   }

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -36,9 +36,7 @@ export class DataService {
   private tilesetYears = ['90', '00', '10'];
   private queryZoom = 10;
 
-  constructor(private http: Http) {
-    setInterval(this.getUrlParameters.bind(this), 5000);
-  }
+  constructor(private http: Http) {}
 
   /**
    * Sets the choropleth layer based on the provided `DataAttributes` ID

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -93,23 +93,28 @@ export class DataService {
    * Returns the URL parameters for the current view
    */
   getUrlParameters() {
-    let param = '';
-    // locations
-    this.activeFeatures.forEach((f, i, arr) => {
-      if (i === 0) { param += 'locations='; }
+    const paramMap = [ 'locations', 'year', 'geography', 'type', 'choropleth', 'bounds' ];
+    return this.getRouteArray().reduce((a, b, i) => {
+      return a + ';' + paramMap[i] + '=' + b;
+    }, '');
+  }
+
+  /**
+   * Gets an array of values that represent the current route
+   */
+  getRouteArray() {
+    const locations = this.activeFeatures.map((f, i, arr) => {
       const xy = this.getFeatureXY(f);
-      param += f.properties['layerId'] + ',' + xy.x + ',' + xy.y;
-      param += (i === arr.length - 1 ? ';' : '+');
-    });
-    param += 'year=' + this.activeYear + ';';
-    if (this.mapView) {
-      param += 'bounds=' + this.mapView.join() + ';';
-    }
-    param += 'type=' + this.stripYearFromAttr(this.activeBubbleHighlight.id) + ';';
-    param += 'geography=' + this.activeDataLevel.id + ';';
-    param += 'choropleth=' + this.stripYearFromAttr(this.activeDataHighlight.id) + ';';
-    console.log('params', param);
-    return param;
+      return f.properties['layerId'] + ',' + xy.x + ',' + xy.y;
+    }).join('+');
+    return [
+      (locations === '' ? 'none' : locations),
+      this.activeYear,
+      this.activeDataLevel.id,
+      this.stripYearFromAttr(this.activeBubbleHighlight.id),
+      this.stripYearFromAttr(this.activeDataHighlight.id),
+      this.mapView ? this.mapView.join() : null
+    ];
   }
 
   /**

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -42,14 +42,14 @@
         [features]="dataService.activeFeatures"
         [year]="dataService.activeYear"
         (viewMore)="goToDataPanel($event)"
-        (dismissedCard)="dataService.removeLocation($event)"
+        (dismissedCard)="dataService.removeLocation($event); updateRoute()"
     ></app-location-cards>
     <app-data-panel
         id="data-panel"
         *ngIf="dataService.activeFeatures.length > 0"
         [year]="dataService.activeYear"
         [locations]="dataService.activeFeatures" 
-        (locationRemoved)="dataService.removeLocation($event)"
+        (locationRemoved)="dataService.removeLocation($event); updateRoute()"
         (locationAdded)="onSearchSelect($event, false)"
     ></app-data-panel>
     <div class="footer">

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -21,7 +21,7 @@
     </div>
     <app-map
       [mapConfig]="dataService.mapConfig"
-      [autoSwitch]="autoSwitchLayers"
+      [autoSwitch]="dataService.autoSwitchLayers"
       [bubbleOptions]="dataService.bubbleAttributes"
       [layerOptions]="dataService.dataLevels"
       [choroplethOptions]="dataService.dataAttributes"

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -31,6 +31,11 @@
       [(selectedChoropleth)]="dataService.activeDataHighlight"
       [(selectedLayer)]="dataService.activeDataLevel"
       (featureClick)="onFeatureSelect($event)"
+      (boundingBoxChange)="updateRoute()"
+      (yearChange)="updateRoute()"
+      (selectedBubbleChange)="updateRoute()"
+      (selectedChoroplethChange)="updateRoute()"
+      (selectedLayerChange)="updateRoute()"
     ></app-map>
     <app-location-cards 
         *ngIf="dataService.activeFeatures.length > 0" 

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -3,6 +3,7 @@ import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import { PageScrollConfig, PageScrollService, PageScrollInstance } from 'ng2-page-scroll';
 import Debounce from 'debounce-decorator';
+import 'rxjs/add/operator/take';
 
 import { MapFeature } from './map/map-feature';
 import { MapComponent } from './map/map/map.component';
@@ -18,6 +19,7 @@ export class MapToolComponent implements OnInit {
   autoSwitchLayers = true;
   verticalOffset;
   enableZoom;
+  currentRoute = [];
   @ViewChild(MapComponent) map;
 
   constructor(
@@ -30,14 +32,15 @@ export class MapToolComponent implements OnInit {
 
   ngOnInit() {
     this.configurePageScroll();
-    this.route.data.subscribe(this.setMapToolData.bind(this));
-    this.route.paramMap.subscribe(this.setRouteParams.bind(this));
+    this.route.data.take(1).subscribe(this.setMapToolData.bind(this));
+    this.route.paramMap.take(1).subscribe(this.setRouteParams.bind(this));
   }
 
   /**
    * Configures the data service based on any route parameters
    */
   setRouteParams(params: ParamMap) {
+    console.log('setting route params');
     if (params.has('year')) {
       this.dataService.activeYear = params.get('year');
     }
@@ -63,10 +66,16 @@ export class MapToolComponent implements OnInit {
     }
   }
 
+  /** Update route if it has changed */
+  updateRoute() {
+    this.router.navigate(this.dataService.getRouteArray(), { replaceUrl: true });
+  }
+
   /**
    * Configures the data service with any static data passed through the route
    */
   setMapToolData(data) {
+    console.log('setting data');
     this.dataService.mapConfig = data.mapConfig;
     if (data.hasOwnProperty('year')) {
       this.dataService.activeYear = data.year;

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -40,7 +40,6 @@ export class MapToolComponent implements OnInit {
    * Configures the data service based on any route parameters
    */
   setRouteParams(params: ParamMap) {
-    console.log('setting route params');
     if (params.has('year')) {
       this.dataService.activeYear = params.get('year');
     }
@@ -66,20 +65,19 @@ export class MapToolComponent implements OnInit {
     }
   }
 
-  /** Update route if it has changed */
-  updateRoute() {
-    this.router.navigate(this.dataService.getRouteArray(), { replaceUrl: true });
-  }
-
   /**
    * Configures the data service with any static data passed through the route
    */
   setMapToolData(data) {
-    console.log('setting data');
     this.dataService.mapConfig = data.mapConfig;
     if (data.hasOwnProperty('year')) {
       this.dataService.activeYear = data.year;
     }
+  }
+
+  /** Update route if it has changed */
+  updateRoute() {
+    this.router.navigate(this.dataService.getRouteArray(), { replaceUrl: true });
   }
 
   /**
@@ -89,7 +87,10 @@ export class MapToolComponent implements OnInit {
   onFeatureSelect(feature: MapFeature) {
     const featureLonLat = this.dataService.getFeatureLonLat(feature);
     this.dataService.getTileData(feature['layer']['id'], featureLonLat, true)
-      .subscribe(data => this.dataService.addLocation(data));
+      .subscribe(data => {
+        this.dataService.addLocation(data);
+        this.updateRoute();
+      });
   }
 
   /**

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -179,13 +179,13 @@ export class MapToolComponent implements OnInit {
   private getLocationsFromString(locations: string) {
     return locations.split('+').map(loc => {
       const locArray = loc.split(',');
-      if (locArray.length !== 3) { return null; }
+      if (locArray.length !== 3) { return null; } // invalid location
       return {
         layer: locArray[0],
         lonLat: this.dataService.getLonLatFromXYZ(
           parseFloat(locArray[1]), parseFloat(locArray[2])
         )
       };
-    });
+    }).filter(loc => loc); // filter null values
   }
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -16,7 +16,7 @@ import { DataService } from '../data/data.service';
 })
 export class MapToolComponent implements OnInit {
   title = 'Eviction Lab';
-  autoSwitchLayers = true;
+  // autoSwitchLayers = true;
   verticalOffset;
   enableZoom;
   currentRoute = [];
@@ -50,8 +50,11 @@ export class MapToolComponent implements OnInit {
       this.dataService.setBubbleHighlight(params.get('type'));
     }
     if (params.has('geography')) {
-      this.dataService.setGeographyLevel(params.get('geography'));
-      this.autoSwitchLayers = false;
+      const geo = params.get('geography');
+      if (geo !== 'auto') {
+        this.dataService.setGeographyLevel(geo);
+        // this.autoSwitchLayers = false;
+      }
     }
     if (params.has('locations')) {
       const locations = this.getLocationsFromString(params.get('locations'));
@@ -99,7 +102,7 @@ export class MapToolComponent implements OnInit {
    * @param updateMap moves the map to the selected location if true
    */
   onSearchSelect(feature: MapFeature | null, updateMap = true) {
-    this.autoSwitchLayers = false;
+    // this.autoSwitchLayers = false;
     if (feature) {
       const layerId = feature.properties['layerId'];
       this.dataService.getTileData(layerId, feature.geometry['coordinates'], true)
@@ -192,9 +195,7 @@ export class MapToolComponent implements OnInit {
       if (locArray.length !== 3) { return null; } // invalid location
       return {
         layer: locArray[0],
-        lonLat: this.dataService.getLonLatFromXYZ(
-          parseFloat(locArray[1]), parseFloat(locArray[2])
-        )
+        lonLat: [ parseFloat(locArray[1]), parseFloat(locArray[2]) ]
       };
     }).filter(loc => loc); // filter null values
   }

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -27,6 +27,7 @@
           class="highlight-select"
           label="Census Data"
           labelProperty="name"
+          [selectedValue]="selectedChoropleth"
           [values]="choroplethOptions"
           (change)="selectedChoropleth = $event">
       </app-ui-select>
@@ -40,7 +41,7 @@
           (change)="setGroupVisibility($event)">
       </app-ui-select>
       <div 
-        *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None'" 
+        *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length" 
         class="map-legend" 
         [style.background]="getLegendGradient()"
       >
@@ -48,7 +49,7 @@
           <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
       </div>
       <app-ui-hint 
-          *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None'"
+          *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length"
           class="legend-hint"
           [hint]="'The colored ' + selectedLayer['name'] + ' on the map represent ' + selectedChoropleth['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
           placement="bottom"


### PR DESCRIPTION
Deep linking implementation, from the README:

The following options can be set through app routes or URL parameters:

  - Locations
  - Map Bounds
  - Eviction Type
  - Choropleth Highlight
  - Geography Layer

## Routes

Routes for the app are as follows:

http://{{BASE_URL}}/:locations/:year/:geography/:type/:choropleth/:bounds

With the following options

  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{x}},{{y}}`.  Set to `none` for no active locations.
    - e.g. `states,257,381+counties,230,385` would activate Illinois and Kearney County
  - `:year`: a year anywhere from 1990 to 2016
  - `:geography`: `states`, `counties`, `cities`, `zip-codes`, `tracts`, or `block-groups`. 
  - `:type`: an ID for the corresponding `BubbleAttribute` (`er` or `efr`)
  - `:choropleth`: an ID for the corresponding choropleth `DataAttribute` (`p` or `pr`, more to come)
  - `:bounds` a comma separated bounding box for the map to zoom to `{{west}},{{south}},{{east}},{{north}}`

Data must be set through routes in this order `:locations/:year/:geography/:type/:choropleth/:bounds`.  If you want to set only one of these parameters, use the URL Parameters.

## URL Parameters

Map settings can also be set through URL parameters instead of routes, with the following format:

http://{{BASE_URL}}/link;locations={{locations}};year={{year}};geography={{geography}};type={{type}};choropleth={{choropleth}};bounds={{bounds}}

All settings are optional, so you could set only the year, eviction rate bubbles, and bounds with:

http://{{BASE_URL}}/link;year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76