### PR TITLE
Show popup if mailto client not setup

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -70,7 +70,7 @@
                 </svg>
               </button>
             </a>
-            <a [href]="'mailto:?subject=Eviction Lab&body=' + getCurrentUrl()">
+            <a [href]="'mailto:?subject=Eviction Lab&body=' + getCurrentUrl()" (click)="checkMailto($event)">
               <button class="btn btn-border btn-social-icon btn-email">
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
                   <path d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -166,6 +166,28 @@ export class DataPanelComponent implements OnInit, OnChanges {
   }
 
   /**
+   * Display dialog with error message if mailto link doesn't open after 1 second
+   * @param e
+   */
+  checkMailto(e) {
+    // https://www.uncinc.nl/articles/dealing-with-mailto-links-if-no-mail-client-is-available
+    let timeout;
+
+    window.addEventListener('blur', () => clearTimeout(timeout));
+    timeout = setTimeout(() => {
+      this.dialogService.showDialog({
+        title: 'Email Link Error',
+        content: [
+          {
+            type: 'text',
+            data: 'Please set a default mail client in your browser to use the email link.'
+          }
+        ]
+      });
+    }, 1000);
+  }
+
+  /**
    * Genrates line graph data from the features in `locations`
    */
   private createLineGraphData() {


### PR DESCRIPTION
Closes #121. Uses the implementation [here](https://www.uncinc.nl/articles/dealing-with-mailto-links-if-no-mail-client-is-available) to check if the window has been blurred and the `mailto` client worked, and if it hasn't after a second opens a dialog with an error message. I tested this by changing the link to `#`, and it worked (GIF below), and when I re-enabled the link it doesn't open the dialog as expected

![mailto-popup](https://user-images.githubusercontent.com/8291663/32854752-4a32b812-ca05-11e7-8dee-821208ab411e.gif)
