### PR TITLE
Feature/map legend

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,32 @@
-import { Component, ViewChild, Inject, HostListener } from '@angular/core';
+import { Component, OnInit, Inject, HostListener, HostBinding } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
 
+// return the global native browser window object
+function _window(): any { return window; }
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
+  @HostBinding('class.gt-mobile') largerThanMobile: boolean;
+  @HostBinding('class.gt-tablet') largerThanTablet: boolean;
+  @HostBinding('class.gt-small-desktop') largerThanSmallDesktop: boolean;
+  @HostBinding('class.gt-large-desktop') largerThanLargeDesktop: boolean;
+  get nativeWindow() { return _window(); }
 
+  /** Sets the size relevant classes on init */
+  ngOnInit() { this.onWindowResize(); }
+
+  /** Sets the booleans that determine the classes on the app component */
+  @HostListener('window:resize') onWindowResize() {
+    const w = this.nativeWindow.innerWidth;
+    this.largerThanMobile = (w > 767);
+    this.largerThanTablet = (w > 1024);
+    this.largerThanSmallDesktop = (w > 1279);
+    this.largerThanLargeDesktop = (w > 1599);
+  }
 }

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -164,7 +164,7 @@
     &:nth-child(4) .legend-marker { background: $graphColor4; }
   }
 }
-@media(min-width: 768px) {
+:host-context(.gt-mobile) {
   .graph-area { 
     width:60%; 
     display:inline-block;
@@ -172,7 +172,6 @@
   .graph-legend {
     width: 40%;
     float:right;
-    
   }
 }
 

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -24,9 +24,9 @@
   }
 }
 
