### PR TITLE
Refactor HttpModule to HttpClientModule

### DIFF
--- a/src/app/data/data.service.spec.ts
+++ b/src/app/data/data.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { DataService } from './data.service';
-import { HttpClient } from 'selenium-webdriver/http';
 
 describe('DataService', () => {
   beforeEach(() => {

--- a/src/app/data/data.service.spec.ts
+++ b/src/app/data/data.service.spec.ts
@@ -1,18 +1,40 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule, HttpRequest } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { DataService } from './data.service';
+import { HttpClient } from 'selenium-webdriver/http';
 
 describe('DataService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [DataService],
       imports: [
-        HttpModule
+        HttpClientModule,
+        HttpClientTestingModule
       ]
     });
   });
 
+  afterEach(inject([HttpTestingController], (backend: HttpTestingController) => {
+    backend.verify();
+  }));
+
   it('should be created', inject([DataService], (service: DataService) => {
     expect(service).toBeTruthy();
   }));
+
+  it(
+    'should make a single http request for data for a single year', 
+    inject(
+      [DataService, HttpTestingController], 
+      (service: DataService, backend: HttpTestingController) => {
+        service.getTileData('states', [50, 50], 'featureName', false).subscribe();
+        backend.expectOne((req: HttpRequest<any>) => {
+          return req.url.includes('states')
+            && req.method === 'GET'
+            && req.responseType === 'arraybuffer';
+        }, `GET request to endpoint with data`);
+      }
+    )
+  )
 });

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Http, Response, ResponseContentType } from '@angular/http';
+import { HttpClient, HttpResponse } from '@angular/common/http';
 import * as SphericalMercator from '@mapbox/sphericalmercator';
 import * as vt from '@mapbox/vector-tile';
 import * as Protobuf from 'pbf';
