### PR TITLE
Full width search results with ellipsis

### DIFF
--- a/src/app/ui/predictive-search/predictive-search.component.scss
+++ b/src/app/ui/predictive-search/predictive-search.component.scss
@@ -38,6 +38,20 @@ input {
     @include predictive-search-colors($searchTextColor, $searchPlaceholderColor, $searchHighlightTextColor, $searchHighlightBackgroundColor);
     input::placeholder { color: $searchPlaceholderColor;  }
   }
+  /deep/ typeahead-container {
+    right: 0;
+
+    ul.dropdown-menu {
+      width: 100%;
+      overflow-x: hidden;
+
+      li.active a {
+        overflow-x: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+  }
   .search {
     flex:1;
     width:auto;


### PR DESCRIPTION
Closes #225. Makes all search results span the full width of the input, and clips any results that go over the full width with ellipsis. Works for both mobile and desktop

<img width="330" alt="screen shot 2017-12-02 at 11 16 38 am" src="https://user-images.githubusercontent.com/8291663/33517944-834d2f6a-d752-11e7-8067-d61594517d77.png">

<img width="1363" alt="screen shot 2017-12-02 at 11 16 45 am" src="https://user-images.githubusercontent.com/8291663/33517947-86800450-d752-11e7-970c-cd37e2e70d69.png">

<img width="396" alt="screen shot 2017-12-02 at 11 17 00 am" src="https://user-images.githubusercontent.com/8291663/33517948-87d74ffc-d752-11e7-85b5-a47a33f8c6df.png">

