### PR TITLE
Fix select text wrap, scroll on open

### DIFF
--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -1,4 +1,4 @@
-<div class="el-select" dropdown (isOpenChange)="open = dropdown.isOpen">
+<div class="el-select" dropdown (isOpenChange)="onIsOpenChange()">
   <button dropdownToggle type="button" class="btn btn-small dropdown-toggle">
     <span *ngIf="label" class="el-select-label">{{label}} </span> 
     <span class="el-select-value">{{selectedLabel}}</span>
@@ -8,7 +8,7 @@
       </g>
     </svg>
   </button>
-  <ul *dropdownMenu class="dropdown-menu" role="menu">
+  <ul #dropdownList *dropdownMenu class="dropdown-menu" role="menu">
     <li *ngFor="let value of values" role="menuitem">
       <a 
         class="dropdown-item" 

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -39,11 +39,10 @@
       padding:0;
       overflow: auto;
       & > li > a {
-        padding: 0px $defaultPadding;
-        line-height: grid(5);
-        white-space: nowrap;
+        padding: $defaultPadding;
         border-top: 1px solid $shadingColor;
-        height: grid(5);
+        min-height: grid(5);
+        white-space: normal;
         box-sizing: border-box;
       }
       & li:first-child a { border-top: none; }

--- a/src/app/ui/ui-select/ui-select.component.ts
+++ b/src/app/ui/ui-select/ui-select.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, Input, Output, EventEmitter, HostListener, ViewChild, HostBinding } from '@angular/core';
+import {
+  Component, OnInit, Input, Output, EventEmitter, HostListener, ViewChild, HostBinding, ElementRef
+} from '@angular/core';
 import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
 import * as _isEqual from 'lodash.isequal';
 
@@ -23,6 +25,7 @@ export class UiSelectComponent implements OnInit {
   @Input() values: Array<any> = [];
   @Output() change: EventEmitter<any> = new EventEmitter<any>();
   @ViewChild(BsDropdownDirective) dropdown;
+  @ViewChild('dropdownList') dropdownList: ElementRef;
   highlightedItem: any;
   get selectedLabel(): string { return this.getLabel(this.selectedValue); }
   private valuesArray = true; // true if `values` is an array of values instead of objects
@@ -59,6 +62,14 @@ export class UiSelectComponent implements OnInit {
     const i = this.values.findIndex((v) => _isEqual(this.highlightedItem, v));
     const offset = previousItem ? -1 : 1;
     return this.values[(i + offset) % this.values.length];
+  }
+
+  /**
+   * Set open status, reset scrollTop in dropdown
+   */
+  onIsOpenChange() {
+    this.open = this.dropdown.isOpen;
+    this.dropdownList.nativeElement.scrollTop = 0;
   }
 
   @HostListener('keydown', ['$event']) onFocus(e) {


### PR DESCRIPTION
Closes #255. Sets text to wrap, using `padding` instead of `line-height`. Also resets the scroll position on open/close. I didn't see a straightforward way of getting the `ul` element from the directive, so I added it as an `ElementRef` `ViewChild`.

![select-dropdown](https://user-images.githubusercontent.com/8291663/33636048-17158e42-d9e0-11e7-8c00-95df23bb4033.gif)

