### PR TITLE
Update attempt for legend style

### DIFF
--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -44,16 +44,18 @@
       <div 
         *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length" 
         class="map-legend" 
-        [style.background]="getLegendGradient()"
       >
-          <span class="legend-start">{{legend[1][0]}}</span>
-          <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
+        <div class="legend-bg"></div>
+        <div class="legend" [style.background]="getLegendGradient()">
+            <span class="legend-start">{{legend[1][0]}}</span>
+            <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
+        </div>
       </div>
       <app-ui-hint 
           *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length"
           class="legend-hint"
           [hint]="'The colored ' + selectedLayer['name'] + ' on the map represent ' + selectedChoropleth['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
-          placement="bottom"
+          [placement]="fullWidth ? 'bottom' : 'right'"
       ></app-ui-hint>
   </div>
   <div class="year-slider-container">

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -95,34 +95,51 @@ app-ui-select.open {
 // Map Legend
 
 .legend-hint {
-  float:right;
-  margin-top: -12px;
+  position: absolute;
+  top: 52px;
+  left: 0;
+  right: 220px;
 }
 
 .map-legend {
-  float: left;
-  width: 80%;
+  position: absolute;
   height: 24px;
-  padding:4px 8px;
-  margin: 4px 0;
-  margin-top: -8px;
-  font-size:11px;
-  font-weight:bold;
+  right: 0;
+  top: 56px;
+  left: 30px;
+  width: auto;
   box-shadow: 0 1px 3px rgba(0,0,0,0.25);
-  .legend-end {
-    float:right;
+  
+  & > .legend-bg {
+    background-color: #f8f8f9;
+  }
+
+  & > div {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    font-size:11px;
+    font-weight:bold;
+    padding: 4px;
+
+    .legend-end {
+      float: right;
+    }
   }
 }
 
 @media (min-width: 767px) {
   .map-legend {
-    min-width:196px;
-    width:26%;
-    float:right;
-    margin-top: inherit;
+    height: 24px;
+    width: 200px;
+    left: auto;
+    float: right;
+    top: 16px;
   }
   .legend-hint {
-    margin-top: inherit;
+    top: 12px;
+    right: 200px;
+    left: auto;
   }
 }
 

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -97,6 +97,7 @@ export class MapComponent implements OnInit {
   legend;
   mapLoading = false;
   mapEventLayers: Array<string>;
+  get fullWidth(): boolean { return window.innerWidth >= 767; };
   private zoom = 3;
   private _store = {
     layer: null,


### PR DESCRIPTION
Attempt to fix #146. Adds a solid background that's the same color as the basemap to the legend so that it doesn't blend in with the opacity as much. Also updates some of the styles for positioning, and bases the tooltip display position on screen size (added a `fullWidth` prop because I couldn't find an easier way of doing this).

I tried a white border out, but it wasn't helpful. Feedback and different approaches definitely welcome!