### PR TITLE
Add ui-toast for location max select

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -173,7 +173,7 @@ export class DataService {
    * Adds a location to the cards and data panel
    * @param feature the feature for the corresponding location to add
    */
-  addLocation(feature) {
+  addLocation(feature): boolean {
     if (this.activeFeatures.length < 3) {
       const i = this.activeFeatures.findIndex((f) => {
         return f.properties.n === feature.properties.n &&
@@ -181,8 +181,12 @@ export class DataService {
       });
       if (!(i > -1)) {
         this.activeFeatures = [ ...this.activeFeatures, feature ];
+        return true;
+      } else {
+        return false;
       }
     }
+    return false;
   }
 
   /**

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -161,8 +161,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
           }
         } else {
           this.toast.display(
-            'You have selected the maximum allowed locations. ' +
-            'Dismiss one of the locations and try again.'
+            'Maximum limit reached. Please remove a location to add another.'
           );
         }
         this.updateRoute();

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -154,8 +154,17 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     this.dataService.isLoading = true;
     this.dataService.getTileData(feature['layer']['id'], featureLonLat, null, true)
       .subscribe(data => {
-        console.log('got data', data);
-        this.dataService.addLocation(data);
+        if (this.dataService.activeFeatures.length < 3) {
+          const locationAdded = this.dataService.addLocation(data);
+          if (!locationAdded) {
+            this.toast.display('You have already selected this location.');
+          }
+        } else {
+          this.toast.display(
+            'You have selected the maximum allowed locations. ' +
+            'Dismiss one of the locations and try again.'
+          );
+        }
         this.updateRoute();
         this.dataService.isLoading = false;
       });


### PR DESCRIPTION
Closes #248. Adds a toast notification when a user tries to select a location when they already have 3 location cards. Also adds one if they try to select the same location twice. Currently have it in the top right corner so we can reuse the general toast notification, but if it's important to have it closer to the cards we can probably add a function for dynamically setting the position (rather than just having that as an input.

![location-cards](https://user-images.githubusercontent.com/8291663/33610645-aa627f1a-d991-11e7-808b-ed7df3d5777e.gif)
