### PR TITLE
Position progress bar over ui-select

### DIFF
--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -134,6 +134,13 @@ app-ui-select.open {
 // ----
 // End Map Data Select Boxes
 
+// Map Progress Bar
+//   z-index greater than ui-select
+// ----
+app-progress-bar {
+  z-index: 102;
+}
+
 
 // Map Legend
 // ----


### PR DESCRIPTION
With the UI select components on the map getting moved up, they're currently in front of the progress indicator which makes it less visible. Fixed here