### PR TITLE
Add notice for hidden layers in select

### DIFF
--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -38,6 +38,7 @@
           labelProperty="name"
           [selectedValue]="selectedLayer"
           [values]="selectDataLevels" 
+          [bottomLabel]="selectDataLevels.length < layerOptions.length ? 'Zoom for more' : false"
           (change)="setGroupVisibility($event)">
       </app-ui-select>
       <div 

--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -17,5 +17,6 @@
         {{getLabel(value)}}
       </a>
     </li>
+    <li *ngIf="bottomLabel" class="bottom-label"><a class="dropdown-item">Zoom for more</a></li>
   </ul>
 </div>

--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -17,6 +17,6 @@
         {{getLabel(value)}}
       </a>
     </li>
-    <li *ngIf="bottomLabel" class="bottom-label"><a class="dropdown-item">Zoom for more</a></li>
+    <li *ngIf="bottomLabel" class="bottom-label"><a class="dropdown-item">{{bottomLabel}}</a></li>
   </ul>
 </div>

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -16,8 +16,6 @@
       box-sizing: border-box;
       min-width: 140px;
       padding:0;
-      // TODO: It seems like this isn't necessary
-      // max-height: 190px;
       overflow: auto;
       & > li > a {
         padding: 0px 12px;
@@ -65,6 +63,10 @@
         }
       }
     }
+  }
+
+  @media(max-width: 768px) {
+    .el-select .dropdown-menu { max-height: 190px; }
   }
 
   // OVERRIDES

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -16,7 +16,8 @@
       box-sizing: border-box;
       min-width: 140px;
       padding:0;
-      max-height: 190px;
+      // TODO: It seems like this isn't necessary
+      // max-height: 190px;
       overflow: auto;
       & > li > a {
         padding: 0px 12px;
@@ -27,6 +28,17 @@
         box-sizing: border-box;
       }
       & li:first-child a { border-top: none; }
+      & > li, & > li > a {
+        cursor: pointer;
+      }
+      & > li.bottom-label, & > li.bottom-label > a {
+        font-style: italic;
+        color: rgba(0, 0, 0, 0.5);
+        cursor: inherit;
+      }
+      & > li.bottom-label:hover, & > li.bottom-label > a:hover {
+        background: inherit;
+      }
     }
     .dropdown-toggle.btn {
       position:relative;

--- a/src/app/ui/ui-select/ui-select.component.ts
+++ b/src/app/ui/ui-select/ui-select.component.ts
@@ -11,6 +11,7 @@ import * as _isEqual from 'lodash.isequal';
 export class UiSelectComponent implements OnInit {
   @Input() label: string; // optional label for the select dropdown
   @Input() labelProperty: string; // only provided if values are an object
+  @Input() bottomLabel: string;
   @Input()
   set selectedValue(newValue) {
     if (_isEqual(newValue, this._selectedValue)) { return; }


### PR DESCRIPTION
Closes #143. Instead of just hiding the layers that can't be accessed or graying them out, whenever layers are hidden the message "Zoom for more" displays at the bottom of the select. Tried to modify as little as possible since UI select is used everywhere. 

Some other things to note:
* I took out the `max-height` for UI select because some of the layers aren't visible without it. If this was for mobile though I'm happy to change it back
* I added `cursor: pointer` to select items to make it more explicit that they can be clicked

![layer-select](https://user-images.githubusercontent.com/8291663/32673814-1791ae38-c616-11e7-98b5-48cfb945bce8.gif)
