### PR TITLE
Tweak select transition, judgment spelling

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -8,7 +8,7 @@
   <div class="graph-container">
     <div class="data-content-inner">
       <div class="graph-header">
-        <app-ui-switch leftLabel="Judgements" rightLabel="Filings" (switched)="changeGraphProperty($event)"></app-ui-switch>
+        <app-ui-switch leftLabel="Judgments" rightLabel="Filings" (switched)="changeGraphProperty($event)"></app-ui-switch>
         <app-ui-toggle class="graph-type-toggle" [values]="[ 'Bar', 'Line' ]" (selectedValueChanged)="changeGraphType($event)"></app-ui-toggle>
         <div class="graph-year-select">
           <span class="graph-year-label">Date range</span>

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -106,6 +106,7 @@ app-ui-select {
   position: absolute;
   width:33.3333%;
   top:0;
+  transition: width 0.2s ease, left 0.2s ease, right 0.2s ease;
   ::ng-deep {
     .el-select .el-select-label,
     .el-select .el-select-value {
@@ -124,13 +125,12 @@ app-ui-select {
 // position the dropwdowns
 app-ui-select:nth-of-type(1) { left: 0; }
 app-ui-select:nth-of-type(2) { left: 33.33333%; }
-app-ui-select:nth-of-type(3) { right: 0; }
+app-ui-select:nth-of-type(3) { left: 66.66666%; right: 0; }
 // span full width when open
 app-ui-select.open {
   left: 0;
   right: 0;
   width: 100%;
-  transition: width 0.2s ease;
   z-index: 101;
   ::ng-deep .el-select .el-select-label {
     display: inherit;


### PR DESCRIPTION
Just noticed some minor quirks with the transition for the last map UI dropdown that I wanted to fix, as well as a "Judgment" label to update

![select-transition](https://user-images.githubusercontent.com/8291663/33277469-a4849532-d366-11e7-8228-a93eea68a37e.gif)
