### PR TITLE
Change hint trigger to click for browsers

### DIFF
--- a/src/app/ui/ui-hint/ui-hint.component.ts
+++ b/src/app/ui/ui-hint/ui-hint.component.ts
@@ -8,5 +8,5 @@ import { Component, OnInit, Input } from '@angular/core';
 export class UiHintComponent {
   @Input() hint: string;
   @Input() placement = 'top';
-  @Input() triggers = 'focus';
+  @Input() triggers = 'click';
 }


### PR DESCRIPTION
Fixes #138. Was also a problem for Firefox. It looks like there are just some issues with ngx-bootstrap and the `focus` event across browsers. If there's no issue with using the `click` even this will work