@@ -38,7 +38,7 @@ export class DataService {
   private tilesetYears = ['90', '00', '10'];
   private queryZoom = 10;
 
-  constructor(private http: Http) {}
+  constructor(private http: HttpClient) {}
 
   /**
    * Sets the choropleth layer based on the provided `DataAttributes` ID
@@ -211,8 +211,8 @@ export class DataService {
   private getParser(layerId, lonLat, featName) {
     const point = this.getPoint(lonLat);
     const coords = this.getXYFromLonLat(lonLat);
-    return (res: Response): MapFeature => {
-      const tile = new vt.VectorTile(new Protobuf(res.arrayBuffer()));
+    return (res: ArrayBuffer): MapFeature => {
+      const tile = new vt.VectorTile(new Protobuf(res));
       const layer = tile.layers[layerId];
       const features = [...Array(layer.length)].fill(null).map((d, i) => {
         return layer.feature(i).toGeoJSON(coords.x, coords.y, 10);
@@ -279,7 +279,7 @@ export class DataService {
       this.tileBase + this.tilePrefix + layerId;
     return this.http.get(
       `${tilesetUrl}/${this.queryZoom}/${coords.x}/${coords.y}.pbf`,
-      { responseType: ResponseContentType.ArrayBuffer }
+      { responseType: 'arraybuffer' }
     );
   }
 

--- a/src/app/map-tool/data-panel/data-panel.component.spec.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.spec.ts
@@ -1,11 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpModule } from '@angular/http';
-
-import { DataPanelComponent } from './data-panel.component';
-import { UiModule } from '../../ui/ui.module';
-import { GraphModule } from 'angular-d3-graph/module';
 import { Observable } from 'rxjs/Observable';
-import { DataService } from '../../data/data.service';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { DataPanelComponent } from './data-panel.component';
+import { DataPanelModule } from './data-panel.module';
+import { FileExportService } from './download-form/file-export.service';
+import { DownloadFormComponent } from './download-form/download-form.component';
+
+export class FileExportStub {
+  getFileTypes() { 
+    return [
+      { name: 'Excel', value: 'xlsx', path: '/format/xlsx', checked: false },
+      { name: 'PowerPoint', value: 'pptx', path: '/format/pptx', checked: false },
+      { name: 'PDF', value: 'pdf', path: '/pdf', checked: false }
+    ];
+  }
+  setExportValues(...args) {}
+  sendFileRequest(...args) {}
+}
+
 
 describe('DataPanelComponent', () => {
   let component: DataPanelComponent;
@@ -13,9 +26,7 @@ describe('DataPanelComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DataPanelComponent ],
-      imports: [ UiModule, GraphModule.forRoot(), HttpModule ],
-      providers: [ {provide: DataService, useValue: {} } ]
+      imports: [ DataPanelModule, HttpClientModule ]
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -70,7 +70,6 @@ export class DataPanelComponent implements OnInit, OnChanges {
     this.updateLineYears(this.year, this.maxYear);
     this.barYear = this.year;
     this.barYearSelect = this.generateYearArray(this.minYear, this.maxYear);
-    console.log('line end select', this.endSelect);
   }
 
   /**

--- a/src/app/map-tool/data-panel/download-form/download-form.component.spec.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.spec.ts
@@ -2,12 +2,28 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ModalModule, BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
 import { FormsModule } from '@angular/forms';
-import { HttpModule, XHRBackend } from '@angular/http';
 import { UiModule } from '../../../ui/ui.module';
-import { MockBackend } from '@angular/http/testing';
 import { DownloadFormComponent } from './download-form.component';
+import { FileExportService } from './file-export.service';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/delay';
 
 const mockResponse = { path: 'http://localhost' };
+
+export class FileExportStub {
+  getFileTypes() { 
+    return [
+      { name: 'Excel', value: 'xlsx', path: '/format/xlsx', checked: false },
+      { name: 'PowerPoint', value: 'pptx', path: '/format/pptx', checked: false },
+      { name: 'PDF', value: 'pdf', path: '/pdf', checked: false }
+    ];
+  }
+  setExportValues(...args) {}
+  sendFileRequest(...args) { 
+    return { subscribe: (...args) => {} }
+  }
+}
 
 describe('DownloadFormComponent', () => {
   let component: DownloadFormComponent;
@@ -16,9 +32,14 @@ describe('DownloadFormComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ FormsModule, HttpModule, UiModule, ModalModule.forRoot() ],
+      imports: [ FormsModule, ModalModule.forRoot(), UiModule ],
       declarations: [ DownloadFormComponent ],
-      providers: [ BsModalService, BsModalRef, { provide: XHRBackend, useClass: MockBackend } ]
+      providers: [ BsModalService, BsModalRef ]
+    })
+    TestBed.overrideComponent(DownloadFormComponent, {
+      set: {
+        providers: [ {provide: FileExportService, useValue: new FileExportStub() }]
+      }
     })
     .compileComponents();
   }));
@@ -26,39 +47,12 @@ describe('DownloadFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DownloadFormComponent);
     component = fixture.componentInstance;
-    component.lang = 'en';
-    component.features = [
-      {
-        type: 'Feature',
-        properties: { n: 'Test One' },
-        geometry: { type: 'Point', coordinates: [0, 0] }
-      },
-      {
-        type: 'Feature',
-        properties: { n: 'Test Two' },
-        geometry: { type: 'Point', coordinates: [0, 0] }
-      }
-    ];
-    component.startYear = 2010;
-    component.endYear = 2016;
     submitButtonEl = fixture.debugElement.query(By.css('.btn-primary'));
     fixture.detectChanges();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should create a DownloadRequest with parameters', () => {
-    component.filetypes[0].checked = true;
-    const downloadRequest = component.createDownloadRequest([component.filetypes[0].value]);
-    expect(downloadRequest.lang).toBe('en');
-    expect(downloadRequest.hasOwnProperty('formats')).toBe(false);
-  });
-
-  it('should include formats in request if more than one filetype selected', () => {
-    const downloadRequest = component.createDownloadRequest(['pptx', 'xlsx']);
-    expect(downloadRequest.formats).toEqual(['pptx', 'xlsx']);
   });
 
   it('should not display the loading indicator if not loading', () => {

--- a/src/app/map-tool/data-panel/download-form/download-form.component.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.ts
@@ -1,78 +1,41 @@
-import { Component, EventEmitter } from '@angular/core';
-import { Http, Headers, RequestOptions } from '@angular/http';
+import { Component, EventEmitter, OnInit } from '@angular/core';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
-import { MapFeature } from '../../map/map-feature';
 import { DialogResponse } from '../../../ui/ui-dialog/ui-dialog.types';
-
-interface DownloadRequest {
-  lang: string;
-  years: number[];
-  features: MapFeature[];
-  formats?: string[];
-}
-
-interface ExportType {
-  name: string;
-  value: string;
-  path: string;
-  checked: boolean;
-}
+import { FileExportService, ExportType } from './file-export.service';
 
 @Component({
   selector: 'app-download-form',
   templateUrl: './download-form.component.html',
-  styleUrls: ['./download-form.component.scss']
+  styleUrls: ['./download-form.component.scss'],
+  providers: [ FileExportService ]
 })
-export class DownloadFormComponent {
-  downloadBase = 'https://exports.evictionlab.org';
-  lang: string;
-  features: MapFeature[];
-  startYear: number;
-  endYear: number;
-  filetypes: ExportType[] = [
-    { name: 'Excel', value: 'xlsx', path: '/format/xlsx', checked: false },
-    { name: 'PowerPoint', value: 'pptx', path: '/format/pptx', checked: false },
-    { name: 'PDF', value: 'pdf', path: '/pdf', checked: false }
-  ];
+export class DownloadFormComponent implements OnInit {
+  filetypes: ExportType[];
   loading = false;
   buttonClicked = new EventEmitter<DialogResponse>();
 
-  constructor(private http: Http, public bsModalRef: BsModalRef) { }
+  constructor(private exportService: FileExportService, public bsModalRef: BsModalRef) { }
 
-  setFormConfig(config: Object) {
-    this.lang = config['lang'];
-    this.features = config['features'];
-    this.startYear = config['startYear'];
-    this.endYear = config['endYear'];
+  ngOnInit() {
+    this.filetypes = this.exportService.getFileTypes();
   }
 
-  createDownloadRequest(fileValues: string[]): DownloadRequest {
-    const downloadRequest: DownloadRequest = {
-      lang: this.lang, years: [this.startYear, this.endYear], features: this.features
-    };
-    if (this.filetypes.filter(f => fileValues.indexOf(f.value) !== -1).length > 1) {
-      downloadRequest.formats = fileValues;
-    }
-    return downloadRequest;
+  setFormConfig(config: Object) {
+    this.exportService.setExportValues(config);
   }
 
   onDownloadClick(e) {
     this.loading = true;
-    const filetypes = this.filetypes.filter(f => f.checked);
-    const downloadRequest = this.createDownloadRequest(filetypes.map(f => f.value));
-    const downloadPath = filetypes.length > 1 ?
-      `${this.downloadBase}/format/zip` : `${this.downloadBase}${filetypes[0].path}`;
-
-    const headers = new Headers({ 'Content-Type': 'application/json' });
-    this.http.post(downloadPath, JSON.stringify(downloadRequest), { headers: headers})
+    const filetypes = this.filetypes
+      .filter(f => f.checked).map(f => f.value);
+    this.exportService.sendFileRequest(filetypes)
       .subscribe(res => {
         this.loading = false;
-        const jsonRes = res.json();
-        if (!jsonRes.hasOwnProperty('path')) {
-          console.log(`Error occured: ${jsonRes}`);
+        if (!res.hasOwnProperty('path')) {
+          console.log(`Error occured: ${res}`);
         } else {
-          window.location.href = jsonRes['path'];
+          window.location.href = res['path'];
           this.dismiss({ accepted: true });
         }
       });

--- a/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed, inject, async } from '@angular/core/testing';
+import { HttpClientModule, HttpRequest, HttpParams } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FileExportService } from './file-export.service';
+
+describe('FileExportService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        HttpClientTestingModule
+      ],
+      providers: [FileExportService]
+    });
+  });
+
+  afterEach(inject([HttpTestingController], (backend: HttpTestingController) => {
+    backend.verify();
+  }));
+
+  it('should be created', inject([FileExportService], (service: FileExportService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should create a DownloadRequest with parameters', inject(
+    [FileExportService], (service: FileExportService) => {
+      service.setExportValues({
+        lang: 'en',
+        features: [],
+        startYear: '2001',
+        endYear: '2004'
+      })
+      const downloadRequest = service.createDownloadRequest(['xlsx']);
+      expect(downloadRequest.lang).toBe('en');
+      expect(downloadRequest.hasOwnProperty('formats')).toBe(false);
+    }
+  ));
+
+  it(
+    'should include formats in request if more than one filetype selected',
+    inject(
+      [FileExportService], (service: FileExportService) => {
+        const downloadRequest = service.createDownloadRequest(['pptx', 'xlsx']);
+        expect(downloadRequest.formats).toEqual(['pptx', 'xlsx']);
+      }
+    )
+  );
+
+  it('should send a file request', async(
+    inject(
+      [FileExportService, HttpTestingController],
+      (service: FileExportService, backend: HttpTestingController) => {
+        service.setExportValues({
+          lang: 'en',
+          features: [],
+          startYear: '2001',
+          endYear: '2004'
+        })
+        service.sendFileRequest(['xlsx']).subscribe();
+        backend.expectOne((req: HttpRequest<any>) => {
+          const body = JSON.parse(req.body);
+          return req.url === 'https://exports.evictionlab.org/format/xlsx'
+            && req.method === 'POST'
+            && req.headers.get('Content-Type') === 'application/json'
+            && body.lang === 'en'
+            && body.years[0] === '2001'
+            && body.years[1] === '2004'
+            && body.features.length === 0;
+        }, `POST to endpoint with data`);
+      }
+    )
+  ));
+});

--- a/src/app/map-tool/data-panel/download-form/file-export.service.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { MapFeature } from '../../map/map-feature';
+
+export interface DownloadRequest {
+  lang: string;
+  years: number[];
+  features: MapFeature[];
+  formats?: string[];
+}
+
+export interface ExportType {
+  name: string;
+  value: string;
+  path: string;
+  checked: boolean;
+}
+
+@Injectable()
+export class FileExportService {
+  downloadBase = 'https://exports.evictionlab.org';
+  lang: string;
+  features: MapFeature[];
+  startYear: number;
+  endYear: number;
+  filetypes: ExportType[] = [
+    { name: 'Excel', value: 'xlsx', path: '/format/xlsx', checked: false },
+    { name: 'PowerPoint', value: 'pptx', path: '/format/pptx', checked: false },
+    { name: 'PDF', value: 'pdf', path: '/pdf', checked: false }
+  ];
+
+  constructor(private http: HttpClient) { }
+
+  getFileTypes() { return this.filetypes; }
+
+  /**
+   * Sets the values for the export
+   */
+  setExportValues(config: Object) {
+    this.lang = config['lang'];
+    this.features = config['features'];
+    this.startYear = config['startYear'];
+    this.endYear = config['endYear'];
+  }
+
+  /**
+   * Create the file request data
+   */
+  createDownloadRequest(fileValues: string[]): DownloadRequest {
+    const downloadRequest: DownloadRequest = {
+      lang: this.lang, years: [this.startYear, this.endYear], features: this.features
+    };
+    if (this.filetypes.filter(f => fileValues.indexOf(f.value) !== -1).length > 1) {
+      downloadRequest.formats = fileValues;
+    }
+    return downloadRequest;
+  }
+
+  /**
+   * Sends a request for the provided file types
+   * @param types an array of filetypes containing one or more of 'xls', 'pptx', 'pdf'
+   */
+  sendFileRequest(types: Array<string> = []) {
+    if (types.length === 0) { throw new Error('Sent file request with no file type specified.'); }
+    const downloadRequest = this.createDownloadRequest(types);
+    const downloadPath = types.length > 1 ?
+      `${this.downloadBase}/format/zip` : this.downloadBase + this.getFileTypePath(types[0]);
+
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    return this.http.post(downloadPath, JSON.stringify(downloadRequest), { headers: headers});
+  }
+
+  /** Gets the path for the given file type */
+  private getFileTypePath(type: string): string {
+    return this.filetypes.find(f => f.value === type).path;
+  }
+
+
+
+}

