### PR TITLE
slider show marker on hover, shows year label, less jank

### DIFF
--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -11,7 +11,7 @@ app-progress-bar {
 .app-wrapper {
   min-height:100%;
   &.map-active {
-    height: calc(100vh - #{$headerHeightSm});
+    height: 100vh;
     overflow: hidden;
   }
   app-map {
@@ -36,9 +36,6 @@ app-progress-bar {
 //    Adjust height of map / location cards to reflect large header.
 :host-context(.gt-mobile) {
   .app-wrapper {
-    &.map-active {
-      height: calc(100vh - #{$headerHeightLg});
-    }
     app-map {
       margin-top: $headerHeightLg;
       height: calc(100vh - #{$headerHeightLg});

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -60,10 +60,9 @@
 <div class="year-slider-container">
   <app-ui-slider tabindex="9"
     class="year-slider"
-    [label]="'Year'"
-    [currentValue]="year" 
+    [label]="year"
+    [(value)]="year" 
     [min]="2000" 
     [max]="2016" 
-    (change)="year=$event"
   ></app-ui-slider>
 </div>

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -282,7 +282,7 @@ app-ui-map-legend {
   height: $timeSliderHeight;
   z-index: 49;
   background: $timeSliderBackground;
-  padding: 0 $pageMargin;
+  padding: 0 grid(4) 0 $pageMargin;
   border-bottom: 1px solid $shadingColor;
   transition: transform 0.2s ease;
   transform: translateY(120%);

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -33,6 +33,7 @@ describe('MapComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MapComponent);
     component = fixture.componentInstance;
+    component.year = 2010;
     component.choroplethOptions = [{
       'id': 'none',
       'name': 'None',

--- a/src/app/ui/ui-slider/ui-slider.component.html
+++ b/src/app/ui/ui-slider/ui-slider.component.html
@@ -1,9 +1,9 @@
 <span class="slider-label" *ngIf="label">{{label}}</span>
-<div class="el-slider" [class.vertical]="vertical">
+<div #container class="el-slider">
   <div class="track track-full"></div>
-  <div class="track track-value" [style.width]="vertical ? null : percent" [style.height]="vertical ? percent : null"></div>
-  <div #scrubber class="scrubber" [style.left]="vertical ? null : percent" [style.bottom]="vertical ? percent : null">
+  <div class="track track-value" [style.width]="percent"></div>
+  <div #scrubber class="scrubber" [style.transform]="'translateX('+pxValue+'px)'">
     <span class="scrubber-marker"></span>
-    <span class="scrubber-label">{{ getStepValue(currentValue) }}</span>
+    <span class="scrubber-label">{{ getStepValue(value) }}</span>
   </div>
 </div>

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -65,10 +65,12 @@
     bottom: 0;
     margin: auto;
     margin-left: -1 * grid(8) / 2;
-    transition: left 0.1s ease;
+    transition: transform 0.1s cubic-bezier(0,.66,.66,1);
     cursor: move;
   }  
   .scrubber-label {
+    opacity:0;
+    transition: opacity 0.2s ease-in-out;
     position: absolute;
     text-align: center;
     padding: 0;  
@@ -97,6 +99,11 @@
       transform: scale(0.75, 1);
     }
   }
+  &.active, &:hover {
+    .scrubber-label {
+      opacity:1;
+    }
+  }
 
   // circle marker for scrubber
   .scrubber-marker {
@@ -110,7 +117,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-    transition: transform 0.2s ease;
   }
 }
 

--- a/src/app/ui/ui-slider/ui-slider.component.spec.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.spec.ts
@@ -19,7 +19,7 @@ describe('UiSliderComponent', () => {
     component.min = 200;
     component.max = 1000;
     component.step = 10;
-    component.currentValue = 600;
+    component.value = 600;
     fixture.detectChanges();
   });
 
@@ -33,32 +33,36 @@ describe('UiSliderComponent', () => {
   });
 
   it('should accept a new value and update the position', () => {
-    component.setValue(800);
+    component.value = 800;
+    component.updatePosition();
     fixture.detectChanges();
     expect(component.position).toEqual(0.75);
     expect(component.percent).toEqual('75%');
   });
 
   it('should not allow less than min value', () => {
-    component.setValue(-100);
+    component.value = (-100);
+    component.updatePosition();    
     fixture.detectChanges();
-    expect(component.currentValue).toEqual(200);
+    expect(component.value).toEqual(200);
     expect(component.position).toEqual(0);
     expect(component.percent).toEqual('0%');
   });
 
   it('should not exceed max value', () => {
-    component.setValue(10000);
+    component.value = (10000);
+    component.updatePosition();    
     fixture.detectChanges();
-    expect(component.currentValue).toEqual(1000);
+    expect(component.value).toEqual(1000);
     expect(component.position).toEqual(1);
     expect(component.percent).toEqual('100%');
   });
 
   it('should round to the nearest step value', () => {
-    component.setValue(404);
+    component.value = (404);
+    component.updatePosition();    
     fixture.detectChanges();
-    expect(component.currentValue).toEqual(400);
+    expect(component.value).toEqual(400);
     expect(component.position).toEqual(0.25);
     expect(component.percent).toEqual('25%');
   });

--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, ElementRef, AfterViewInit, HostListener, HostBinding, ViewChild, Input, Output } from '@angular/core';
+import { Component, EventEmitter, ChangeDetectorRef, ElementRef, AfterViewInit, HostListener, HostBinding, ViewChild, Input, Output } from '@angular/core';
 import { AfterViewChecked } from '@angular/core/src/metadata/lifecycle_hooks';
 
 @Component({
@@ -11,7 +11,8 @@ export class UiSliderComponent implements AfterViewInit {
   set value(value: number) {
     const boundsValue = (this.min && this.max) ?
       Math.min(this.max, Math.max(this.min, value)) : value;
-    this._currentValue = this.getStepValue(boundsValue);    
+    this._currentValue = this.getStepValue(boundsValue);   
+     
   }
   get value(): number {
     return this._currentValue;
@@ -30,9 +31,14 @@ export class UiSliderComponent implements AfterViewInit {
   private elRect = null;
   private _currentValue = 0;
 
+  constructor(private cdRef:ChangeDetectorRef) {}
+
   ngAfterViewInit() {
     this.setSliderDimensions();
     this.updatePosition();
+    // need to notify of changes when modifying inside of AfterViewInit
+    // https://github.com/angular/angular/issues/14748
+    this.cdRef.detectChanges();
   }
 
   /**
@@ -114,7 +120,7 @@ export class UiSliderComponent implements AfterViewInit {
     return (Math.round((val * step)) / step);
   }
 
-  private updatePosition() {
+  updatePosition() {
     this.position = (this.value - this.min) / (this.max - this.min);
     this.valueChange.emit(this.value);
   }

--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -1,39 +1,39 @@
-import { Component, EventEmitter, ElementRef, HostListener, HostBinding, ViewChild, Input, Output } from '@angular/core';
-
-// TODO: add key bindings
+import { Component, EventEmitter, ElementRef, AfterViewInit, HostListener, HostBinding, ViewChild, Input, Output } from '@angular/core';
+import { AfterViewChecked } from '@angular/core/src/metadata/lifecycle_hooks';
 
 @Component({
   selector: 'app-ui-slider',
   templateUrl: './ui-slider.component.html',
   styleUrls: ['./ui-slider.component.scss']
 })
-export class UiSliderComponent {
+export class UiSliderComponent implements AfterViewInit {
+  @Input()
+  set value(value: number) {
+    const boundsValue = (this.min && this.max) ?
+      Math.min(this.max, Math.max(this.min, value)) : value;
+    this._currentValue = this.getStepValue(boundsValue);    
+  }
+  get value(): number {
+    return this._currentValue;
+  }
+  @Input() label;
+  @Input() min;
+  @Input() max;
+  @Input() step = 1;
+  @Output() valueChange = new EventEmitter<number>();
+  @ViewChild('scrubber') scrubber: ElementRef;
+  @ViewChild('container') el: ElementRef;
+  @HostBinding('class.active') pressed = false;
   position = 0;
   get percent() { return (this.position * 100) + '%'; }
-  @Input() label;
-  @Input() vertical = false;
-  @Input() min = 0;
-  @Input() max = 100;
-  @Input() step = 1;
-  @Output() change = new EventEmitter<number>();
-  @ViewChild('scrubber') scrubber;
-  @HostBinding('class.active') pressed = false;
+  get pxValue() { return this.elRect ? this.position * this.elRect.width : 0 }
   private elRect = null;
   private _currentValue = 0;
 
-  /**
-   * Using getter and setter on currentValue to handle
-   * updates from external components
-   */
-  @Input() set currentValue(value) {
-    this.setValue(value);
+  ngAfterViewInit() {
+    this.setSliderDimensions();
+    this.updatePosition();
   }
-
-  get currentValue() {
-    return this._currentValue;
-  }
-
-  constructor(public el: ElementRef) { }
 
   /**
    * Update the slider dimensions when the window resizes
@@ -71,7 +71,7 @@ export class UiSliderComponent {
    */
   @HostListener('document:mouseup', ['$event']) onRelease(e) {
     if (this.pressed) {
-      this.setValue();
+      this.updatePosition();
       this.pressed = false;
     }
   }
@@ -92,31 +92,18 @@ export class UiSliderComponent {
 
   @HostListener('touchend', ['$event']) onTouchEnd(e) {
     if (this.pressed && e.touches && e.touches.length === 1) {
-      this.setValue();
+      this.updatePosition();
       this.pressed = false;
     }
   }
 
   // TODO: change so keydown only triggers on element focus
   @HostListener('keydown', ['$event']) onKeypress(e) {
-    if (this.vertical && (e.keyCode === 38 || e.keyCode === 40)) {
-      if (e.keyCode === 38) {
-        // up
-        this.setValue(this._currentValue + this.step);
-      }
-      if (e.keyCode === 40) {
-        this.setValue(this._currentValue - this.step);
-      }
-      this.change.emit(this.getStepValue());
-    } else if (!this.vertical && (e.keyCode === 37 || e.keyCode === 39)) {
-      if (e.keyCode === 37) {
-        // left
-        this.setValue(this._currentValue - this.step);
-      }
-      if (e.keyCode === 39) {
-        this.setValue(this._currentValue + this.step);
-      }
-      this.change.emit(this.getStepValue());
+    if ((e.keyCode === 37 || e.keyCode === 39)) {
+      // left or right
+      this.value = (e.keyCode === 37) ?
+        this.value - this.step : this.value + this.step;
+      this.updatePosition();
     }
   }
 
@@ -127,14 +114,9 @@ export class UiSliderComponent {
     return (Math.round((val * step)) / step);
   }
 
-
-  /**
-   * Set the value and scrubber position
-   * @param val the slider value
-   */
-  setValue(val: number = this._currentValue) {
-    this._currentValue = this.getStepValue(Math.min(this.max, Math.max(this.min, val)));
-    this.position = (this._currentValue - this.min) / (this.max - this.min);
+  private updatePosition() {
+    this.position = (this.value - this.min) / (this.max - this.min);
+    this.valueChange.emit(this.value);
   }
 
   /**
@@ -168,14 +150,11 @@ export class UiSliderComponent {
    */
   private setScrubberPosition(e) {
     if (e.clientX && this.elRect) {
-      const maxVal =
-        this.vertical ? this.getVerticalValue(e.clientY) : this.getHorizontalValue(e.clientX);
-      this.setValue(maxVal);
+      const maxVal = this.getHorizontalValue(e.clientX);
       this.position = Math.min(1, maxVal);
       const newValue = this.getStepValue();
-      if (newValue !== this.currentValue) {
-        this.currentValue = newValue;
-        this.change.emit(newValue);
+      if (newValue !== this.value) {
+        this.value = newValue;
       }
     }
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,6 +22,11 @@ html, body {
   font-family: $fontStack!important;
 }
 
+body {
+  height:auto;
+  overflow-x:hidden;
+}
+
 .btn.btn-close { 
   font-size: 24px; 
   width:40px;


### PR DESCRIPTION
Some fixes for the slider

- Show current year as label
- Only show the year marker on hover / interaction
- Drop the vertical treatment on the slider, we're not using it.
- Fix delays on drag / only emit updates on release / touchend / key press

Before:
![slider-before](https://user-images.githubusercontent.com/21034/33522515-6fb1e686-d7ab-11e7-80c8-571b86b04c57.gif)

After:
![slider-fix](https://user-images.githubusercontent.com/21034/33522516-798927d2-d7ab-11e7-8d94-aba00cbbd4db.gif)

