### PR TITLE
Use forked mapbox-gl-js to fix bubble bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,14 @@
         "tslib": "1.8.0"
       }
     },
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
     "@mapbox/gl-matrix": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz",
@@ -1187,11 +1195,6 @@
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
-    "base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
-    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -1329,15 +1332,6 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
-    },
-    "bops": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
-      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
-      "requires": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
-      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -4460,6 +4454,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4467,13 +4468,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4631,43 +4625,20 @@
         "is-property": "1.0.2"
       }
     },
-    "geojson-area": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.1.0.tgz",
-      "integrity": "sha1-1I2AcILPrfSnjfE0m+UPOL8YlK4=",
-      "requires": {
-        "wgs84": "0.0.0"
-      }
-    },
     "geojson-rewind": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.2.0.tgz",
-      "integrity": "sha1-6lWOnkT/A7hlXQoIt1B43DOhXnk=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.0.tgz",
+      "integrity": "sha512-5dsjiZGk6p///Ju9kh7uGW+I74CZriHsxqBNPbIN4bbInfKmHwwM+f8fZ42fmpV5emeUYLTTC+GWs3EC1TMjNQ==",
       "requires": {
-        "concat-stream": "1.2.1",
-        "geojson-area": "0.1.0",
-        "minimist": "0.0.5"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.2.1.tgz",
-          "integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA=",
-          "requires": {
-            "bops": "0.0.6"
-          }
-        },
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-        }
+        "@mapbox/geojson-area": "0.2.2",
+        "concat-stream": "1.6.0",
+        "minimist": "1.2.0"
       }
     },
     "geojson-vt": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-2.4.0.tgz",
-      "integrity": "sha1-PBz0RJPzXrTSxwyV2mVQ3mYHLAU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.0.0.tgz",
+      "integrity": "sha512-FL7VV56gYBDBh0F7EWyZV5G9/L2EHEHh9SyhEpJz4c8YDPerM6dnP9VbRcsbyg1wH+1oyoHRA9dlJkGs/IXULA=="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -6521,9 +6492,7 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "0.42.2",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.42.2.tgz",
-      "integrity": "sha512-YwTP5g6ljzUvT4puPOubhZ+RQO6umOtfSBAu07LNrBXP9ZhprD5y6DoQJID1BaB6DTFQ5BD0CN717a/NPUG5Xg==",
+      "version": "git://github.com/EvictionLab/mapbox-gl-js.git#f005c95b3a0c7f28e6f77ceff8228d8236fb1397",
       "requires": {
         "@mapbox/gl-matrix": "0.0.1",
         "@mapbox/point-geometry": "0.1.0",
@@ -6536,8 +6505,8 @@
         "bubleify": "0.7.0",
         "csscolorparser": "1.0.3",
         "earcut": "2.1.2",
-        "geojson-rewind": "0.2.0",
-        "geojson-vt": "2.4.0",
+        "geojson-rewind": "0.3.0",
+        "geojson-vt": "3.0.0",
         "gray-matter": "3.1.1",
         "grid-index": "1.0.0",
         "jsonlint-lines-primitives": "1.6.0",
@@ -10215,11 +10184,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
-    },
-    "to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
     "toposort": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "core-js": "^2.4.1",
     "debounce-decorator": "^1.0.6",
     "lodash.isequal": "^4.5.0",
-    "mapbox-gl": "^0.42.0",
+    "mapbox-gl": "git://github.com/EvictionLab/mapbox-gl-js.git",
     "ng2-page-scroll": "^4.0.0-beta.11",
     "ngx-bootstrap": "^2.0.0-beta.9",
     "pbf": "^3.1.0",


### PR DESCRIPTION
Fixes #29. Modifies the `mapbox-gl-js` source in our fork to treat 404s the same as a 204 empty content response. The problem is that Mapbox treats a 404 as if it needs to overzoom a layer to account for a missing layer below it, even if the tile that returns the 404 isn't necessarily the one being displayed. This is why this seems to happen mostly at the edge of the map where tiles aren't created. There's still a little bit of a flicker sometimes, but unlike before it will disappear in about half a second, rather than require someone to zoom past it