### PR TITLE
Set one fixed progress bar listening to events

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -31,6 +31,7 @@ export class DataService {
   autoSwitchLayers = true;
   mapView;
   mapConfig;
+  isLoading = false;
   private mercator = new SphericalMercator({ size: 256 });
   private tileBase = 'https://tiles.evictionlab.org/fixtures/';
   private tilePrefix = 'evictions-';

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,3 +1,4 @@
+<app-progress-bar *ngIf="isLoading"></app-progress-bar>
 <div id="top" 
   class="app-wrapper" 
   [class.map-active]="dataService.activeFeatures.length === 0" 

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -1,5 +1,12 @@
 @import '../../theme';
 
+// Fixed progress bar
+app-progress-bar {
+  position: fixed;
+  top: 0;
+  z-index: 1000;
+}
+
 // Page Layout
 .app-wrapper {
   min-height:100%;

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -29,6 +29,9 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     if (!this.panelOffset || !this.verticalOffset) { return false; }
     return (this.verticalOffset - this.panelOffset) > 0;
   }
+  get isLoading() {
+    return this.map.mapLoading || this.dataService.isLoading;
+  }
   @ViewChild(MapComponent) map;
   @ViewChild('divider') dividerEl;
 
@@ -119,10 +122,12 @@ export class MapToolComponent implements OnInit, AfterViewInit {
    */
   onFeatureSelect(feature: MapFeature) {
     const featureLonLat = this.dataService.getFeatureLonLat(feature);
+    this.dataService.isLoading = true;
     this.dataService.getTileData(feature['layer']['id'], featureLonLat, null, true)
       .subscribe(data => {
         this.dataService.addLocation(data);
         this.updateRoute();
+        this.dataService.isLoading = false;
       });
   }
 
@@ -134,6 +139,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   onSearchSelect(feature: MapFeature | null, updateMap = true) {
     // this.autoSwitchLayers = false;
     if (feature) {
+      this.dataService.isLoading = true;
       const layerId = feature.properties['layerId'];
       this.dataService.getTileData(
         layerId, feature.geometry['coordinates'], feature.properties['name'], true
@@ -151,6 +157,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
               this.map.zoomToPointFeature(feature);
             }
           }
+          this.dataService.isLoading = false;
         });
     }
   }

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -15,7 +15,6 @@
 <div class="map-ui-wrapper">
   <ng-content></ng-content>
   <app-ui-map-legend *ngIf="showLegend" [choropleth]="selectedChoropleth" [bubbles]="selectedBubble" [layer]="selectedLayer"></app-ui-map-legend>   
-  <app-progress-bar *ngIf="mapLoading"></app-progress-bar>
   <app-location-cards 
     *ngIf="activeFeatures.length > 0"
     [features]="activeFeatures"


### PR DESCRIPTION
Closes #172. Use one main progress bar for both map and data service loading events. Right now, I don't like setting `dataService.isLoading` manually each time, but given the chain of observables and different places they can be called I'm not sure what the best way of managing that would be.

![progress](https://user-images.githubusercontent.com/8291663/32853372-b305c2ee-ca00-11e7-8603-0f8930fd32a6.gif)