--- a/src/app/map-tool/header-bar/header-bar.component.spec.ts
+++ b/src/app/map-tool/header-bar/header-bar.component.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
-import { HttpModule } from '@angular/http';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { HeaderBarComponent } from './header-bar.component';
 import { UiModule } from '../../ui/ui.module';
 import { By } from '@angular/platform-browser';
+
 
 describe('HeaderBarComponent', () => {
   let component: HeaderBarComponent;
@@ -10,8 +11,11 @@ describe('HeaderBarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderBarComponent ],
-      imports: [ UiModule, HttpModule ]
+      declarations: [ 
+        HeaderBarComponent, 
+      ],
+      // ignore child components, they have their own tests
+      schemas: [NO_ERRORS_SCHEMA] 
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -1,22 +1,34 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Ng2PageScrollModule } from 'ng2-page-scroll';
-import { HeaderBarComponent  } from './header-bar/header-bar.component';
 import { MapToolComponent } from './map-tool.component';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-import { MapModule } from './map/map.module';
-import { HttpModule } from '@angular/http';
-import { DataPanelModule } from './data-panel/data-panel.module';
-import { UiModule } from '../ui/ui.module';
 import { DataService } from '../data/data.service';
-import { TranslateService, TranslateModule, TranslatePipe } from '@ngx-translate/core';
-
+import { TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { MapToolModule } from './map-tool.module';
+import { DataAttributes, BubbleAttributes } from '../data/data-attributes';
+import { DataLevels } from '../data/data-levels';
 
 export class TranslateServiceStub{
   public get(key: any): any {
     Observable.of(key);
   }
+}
+
+export class DataServiceStub {
+  get dataLevels() { return DataLevels; }
+  get dataAttributes() { return DataAttributes; }
+  get bubbleAttributes() { return BubbleAttributes; }
+  activeYear = 2010;
+  activeFeatures = [];
+  activeDataLevel = DataLevels[0];
+  activeDataHighlight = DataAttributes[0];
+  activeBubbleHighlight = BubbleAttributes[0];
+  autoSwitchLayers = true;
+  mapView;
+  mapConfig;
+  isLoading = false;
+  getRouteArray() { return []; }
 }
 
 describe('MapToolComponent', () => {
@@ -25,17 +37,18 @@ describe('MapToolComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MapToolComponent, HeaderBarComponent ],
       imports: [
-        UiModule,
-        DataPanelModule,
-        MapModule,
-        Ng2PageScrollModule,
-        HttpModule,
-        RouterTestingModule,
-        TranslateModule
-      ],
-      providers: [DataService, {provide: TranslateService, useClass: TranslateServiceStub}]
+        MapToolModule,
+        RouterTestingModule
+      ]
+    })
+    TestBed.overrideComponent(MapToolComponent, {
+      set: {
+        providers: [
+          {provide: DataService, useClass: DataServiceStub },
+          {provide: TranslateService, useClass: TranslateServiceStub}
+        ]
+      }
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/map-tool.module.ts
+++ b/src/app/map-tool/map-tool.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
 import { TranslateModule } from '@ngx-translate/core';
@@ -16,7 +16,7 @@ import { HeaderBarComponent } from './header-bar/header-bar.component';
   exports: [ MapToolComponent ],
   imports: [
     CommonModule,
-    HttpModule,
+    HttpClientModule,
     UiModule,
     DataPanelModule,
     MapModule,

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -3,8 +3,14 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MapComponent } from './map.component';
 import { MapboxComponent } from '../mapbox/mapbox.component';
 import { UiModule } from '../../../ui/ui.module';
-import { HttpModule } from '@angular/http';
 import { MapService } from '../map.service';
+
+class mapServiceStub {
+  updateCensusSource() {}
+  createMap(settings) { return this; }
+  addControl(...args) { return this; }
+  on(...args) { return this; }
+}
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -13,10 +19,12 @@ describe('MapComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ MapComponent, MapboxComponent ],
-      imports: [ UiModule, HttpModule ],
-      providers: [
-        { provide: MapService, useValue: { updateCensusSource: () => {} } }
-      ]
+      imports: [ UiModule ]
+    })
+    TestBed.overrideComponent(MapComponent, {
+      set: {
+        providers: [ {provide: MapService, useValue: new mapServiceStub()  } ],
+      }
     })
     .compileComponents();
   }));

--- a/src/app/ui/location-search/location-search.component.spec.ts
+++ b/src/app/ui/location-search/location-search.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
 import { LocationSearchComponent } from './location-search.component';
 import { PredictiveSearchComponent } from '../predictive-search/predictive-search.component';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
@@ -19,8 +18,12 @@ describe('LocationSearchComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ LocationSearchComponent, PredictiveSearchComponent ],
-      providers: [ {provide: SearchService, useValue: searchServiceStub } ],
-      imports: [ FormsModule, TypeaheadModule.forRoot(), HttpModule ]
+      imports: [ FormsModule, TypeaheadModule.forRoot() ]
+    })
+    TestBed.overrideComponent(LocationSearchComponent, {
+      set: {
+        providers: [ {provide: SearchService, useValue: searchServiceStub } ],
+      }
     })
     .compileComponents();
   }));

