### PR TITLE
Fix layer auto switching

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -148,6 +148,7 @@ export class MapComponent implements OnInit, OnChanges {
       if (this.selectedLayer !== layerGroup) {
         this.selectedLayer = layerGroup;
         this.autoSwitch = false;
+        this.restoreAutoSwitch = false;
       }
       this.layerOptions.forEach((group: MapLayerGroup) => {
         this.map.setLayerGroupVisibility(group, (group.id === layerGroup.id));
@@ -198,8 +199,11 @@ export class MapComponent implements OnInit, OnChanges {
       .subscribe((state) => { this.mapLoading = state; });
     if (this.boundingBox) {
       this.map.zoomToBoundingBox(this.boundingBox);
-      this.autoSwitch = false; // needs to be off when navigating to a param location
-      this.restoreAutoSwitch = true; // restore auto switch after zoom
+      // Only toggle if autoSwitch is currently on
+      if (this.autoSwitch) {
+        this.autoSwitch = false; // needs to be off when navigating to a param location
+        this.restoreAutoSwitch = true; // restore auto switch after zoom
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #169. Updates `restoreAutoSwitch` as well as `autoSwitch` on layer toggle, and only toggles `restoreAutoSwitch` on zooming to a feature if it's currently on (otherwise it's turned back on). I'm sure there are things I'm not accounting for here, but it fixes the immediate bug for now

![autoswitch](https://user-images.githubusercontent.com/8291663/32896249-220f6fee-caa8-11e7-9140-8217c10bd0fa.gif)


