### PR TITLE
Add toast component

### DIFF
--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,4 +1,5 @@
 <app-progress-bar *ngIf="isLoading"></app-progress-bar>
+<app-ui-toast></app-ui-toast>
 <div id="top" 
   class="app-wrapper" 
   [class.map-active]="dataService.activeFeatures.length === 0" 

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -8,6 +8,7 @@ import {scaleLinear} from 'd3-scale';
 
 import { MapFeature } from './map/map-feature';
 import { MapComponent } from './map/map/map.component';
+import { UiToastComponent } from '../ui/ui-toast/ui-toast.component';
 import { DataService } from '../data/data.service';
 
 @Component({
@@ -33,6 +34,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     return this.map.mapLoading || this.dataService.isLoading;
   }
   @ViewChild(MapComponent) map;
+  @ViewChild(UiToastComponent) toast;
   @ViewChild('divider') dividerEl;
 
   constructor(
@@ -145,11 +147,12 @@ export class MapToolComponent implements OnInit, AfterViewInit {
         layerId, feature.geometry['coordinates'], feature.properties['name'], true
       ).subscribe(data => {
           if (!data.properties.n) {
-            console.log('could not find feature');
+            this.toast.display('Could not find data for location.');
+          } else {
+            this.dataService.addLocation(data);
           }
           const dataLevel = this.dataService.dataLevels.filter(l => l.id === layerId)[0];
           this.map.setGroupVisibility(dataLevel);
-          this.dataService.addLocation(data);
           if (updateMap) {
             if (feature.hasOwnProperty('bbox')) {
               this.dataService.mapView = feature['bbox'];

--- a/src/app/ui/ui-toast/ui-toast.component.html
+++ b/src/app/ui/ui-toast/ui-toast.component.html
@@ -1,0 +1,1 @@
+<div class="toast">{{message}}</div>

--- a/src/app/ui/ui-toast/ui-toast.component.scss
+++ b/src/app/ui/ui-toast/ui-toast.component.scss
@@ -1,0 +1,11 @@
+:host {
+    position: fixed;
+    z-index: 1000;
+    padding: 12px;
+    border-radius: 2px;
+    transition: opacity 0.5s ease-in-out;
+    opacity: 0;
+    background: #444;
+    color: #fff;
+    max-width: 200px;
+}

--- a/src/app/ui/ui-toast/ui-toast.component.spec.ts
+++ b/src/app/ui/ui-toast/ui-toast.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UiToastComponent } from './ui-toast.component';
+
+describe('UiToastComponent', () => {
+  let component: UiToastComponent;
+  let fixture: ComponentFixture<UiToastComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UiToastComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UiToastComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui/ui-toast/ui-toast.component.ts
+++ b/src/app/ui/ui-toast/ui-toast.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, Input, HostBinding, HostListener } from '@angular/core';
+
+@Component({
+  selector: 'app-ui-toast',
+  templateUrl: './ui-toast.component.html',
+  styleUrls: ['./ui-toast.component.scss']
+})
+export class UiToastComponent implements OnInit {
+  message = ''; // Message to display
+  @Input() position = 'topright'; // Accepts topright, bottomright, topleft, bottomleft
+  @Input() duration = 3000; // Duration visible in milliseconds
+  // Binding host position to position input
+  @HostBinding('style.top') top = this.position.startsWith('top') ? '10px' : 'auto';
+  @HostBinding('style.bottom') bottom = this.position.startsWith('bottom') ? '10px' : 'auto';
+  @HostBinding('style.left') left = this.position.endsWith('left') ? '10px' : 'auto';
+  @HostBinding('style.right') right = this.position.endsWith('right') ? '10px' : 'auto';
+  @HostBinding('style.opacity') opacity = '0';
+  @HostListener('click') onClick() { this.opacity = '0'; }
+
+  constructor() { }
+
+  ngOnInit() { }
+
+  /**
+   * Display toast component for specified duration
+   */
+  display(message: string) {
+    this.message = message;
+    this.opacity =  '1';
+    setTimeout(() => this.opacity = '0', this.duration);
+  }
+
+}

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -17,6 +17,7 @@ import { UiDialogService } from './ui-dialog/ui-dialog.service';
 import { UiHintComponent } from './ui-hint/ui-hint.component';
 import { LocationCardsComponent } from './location-cards/location-cards.component';
 import { UiMapLegendComponent } from './ui-map-legend/ui-map-legend.component';
+import { UiToastComponent } from './ui-toast/ui-toast.component';
 
 @NgModule({
   exports: [
@@ -28,7 +29,8 @@ import { UiMapLegendComponent } from './ui-map-legend/ui-map-legend.component';
     UiToggleComponent,
     ProgressBarComponent,
     UiHintComponent,
-    UiMapLegendComponent
+    UiMapLegendComponent,
+    UiToastComponent
   ],
   imports: [
     CommonModule,
@@ -48,7 +50,8 @@ import { UiMapLegendComponent } from './ui-map-legend/ui-map-legend.component';
     ProgressBarComponent,
     UiDialogComponent,
     UiHintComponent,
-    UiMapLegendComponent
+    UiMapLegendComponent,
+    UiToastComponent
   ],
   providers: [ UiDialogService ],
   entryComponents: [ UiDialogComponent, LocationCardsComponent ]


### PR DESCRIPTION
Closes #176, progress on #139. Adds a toast component set up to be used as a `ViewChild`, where calling `display` sets the message and displays the component for the specified duration. It can also be dismissed on click. Wasn't sure if it would be better to set up with a service like the dialog, but this seemed simple enough for now. Also updated the location search to use this component to display a message if a location isn't found.

![toast](https://user-images.githubusercontent.com/8291663/32898897-0f898222-caaf-11e7-8ead-2f1a39a62125.gif)
