### PR TITLE
Fix OpenMapTiles overzoom, add motorways to visible streets

### DIFF
--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -6,6 +6,7 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
+      "maxzoom": 13,
       "tiles": [
         "https://openmaptiles.evictionlab.org/{z}/{x}/{y}.pbf"
       ]
@@ -2120,7 +2121,9 @@
           "in",
           "class",
           "primary",
-          "secondary"
+          "secondary",
+          "motorway",
+          "trunk"
         ]
       ],
       "layout": {


### PR DESCRIPTION
One consequence of #272 is that overzooming in response to a 404 no longer works, which just means that we need to specify the max zoom level that Mapbox should request from a layer so that it automatically overzooms without making a request. Also adds highways to the streets visible at high zooms because they left an odd gap when they weren't included