### PR TITLE
Increase default zoom to address points

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -258,9 +258,10 @@ export class MapService {
   /**
    * Zoom to supplied point feature
    * @param feature Point feature
+   * @param zoom Zoom level
    */
-  zoomToPoint(feature: MapFeature) {
-    this.map.flyTo({ center: feature.geometry['coordinates'], zoom: 12 });
+  zoomToPoint(feature: MapFeature, zoom: number) {
+    this.map.flyTo({ center: feature.geometry['coordinates'], zoom: zoom });
   }
 
   /**

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -202,9 +202,10 @@ export class MapComponent implements OnInit, OnChanges {
   /**
    * Zoom to Point feature
    * @param feature Point feature
+   * @param zoom Zoom level
    */
-  zoomToPointFeature(feature: MapFeature) {
-    this.map.zoomToPoint(feature);
+  zoomToPointFeature(feature: MapFeature, zoom = 14) {
+    this.map.zoomToPoint(feature, zoom);
   }
 
   /**


### PR DESCRIPTION
Add `zoom` parameter to `zoomToPoint` and `zoomToPointFeature`, and set it 14 by default (rather than 12). Closes #228 