--- a/src/app/ui/location-search/search/search.service.spec.ts
+++ b/src/app/ui/location-search/search/search.service.spec.ts
@@ -1,12 +1,13 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule, HttpRequest, HttpParams } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { SearchService } from './search.service';
 
 describe('SearchService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpModule],
+      imports: [HttpClientModule,HttpClientTestingModule],
       providers: [SearchService]
     });
   });

--- a/src/app/ui/location-search/search/search.service.ts
+++ b/src/app/ui/location-search/search/search.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Http, Response, ResponseContentType } from '@angular/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 const MapzenLayerMap = {
   'region': 'states',
@@ -23,7 +23,7 @@ export class SearchService {
   query: string;
   results: Observable<Object[]>;
 
-  constructor(private http: Http) {
+  constructor(private http: HttpClient) {
     this.results = Observable.create((observer: any) => {
       this.queryGeocoder(this.query)
         .subscribe((results: Object[]) => {
@@ -38,7 +38,7 @@ export class SearchService {
    */
   queryGeocoder(query: string): Observable<Object[]> {
     return this.http.get(`${this.mapzenBase}text=${query}&${this.mapzenParams.join('&')}`)
-      .map(res => res.json().features);
+      .map(res => res['features']);
   }
 
   /**


### PR DESCRIPTION
`HttpClient` is the [officially supported](https://angular.io/guide/http) HTTP module for Angular starting v4.3.  This PR removes instances of `HttpModule` and replaces them with `HttpClientModule`.

A few other things were refactored including:
  - Stub data service to prevent console logging errors while running tests
  - Split download form component to include `FileExportService` that handles the HTTP requests
  - Add tests to ensure requests are properly formed.