### PR TITLE
Use tile coords for bbox

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -82,7 +82,7 @@ export class DataService {
 
   /**
    * Sets the bounding box for the map to focus to
-   * @param mapBounds an array with four coordinates representing south, west, north, east
+   * @param mapBounds an array with four coordinates representing west, south, east, north
    */
   setMapBounds(mapBounds) {
     this.mapView = mapBounds;
@@ -214,7 +214,12 @@ export class DataService {
         const feat = layer.feature(i).toGeoJSON(coords.x, coords.y, 10);
         if (inside(point, feat)) {
           feat.properties.layerId = layerId;
-          feat.properties.bbox = bbox(feat);
+          feat.bbox = [
+            feat.properties['west'],
+            feat.properties['south'],
+            feat.properties['east'],
+            feat.properties['north']
+          ];
           return feat;
         }
       }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -132,7 +132,11 @@ export class MapToolComponent implements OnInit {
     const layerId = feature.properties['layerId'];
     const dataLevel = this.dataService.dataLevels.filter(l => l.id === layerId)[0];
     this.map.setGroupVisibility(dataLevel);
-    this.map.zoomToFeature(feature);
+    if (feature.hasOwnProperty('bbox')) {
+      this.map.zoomToBoundingBox(feature.bbox);
+    } else {
+      this.map.zoomToPointFeature(feature);
+    }
   }
 
   /**

--- a/src/app/map-tool/map/map-feature.ts
+++ b/src/app/map-tool/map/map-feature.ts
@@ -1,5 +1,6 @@
 export interface MapFeature extends GeoJSON.Feature<GeoJSON.GeometryObject> {
+    bbox?: number[];
     properties: {
-        [n: string]: string
+        [n: string]: string;
     };
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -155,6 +155,14 @@ export class MapComponent implements OnInit {
   }
 
   /**
+   * Zoom to bounding box
+   * @param bbox
+   */
+  zoomToBoundingBox(bbox: number[]) {
+    this.map.zoomToBoundingBox(bbox);
+  }
+
+  /**
    * Returns sanitized gradient for the legend
    */
   getLegendGradient() {


### PR DESCRIPTION
Fixes #152. I forgot that we had added the bounding box coordinates for each feature to the tile data for this exact reason. Replaced the call to `bbox` in `getTileData` with creating the actual bounding box from these points and adding it to the interface. This still means #150 could be relatively complicated, so markers might not be the worst option there 