### PR TITLE
Add "auto" option to layer switch

### DIFF
--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -13,7 +13,6 @@
   ></app-header-bar>
   <app-map
     [mapConfig]="dataService.mapConfig"
-    [autoSwitch]="dataService.autoSwitchLayers"
     [bubbleOptions]="dataService.bubbleAttributes"
     [layerOptions]="dataService.dataLevels"
     [choroplethOptions]="dataService.dataAttributes"

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -45,6 +45,7 @@
           [values]="choroplethOptions"
           (change)="selectedChoropleth = $event">
       </app-ui-select>
+      
       <app-ui-select
           tabindex="6"
           class="layer-select"

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -194,6 +194,10 @@ app-location-cards {
       display:block;
       overflow: hidden;
       text-overflow: ellipsis;
+      span {
+        display:inline-block;
+        margin-left: grid(0.5);
+      }
     }
     .el-select .dropdown-toggle.btn {
       white-space: nowrap;

--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -1,7 +1,7 @@
 <div class="el-select" dropdown (isOpenChange)="onIsOpenChange()">
   <button dropdownToggle type="button" class="btn btn-small dropdown-toggle">
     <span *ngIf="label" class="el-select-label">{{label}} </span> 
-    <span class="el-select-value">{{selectedLabel}}</span>
+    <span class="el-select-value" [innerHTML]="selectedLabel"></span>
     <svg class="svg-down-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g>
         <polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline>


### PR DESCRIPTION
Adds an option to turn on "Auto" switching.  When enabled "(auto)" displays next to the currently selected layer. Closes #240 

![auto-switch2](https://user-images.githubusercontent.com/21034/33682236-1701a554-da84-11e7-85a9-2bb236f9ad31.gif)