-// Tablet+
-// - Adjust height of map / location cards to reflect large header.
-@media(min-width: 768px) {
+// Larger than tablet:
+//    Adjust height of map / location cards to reflect large header.
+:host-context(.gt-mobile) {
   .app-wrapper {
     &.map-active {
       height: calc(100vh - #{$headerHeightLg});

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -14,6 +14,7 @@
 </div>
 <div class="map-ui-wrapper">
   <ng-content></ng-content>
+  <app-ui-map-legend *ngIf="showLegend" [choropleth]="selectedChoropleth" [bubbles]="selectedBubble" [layer]="selectedLayer"></app-ui-map-legend>   
   <app-progress-bar *ngIf="mapLoading"></app-progress-bar>
   <app-location-cards 
     *ngIf="activeFeatures.length > 0"
@@ -51,31 +52,15 @@
           [bottomLabel]="selectDataLevels.length < layerOptions.length ? 'Zoom for more' : false"
           (change)="setGroupVisibility($event)">
       </app-ui-select>
-      <div 
-        *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length" 
-        class="map-legend" 
-      >
-        <div class="legend-bg"></div>
-        <div class="legend" [style.background]="getLegendGradient()">
-            <span class="legend-start">{{legend[1][0]}}</span>
-            <span class="legend-end">{{legend[legend.length - 1][0]}}</span>
-        </div>
+      <!-- map legend here -->
+    </div>
+    <div class="year-slider-container">
+        <app-ui-slider tabindex="9"
+          class="year-slider"
+          [currentValue]="year" 
+          [min]="1990" 
+          [max]="2016" 
+          (change)="year=$event"
+        ></app-ui-slider>
       </div>
-      <app-ui-hint 
-          *ngIf="selectedChoropleth && selectedChoropleth.name !== 'None' && legend && legend.length"
-          class="legend-hint"
-          [hint]="'The colored ' + selectedLayer['name'] + ' on the map represent ' + selectedChoropleth['name'] + ' from ' + legend[1][0] + ' to ' + legend[legend.length - 1][0] + '.'" 
-          [placement]="fullWidth ? 'bottom' : 'right'"
-      ></app-ui-hint>
-  </div>
-  <div class="year-slider-container">
-    <app-ui-slider tabindex="9"
-      class="year-slider"
-      [currentValue]="year" 
-      [min]="1990" 
-      [max]="2016" 
-      (change)="year=$event"
-    ></app-ui-slider>
-  </div>
-  
 </div>

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -1,15 +1,14 @@
 @import '../../../../theme';
 
-
-
 // Map UI Layout
-
+// ----
+// Map fills the component width and height
 .map-wrapper {
   width:100%;
   height:100%;
   display:block;
 }
-
+// Map UI Wrapper spans the entire width of the viewport
 .map-ui-wrapper {
     pointer-events:none;
     position: absolute;
@@ -20,6 +19,7 @@
     bottom: 0;
     right: 0;
 }
+// Map UI maxes out at the max content width
 .map-ui {
     position:absolute;
     max-width: $maxContentWidth;
@@ -32,7 +32,14 @@
     z-index:49;
     pointer-events:all;
 }
+// ----
+// End Map UI Layout
 
+// Map Location Cards
+// ----
+// default:
+//    Fix location cards to the left side of the window
+// ----
 app-location-cards {
   position: absolute;
   top:0;
@@ -46,13 +53,27 @@ app-location-cards {
   align-items: center;
   width:100%;
 }
+// ----
+// greater than tablet:
+//    Adjust cards container to account for the larger header height
+// ----
+:host-context(.gt-tablet) {
+  app-location-cards { height: calc(100vh - #{$headerHeightLg}); }
+}
+// ----
+// End Map Location Cards
 
-// Select boxes
 
+// Map Data Select Boxes
+// ----
+// default: 
+//    hide labels and adjust width so the select menus
+//    span the full width of the window.
+// ----
 app-ui-select {
   position: absolute;
   width:32%;
-  top: 16px;
+  top:0;
   ::ng-deep .el-select-label {
     display: none;
   }
@@ -66,16 +87,11 @@ app-ui-select {
     white-space: nowrap;
   }
 }
-app-ui-select:nth-of-type(1) {
-  left: 0;
-}
-app-ui-select:nth-of-type(2) {
-  left: 34%;
-}
-app-ui-select:nth-of-type(3) {
-  right: 0;
-}
-
+// position the dropwdowns
+app-ui-select:nth-of-type(1) { left: 0; }
+app-ui-select:nth-of-type(2) { left: 34%; }
+app-ui-select:nth-of-type(3) { right: 0; }
+// span full width when open
 app-ui-select.open {
   left: 0;
   right: 0;
@@ -86,8 +102,11 @@ app-ui-select.open {
     display: inherit;
   }
 }
-
-@media (min-width: 767px) {
+// ----
+// greater than tablet: 
+//    float the dropdowns on the top left side of the map
+// ----
+:host-context(.gt-tablet) {
   app-ui-select {
     float:left;
     width:auto;
@@ -101,7 +120,9 @@ app-ui-select.open {
       font-size: 12px;
     }
   }
-  app-ui-select:nth-of-type(1), app-ui-select:nth-of-type(2), app-ui-select:nth-of-type(3) {
+  app-ui-select:nth-of-type(1), 
+  app-ui-select:nth-of-type(2), 
+  app-ui-select:nth-of-type(3) {
     left: inherit;
   }
   app-ui-select.open {
@@ -109,80 +130,69 @@ app-ui-select.open {
     right: inherit;
     width: auto;
   }
-  app-location-cards {
-    height: calc(100vh - #{$headerHeightLg});
-  }
 }
+// ----
+// End Map Data Select Boxes
 
 
 // Map Legend
-
-.legend-hint {
-  position: absolute;
-  top: 52px;
-  left: 0;
-  right: 220px;
+// ----
+// mobile / tablet: 
+//    map spans entire width at bottom of map
+// ----
+app-ui-map-legend {
+  width: 100%;
+  height: $legendHeight;
+  position:absolute;
+  bottom: $timeSliderHeight;
+  right:0;
+  left:0;
 }
-
-.map-legend {
-  position: absolute;
-  height: 24px;
-  right: 0;
-  top: 56px;
-  left: 30px;
-  width: auto;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
-  
-  & > .legend-bg {
-    background-color: #f8f8f9;
-  }
-
-  & > div {
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    font-size:11px;
-    font-weight:bold;
-    padding: 4px;
-
-    .legend-end {
-      float: right;
+// ----
+// larger than tablet: 
+//    move legend to top right of the map
+// ----
+:host-context(.gt-tablet) {
+  app-ui-map-legend {
+    width:calc(100% - #{$defaultPadding*2});
+    max-width: $maxContentWidth;
+    margin:auto;
+    top:0;
+    right:0;
+    left:0;
+    bottom: auto;
+    ::ng-deep .map-legend {
+      width: 268px;
+      position:absolute;
+      right:0;
+      top:0;
     }
   }
 }
+// ----
+// End Map Legend
 
-@media (min-width: 767px) {
-  .map-legend {
-    height: 24px;
-    width: 200px;
-    left: auto;
-    float: right;
-    top: 16px;
-  }
-  .legend-hint {
-    top: 12px;
-    right: 200px;
-    left: auto;
-  }
-}
 
 // Year Slider
-
+// ----
+// default: 
+//    Place year slider at the bottom of the window below the map
+// ----
 .year-slider-container {
   @include fill-parent();
-  top:auto;
-  height:40px;
+  top: auto;
+  height: $timeSliderHeight;
   z-index: 1000;
-  background:#fff;
-  padding: 0 16px;
+  background: $timeSliderBackground;
+  padding: 0 $defaultPadding;
   box-shadow: 0 -1px 2px rgba(0,0,0,0.2);
+  // keep the slider component within the max content width
   .year-slider {
-    margin:auto;
+    margin: auto;
     max-width: $maxContentWidth - $defaultPadding*4;
-    height:40px;
-    display:block;
+    height: $timeSliderHeight;
+    display: block;
   }
 }
-
-  
-
+// ----
+// End Year Slider

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -1,31 +1,19 @@
-#map {
-  width:100%;
-  height:100%;
-  position:absolute;
-  left:0;right:0;top:0;bottom:0;
-}
-
-
 .mapboxgl-map {
   width:100%;
   height:100%;
   position:absolute;
   left:0;right:0;top:0;bottom:0;
 }
-
 // Hide rotate button because it's confusing
 :host ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
   display: none;
 }
-
+// center controls vertically on the right side of the map
 :host ::ng-deep .mapboxgl-ctrl-top-left {
-  top: 50px;
+  top: 0;
+  bottom:40px;
+  margin:auto;
+  height:110px;
   right:16px;
   left: auto;
-}
-
-@media(max-width: 768px) {
-    :host ::ng-deep .mapboxgl-ctrl-top-left {
-        top: 175px;
-    }
 }

--- a/src/app/ui/ui-hint/ui-hint.component.html
+++ b/src/app/ui/ui-hint/ui-hint.component.html
@@ -1,3 +1,3 @@
-<button *ngIf="hint" class="hint-button" [tooltip]="hint" [triggers]="triggers" [placement]="placement">
+<button *ngIf="hint" class="hint-button" container="body" [tooltip]="hint" [triggers]="triggers" [placement]="placement">
     <span class="glyphicon glyphicon-question-sign"></span>
 </button>

--- a/src/app/ui/ui-hint/ui-hint.component.ts
+++ b/src/app/ui/ui-hint/ui-hint.component.ts
@@ -8,5 +8,5 @@ import { Component, OnInit, Input } from '@angular/core';
 export class UiHintComponent {
   @Input() hint: string;
   @Input() placement = 'top';
-  @Input() triggers = 'click';
+  @Input() triggers = 'hover focus';
 }

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.html
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.html
@@ -1,0 +1,8 @@
+<div class="map-legend">
+  <app-ui-hint class="legend-hint" [hint]="hint" placement="left"></app-ui-hint>
+  <div class="legend" [style.background]="legendGradient">
+    <span class="legend-start">{{fillStops[1][0]}}</span>
+    <span class="legend-middle">{{(fillStops[1][0] + fillStops[fillStops.length - 1][0]) / 2}}</span>
+    <span class="legend-end">{{fillStops[fillStops.length - 1][0]}}</span>
+  </div>
+</div>

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.html
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.html
@@ -1,4 +1,4 @@
-<div class="map-legend">
+<div class="map-legend" *ngIf="fillStops">
   <app-ui-hint class="legend-hint" [hint]="hint" placement="left"></app-ui-hint>
   <div class="legend" [style.background]="legendGradient">
     <span class="legend-start">{{fillStops[1][0]}}</span>

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.scss
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.scss
@@ -1,0 +1,56 @@
+@import '../../../theme';
+
+:host {
+  display:block;
+  pointer-events:all;
+}
+
+.map-legend {
+  height: 100%;
+  width: 100%;
+  background: $legendBackground;
+  box-shadow: $z1shadow;
+  .legend {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    font-size: $legendFontSize;
+    line-height: $legendHeight;
+    font-weight:bold;
+    padding: 0 8px;
+    color: $legendTextColor;
+    text-align:center;
+    .legend-start { float: left;}
+    .legend-end { float: right; }
+  }
+}
+// hint icon above the legend on the right
+app-ui-hint.legend-hint {
+  position: absolute;
+  width: $legendHeight;
+  height: $legendHeight;
+  top: -$legendHeight;
+  right:0;
+  left:auto;
+  margin:auto;
+  // adjust for white circle behind icon
+  ::ng-deep .hint-button span {
+    width: 18px;
+    height: 18px;
+    padding: 2px;
+    border-radius: 100%;
+    background: $legendIconBackground;
+    color: $legendIconColor; 
+  }
+}
+// larger than tablet:
+//    hint icon to the left of the legend
+:host-context(.gt-tablet) {
+  app-ui-hint.legend-hint {
+    top: 8px;
+    bottom:0;
+    left: -$legendHeight;
+    right:auto;
+  }
+}
+

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.spec.ts
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UiMapLegendComponent } from './ui-map-legend.component';
+
+describe('UiMapLegendComponent', () => {
+  let component: UiMapLegendComponent;
+  let fixture: ComponentFixture<UiMapLegendComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UiMapLegendComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UiMapLegendComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.spec.ts
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { UiMapLegendComponent } from './ui-map-legend.component';
+import { UiHintComponent } from '../ui-hint/ui-hint.component';
 
 describe('UiMapLegendComponent', () => {
   let component: UiMapLegendComponent;
@@ -8,7 +9,8 @@ describe('UiMapLegendComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ UiMapLegendComponent ]
+      imports: [ TooltipModule.forRoot() ],
+      declarations: [ UiMapLegendComponent, UiHintComponent ]
     })
     .compileComponents();
   }));

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.ts
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-ui-map-legend',
+  templateUrl: './ui-map-legend.component.html',
+  styleUrls: ['./ui-map-legend.component.scss']
+})
+export class UiMapLegendComponent implements OnInit {
+  /** Current `MapDataAttribute` being shown for choropleths */
+  @Input() choropleth;
+  /** Current `MapDataAttribute` being shown for bubbles */
+  @Input() bubbles;
+  /** Current data layer being shown on the map */
+  @Input() layer;
+  /** Gets the fill stops based on the selected choropleth */
+  get fillStops() {
+    return this.choropleth.fillStops[this.layer.id] || this.choropleth.fillStops['default'];
+  }
+  /** Gets the text for the hint */
+  get hint(): string {
+    return 'The colored ' + this.layer['name'] + ' on the map represent ' +
+      this.choropleth['name'] + ' from ' + this.fillStops[1][0] + ' to ' +
+      this.fillStops[this.fillStops.length - 1][0] + '.';
+  }
+  /** Gets the CSS background gradient for the legend */
+  get legendGradient() {
+    if (this.fillStops && this.fillStops.length) {
+      return this.sanitizer.bypassSecurityTrustStyle(`linear-gradient(
+          to right, ${this.fillStops[1][1]}, ${this.fillStops[this.fillStops.length - 1][1]}
+      )`);
+    }
+    return null;
+  }
+
+  constructor(private sanitizer: DomSanitizer) { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/ui/ui-map-legend/ui-map-legend.component.ts
+++ b/src/app/ui/ui-map-legend/ui-map-legend.component.ts
@@ -15,10 +15,12 @@ export class UiMapLegendComponent implements OnInit {
   @Input() layer;
   /** Gets the fill stops based on the selected choropleth */
   get fillStops() {
+    if (!this.choropleth || !this.layer) { return null; }
     return this.choropleth.fillStops[this.layer.id] || this.choropleth.fillStops['default'];
   }
   /** Gets the text for the hint */
   get hint(): string {
+    if (!this.choropleth || !this.layer || !this.fillStops) { return null; }
     return 'The colored ' + this.layer['name'] + ' on the map represent ' +
       this.choropleth['name'] + ' from ' + this.fillStops[1][0] + ' to ' +
       this.fillStops[this.fillStops.length - 1][0] + '.';

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -67,9 +67,8 @@
       }
     }
   }
-
-  @media(min-width: 767px) {
-    // more space for dropdown menus
+  // more space for dropdown menus
+  :host-context(.gt-mobile) {
     .el-select .dropdown-menu { max-height: 300px; }
   }
 

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -16,6 +16,7 @@ import { UiDialogComponent } from './ui-dialog/ui-dialog.component';
 import { UiDialogService } from './ui-dialog/ui-dialog.service';
 import { UiHintComponent } from './ui-hint/ui-hint.component';
 import { LocationCardsComponent } from './location-cards/location-cards.component';
+import { UiMapLegendComponent } from './ui-map-legend/ui-map-legend.component';
 
 @NgModule({
   exports: [
@@ -26,7 +27,8 @@ import { LocationCardsComponent } from './location-cards/location-cards.componen
     UiSliderComponent,
     UiToggleComponent,
     ProgressBarComponent,
-    UiHintComponent
+    UiHintComponent,
+    UiMapLegendComponent
   ],
   imports: [
     CommonModule,
@@ -45,7 +47,8 @@ import { LocationCardsComponent } from './location-cards/location-cards.componen
     UiToggleComponent,
     ProgressBarComponent,
     UiDialogComponent,
-    UiHintComponent
+    UiHintComponent,
+    UiMapLegendComponent
   ],
   providers: [ UiDialogService ],
   entryComponents: [ UiDialogComponent, LocationCardsComponent ]

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -156,7 +156,7 @@ html, body {
   }
 }
 
-@media(min-width: 1600px) {
+@media(min-width: $gtLargeDesktop) {
   // move buttons to gutter
   .data-wrapper .btn-map,
   .btn-compare {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -16,6 +16,12 @@ $z1shadow: 0 1px 3px rgba(0,0,0,0.3);
 $z2shadow: 0 2px 5px rgba(0,0,0,0.5);
 $z3shadow: 0 2px 5px rgba(0,0,0,0.5), 0 2px 10px rgba(0,0,0,0.5);
 
+// Breakpoints
+$gtMobile: 767px;
+$gtTablet: 1024px;
+$gtSmallDesktop: 1279px;
+$gtLargeDesktop: 1599px;
+
 // Typography
 $fontStack: Akkurat-Regular, sans-serif;
 $boldFontStack: Akkurat-Bold, sans-serif;
@@ -88,6 +94,8 @@ $toggleHoverForeground: #000;
 $sliderText: $altTextColor;
 $sliderBackground: #000;
 $sliderTrack: rgba(0,0,0,0.15);
+$timeSliderHeight: 40px;
+$timeSliderBackground: $defaultBackground;
 
 // Select Dropdowns
 $selectText: $textColor;
@@ -112,9 +120,6 @@ $cardLabelText: rgba(0,0,0,0.33);
 $cardLabelTextSize: 11px;
 $cardValueTextSize: 18px;
 
-// Time Slider
-$timeSliderHeight: 40px;
-
 // Header
 $headerHeightSm: 56px;
 $headerHeightLg: 90px;
@@ -127,6 +132,14 @@ $searchTextColor: $textColor;
 $searchHighlightTextColor: $defaultBackground;
 $searchHighlightBackgroundColor: $color1;
 $searchPlaceholderColor: $secondaryTextColor;
+
+// Legend
+$legendHeight: 40px;
+$legendBackground: #f8f8f9;
+$legendIconColor: $color1;
+$legendIconBackground: $defaultBackground;
+$legendFontSize: 11px;
+$legendTextColor: #fff;
 
 // Sizing - panel header
 $headerRowHeight: 72px;

--- a/src/theme/components/header-bar.scss
+++ b/src/theme/components/header-bar.scss
@@ -76,7 +76,7 @@
 // - Shows logo
 // - Shows search bar
 // - Hides all icons, except menu
-@media(min-width: 767px) {
+@media(min-width: $gtMobile) {
   .header-wrapper {
     height: $headerHeightLg;
     .header-content {
@@ -152,7 +152,7 @@
 
 // Desktop+
 // - adds language toggle
-@media(min-width: 1024px) {
+@media(min-width: $gtTablet) {
   .header-wrapper {
     .header-search {
       max-width: 640px;


### PR DESCRIPTION
Separates the map legend into its own component, and adds responsive styles.

Also added some classes on the app component wrapper so that we can style components using `:host-context()` instead of media queries.

The following can be used in components for targeting different device types:

  - `:host-context(.gt-mobile) { }`: styles for devices larger than mobile (> 767px)
  - `:host-context(.gt-tablet) { }`: styles for devices larger than tablets (> 1024px)
  - `:host-context(.gt-small-desktop) { }`: styles for devices larger than small desktop (> 1279px)
  - `:host-context(.gt-large-desktop) { }`: styles for devices larger than large desktop (> 1599px)