### PR TITLE
Fall back to text search if point fails

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -75,7 +75,7 @@ export class DataService {
   /** */
   setLocations(locations) {
     locations.forEach(l => {
-      this.getTileData(l.layer, l.lonLat, true)
+      this.getTileData(l.layer, l.lonLat, null, true)
         .subscribe((data) => { this.addLocation(data); });
     });
   }
@@ -161,11 +161,14 @@ export class DataService {
    *
    * @param layerId ID of layer to query for tile data
    * @param lonLat array of [lon, lat]
+   * @param featName feature name to check as fallback
    * @param multiYear specifies whether to merge multiple year tiles
    */
-  getTileData(layerId: string, lonLat: number[], multiYear = false): Observable<MapFeature> {
+  getTileData(
+    layerId: string, lonLat: number[], featName: string | null, multiYear = false
+  ): Observable<MapFeature> {
     const coords = this.getXYFromLonLat(lonLat);
-    const parseTile = this.getParser(layerId, lonLat);
+    const parseTile = this.getParser(layerId, lonLat, featName);
     if (multiYear) {
       const tileRequests = this.tilesetYears.map((y) => {
         return this.requestTile(layerId, coords, y).map(parseTile);
@@ -204,21 +207,32 @@ export class DataService {
    * @param layerId
    * @param lonLat
    */
-  private getParser(layerId, lonLat) {
+  private getParser(layerId, lonLat, featName) {
     const point = this.getPoint(lonLat);
     const coords = this.getXYFromLonLat(lonLat);
     return (res: Response): MapFeature => {
       const tile = new vt.VectorTile(new Protobuf(res.arrayBuffer()));
       const layer = tile.layers[layerId];
-      for (let i = 0; i < layer.length; ++i) {
-        const feat = layer.feature(i).toGeoJSON(coords.x, coords.y, 10);
-        if (inside(point, feat)) {
-          feat.properties.layerId = layerId;
-          feat.properties.bbox = bbox(feat);
-          return feat;
-        }
+      const features = [...Array(layer.length)].fill(null).map((d, i) => {
+        return layer.feature(i).toGeoJSON(coords.x, coords.y, 10);
+      });
+
+      let matchFeat;
+      const containsPoint = features.filter(feat => inside(point, feat));
+      if (containsPoint.length) {
+        matchFeat = containsPoint[0];
+      } else {
+        const matchesName = features.filter(feat =>
+          feat.properties.n.toLowerCase().startsWith(featName.toLowerCase()));
+        matchFeat = matchesName.length ? matchesName[0] : false;
       }
-      // Return empty object if nothing found for now
+
+      if (matchFeat) {
+        matchFeat.properties.layerId = layerId;
+        matchFeat.properties.bbox = bbox(matchFeat);
+        return matchFeat;
+      }
+
       return {} as MapFeature;
     };
   }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -89,7 +89,7 @@ export class MapToolComponent implements OnInit {
    */
   onFeatureSelect(feature: MapFeature) {
     const featureLonLat = this.dataService.getFeatureLonLat(feature);
-    this.dataService.getTileData(feature['layer']['id'], featureLonLat, true)
+    this.dataService.getTileData(feature['layer']['id'], featureLonLat, null, true)
       .subscribe(data => {
         this.dataService.addLocation(data);
         this.updateRoute();
@@ -105,9 +105,10 @@ export class MapToolComponent implements OnInit {
     // this.autoSwitchLayers = false;
     if (feature) {
       const layerId = feature.properties['layerId'];
-      this.dataService.getTileData(layerId, feature.geometry['coordinates'], true)
-        .subscribe(data => {
-          if (data === {}) {
+      this.dataService.getTileData(
+        layerId, feature.geometry['coordinates'], feature.properties['name'], true
+      ).subscribe(data => {
+          if (!data.properties.n) {
             console.log('could not find feature');
           }
           const dataLevel = this.dataService.dataLevels.filter(l => l.id === layerId)[0];


### PR DESCRIPTION
Fixes #139. I tried the search out with Sheboygan County, and it does fail. It looks like this is a quirk of Mapzen Search's boundaries for this area (screenshot below). To account for any areas like this where the center point may be outside of the land boundaries, I added a fallback name match (using `startsWith` because some census names have extra words) in case the point lookup fails.

This will conflict with #155, so that should probably be merged first and then I'll update the `bbox` handling here.

Mapzen Search boundaries for Sheboygan County:
<img width="749" alt="screen shot 2017-11-12 at 4 52 55 pm" src="https://user-images.githubusercontent.com/8291663/32704791-b8e97548-c7d0-11e7-9102-930016a9be8f.png">
