### PR TITLE
Don't show hover tooltip on mobile

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -204,7 +204,9 @@ export class MapComponent implements OnInit, OnChanges {
   onMapReady(map) {
     this._mapInstance = map;
     this.map.setMapInstance(map);
-    this.map.setupHoverPopup(this.mapEventLayers);
+    if (this.fullWidth) {
+      this.map.setupHoverPopup(this.mapEventLayers);
+    }
     this.setGroupVisibility(this.selectedLayer);
     this.updateCensusYear();
     this.updateMapData();


### PR DESCRIPTION
The hover tooltip makes tapping to select features difficult on mobile, so just removing it