### PR TITLE
Fix map select z-index transition

### DIFF
--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -106,7 +106,8 @@ app-ui-select {
   position: absolute;
   width:33.3333%;
   top:0;
-  transition: width 0.2s ease, left 0.2s ease, right 0.2s ease;
+  z-index: 100;
+  transition: width 0.2s ease, left 0.2s ease, right 0.2s ease, z-index 0.1s ease 0.2s;
   ::ng-deep {
     .el-select .el-select-label,
     .el-select .el-select-value {
@@ -132,6 +133,7 @@ app-ui-select.open {
   right: 0;
   width: 100%;
   z-index: 101;
+  transition: width 0.2s ease, left 0.2s ease, right 0.2s ease;
   ::ng-deep .el-select .el-select-label {
     display: inherit;
   }


### PR DESCRIPTION
Small tweak, but the first two select menus on the map were getting stuck behind the one(s) to their right because of the `z-index` property. I set a delay here and specified a `z-index` property so the transition will work

![select-z-index](https://user-images.githubusercontent.com/8291663/33463466-7d464dc2-d603-11e7-8f5e-903b986705bf.gif)
