### PR TITLE
axis fix, add year marker on hover, font updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,9 +798,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "angular-d3-graph": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.1.tgz",
-      "integrity": "sha512-XAGnQNwmpvUQ8ohkHwam4JUtAbRJorcMnJbCv1oet6ullwhYR6WGGpsk8SdUV7VKm14gPqclmOs86HAXV8ByRw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.4.tgz",
+      "integrity": "sha512-tF9Q9GPeco5zoU/x30EWI94owRHBYWq3p43bqefZn1fhMRMcvg+WNYYmsc0Yj84ZHHs2ywaRYQkGWveISS3rDw==",
       "requires": {
         "@angular/animations": "5.0.3",
         "@angular/common": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.41.0",
-    "angular-d3-graph": "^2.0.1",
+    "angular-d3-graph": "^2.0.4",
     "bootstrap": "^3.3.7",
     "clipboard": "^1.7.1",
     "core-js": "^2.4.1",

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -33,6 +33,7 @@
             <div class="line-tooltip" *ngFor="let tooltip of tooltips; trackBy: trackTooltips" [style.transform]="'translate('+ tooltip.xPos +'px, ' + tooltip.yPos + 'px)'">
               <span class="line-tooltip-value">{{tooltip.y}}</span>
             </div>
+            <div class="year-marker" *ngIf="tooltips.length" [style.transform]="'translateX('+ tooltips[0].xPos +'px)'"><span>{{tooltips[0].x}}</span></div>            
           </div>
           <div class="bar-tooltips" *ngIf="graphType === 'bar'">
             <div class="bar-tooltip" *ngFor="let tooltip of tooltips" [style.transform]="'translate('+ (tooltip.left + tooltip.width/2) +'px, ' + tooltip.top + 'px)'">

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -111,12 +111,16 @@
       // tick labels
       .axis .tick text {
         fill: $graphAxisLabels;
-        font-size:10px;
+        @include numberFont(11px);
       }
       .axis line { stroke: #fff; }
       // hide tick lines
       .axis-x .tick {
         line { display:none; }
+      }
+      .label-y {
+        @include smallCapsText(12px);
+        fill: $graphAxisLabels;
       }
     }
   }
@@ -266,6 +270,25 @@
 
 // Tooltips
 // ----
+.year-marker {
+  position:absolute;
+  left:0;
+  top:20px;
+  height: calc(100% - #{grid(5)});
+  width:1px;
+  border-left: 1px dashed rgba(0,0,0,0.35);
+  transition: transform 0.4s cubic-bezier(0, 0.66, 0.66, 1);
+  span {
+    position:absolute;
+    bottom: -1*grid(3);
+    left:0;
+    width: grid(4);
+    margin-left: -1*grid(2);
+    @include numberFont(14px);
+    text-align: center;
+  }
+
+}
 .line-tooltips, .bar-tooltips {
   @include fill-parent();
   pointer-events: none;
@@ -294,7 +317,7 @@
   margin-left: 12px;
   text-align:center;
   line-height: 15px;
-  transition: transform 0.4s ease;
+  transition: transform 0.4s cubic-bezier(0, 0.66, 0.66, 1);  
   @include left-arrow(6px, rgba(0,0,0,0.8));
   &:after { z-index:5; }
   &:before {
@@ -306,7 +329,7 @@
     position:absolute;
     top: 7px;
     left:0px;
-    margin-left: -14px;
+    margin-left: -17px;
     z-index:1;
   }
   &:nth-child(1):before {

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -127,10 +127,10 @@ export class DataPanelComponent implements OnInit, OnChanges {
       [];
   }
 
-  trackTooltips(index, item) {
-    return item.id;
-  }
+  /** track tooltips by ID so they are animated properly */
+  trackTooltips(index, item) { return item.id; }
 
+  /** changes graph to either line or bar and resets tooltips */
   changeGraphType(newType: string) {
     this.graphType = newType.toLowerCase();
     this.tooltips = [];
@@ -174,10 +174,14 @@ export class DataPanelComponent implements OnInit, OnChanges {
     this.tooltips = [];
     if (this.graphType === 'line') {
       this.graphSettings = this.lineGraphSettings;
-      this.graphData = [ ...this.createLineGraphData() ];
+      this.graphData = [...this.createLineGraphData()];
+      // HACK: something with the dimensions is not set correctly when updating settings
+      //    for now, update in timeout until this is fixed
+      setTimeout(() => { this.graphSettings = { ...this.lineGraphSettings } }, 1250);
     } else {
       this.graphSettings = this.barGraphSettings;
-      this.graphData = [ ...this.createBarGraphData() ];
+      this.graphData = [...this.createBarGraphData()];
+      setTimeout(() => { this.graphSettings = { ...this.barGraphSettings } }, 1250);
     }
   }
 


### PR DESCRIPTION
Update version of `angular-d3-graph` which adds padding to fix #237.
Update the settings in a `setTimeout` wrapper as a temporary way to fix #239
Adds in a "marker" line on the currently hovered year to address #213, this implementation may be changed by #249 
Update fonts to fix #220 

![graph-hover](https://user-images.githubusercontent.com/21034/33635346-d613ece6-d9d4-11e7-8257-2ef8f3e03063.gif)
