### PR TITLE
Keep state borders visible

### DIFF
--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -3946,11 +3946,7 @@
           ]
         },
         "line-blur": 0.4,
-        "line-dasharray": [
-          2,
-          2
-        ],
-        "line-opacity": 1
+        "line-opacity": 0.8
       }
     }
   ]

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1146,48 +1146,6 @@
       }
     },
     {
-      "id": "boundary_state",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "a14c9607bc7954ba1df7205bf660433f"
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "minzoom": 3,
-      "maxzoom": 7,
-      "filter": [
-        "==",
-        "admin_level",
-        4
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "bevel",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(248, 153, 156, 1)",
-        "line-width": {
-          "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              6,
-              1
-            ]
-          ]
-        },
-        "line-blur": 0.4,
-        "line-dasharray": [
-          2,
-          2
-        ],
-        "line-opacity": 1
-      }
-    },
-    {
       "id": "boundary_country",
       "type": "line",
       "metadata": {
@@ -4012,6 +3970,47 @@
             ]
           ]
         }
+      }
+    },
+        {
+      "id": "boundary_state",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "a14c9607bc7954ba1df7205bf660433f"
+      },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 3,
+      "filter": [
+        "==",
+        "admin_level",
+        4
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(248, 153, 156, 1)",
+        "line-width": {
+          "stops": [
+            [
+              3,
+              1
+            ],
+            [
+              7,
+              2
+            ]
+          ]
+        },
+        "line-blur": 0.4,
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-opacity": 1
       }
     },
     {

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1,7 +1,7 @@
 {
   "version": 8,
   "id": "eviction-lab",
-  "name": "Natural Earth",
+  "name": "Eviction Lab",
   "sprite": "https://tiles.evictionlab.org/sprites",
   "sources": {
     "openmaptiles": {
@@ -1143,57 +1143,6 @@
         ],
         "text-halo-width": 0,
         "text-halo-blur": 0
-      }
-    },
-    {
-      "id": "boundary_country",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "a14c9607bc7954ba1df7205bf660433f"
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "minzoom": 0,
-      "maxzoom": 15,
-      "filter": [
-        "==",
-        "admin_level",
-        2
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(248, 153, 156, 1)",
-        "line-width": {
-          "base": 1.1,
-          "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              22,
-              20
-            ]
-          ]
-        },
-        "line-blur": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.4
-            ],
-            [
-              22,
-              4
-            ]
-          ]
-        },
-        "line-opacity": 1
       }
     },
     {
@@ -3972,20 +3921,11 @@
         }
       }
     },
-        {
+    {
       "id": "boundary_state",
       "type": "line",
-      "metadata": {
-        "mapbox:group": "a14c9607bc7954ba1df7205bf660433f"
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "minzoom": 3,
-      "filter": [
-        "==",
-        "admin_level",
-        4
-      ],
+      "source": "us-states-10",
+      "source-layer": "states",
       "layout": {
         "line-cap": "round",
         "line-join": "bevel",
@@ -4011,16 +3951,6 @@
           2
         ],
         "line-opacity": 1
-      }
-    },
-    {
-      "id": "united-states",
-      "type": "line",
-      "source": "us-states-10",
-      "source-layer": "country",
-      "paint": {
-        "line-width": 10,
-        "line-color": "rgba(255, 0, 0, 1)"
       }
     }
   ]


### PR DESCRIPTION
Closes #144. UX/design feedback on this would be good before merging, but I moved the state borders to the top, but still sourced from OpenMapTiles so we don't have to worry about code changes. I also removed the `maxzoom` property and increased the thickness bit on zoom

![state-outlines](https://user-images.githubusercontent.com/8291663/33491764-d9b742b4-d680-11e7-9432-cce876ccf9fa.gif)
