### PR TITLE
Highlight on selected card features 

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -181,6 +181,10 @@ export class MapService {
     return this.map.getBounds().toArray();
   }
 
+  /**
+   * Returns source data
+   * @param sourceId ID of source to return
+   */
   getSourceData(sourceId) {
     return (this.map.getSource(sourceId) as mapboxgl.GeoJSONSource)['_data']['features'];
   }
@@ -194,10 +198,15 @@ export class MapService {
   setSourceData(sourceId: string, features?: MapFeature[]) {
     (this.map.getSource(sourceId) as mapboxgl.GeoJSONSource).setData({
       'type': 'FeatureCollection',
-      'features': features
+      'features': features ? features : []
     });
   }
 
+  /**
+   * Sets or updates highlight features
+   * @param layerId String ID of current displayed map layer
+   * @param features Array of active features to highlight
+   */
   updateHighlightFeatures(layerId: string, features: MapFeature[]) {
     const highlightSource = this.getSourceData('highlight');
     const geoids = highlightSource.map(f => f['properties']['GEOID']);

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -15,6 +15,7 @@ export class MapService {
   private _isLoading = new BehaviorSubject<boolean>(true);
   isLoading$ = this._isLoading.asObservable();
   private colors = ['#e24000', '#434878', '#2c897f'];
+  get mapCreated() { return this.map !== undefined; }
 
   constructor() { }
 

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -175,6 +175,15 @@ export class MapComponent implements OnInit, OnChanges {
     if (changes.scrollZoom) {
       changes.scrollZoom.currentValue ? this.enableZoom() : this.disableZoom();
     }
+    if (changes.activeFeatures && !this.mapLoading) {
+      if (changes.activeFeatures.currentValue.length) {
+        this.map.updateHighlightFeatures(
+          this.selectedLayer.id, changes.activeFeatures.currentValue
+        );
+      } else if (!changes.activeFeatures.firstChange) {
+        this.map.setSourceData('highlight');
+      }
+    }
   }
 
   /**
@@ -249,6 +258,9 @@ export class MapComponent implements OnInit, OnChanges {
         this.restoreAutoSwitch = true; // restore auto switch after zoom
       }
     }
+    this.map.updateHighlightFeatures(
+      this.selectedLayer.id, this.activeFeatures
+    );
   }
 
   /**
@@ -305,7 +317,7 @@ export class MapComponent implements OnInit, OnChanges {
     this.featureHover.emit(feature);
     if (feature && feature.layer.id === this.selectedLayer.id) {
       const union = this.map.getUnionFeature(this.selectedLayer.id, feature);
-      this.map.setSourceData('hover', union);
+      this.map.setSourceData('hover', [union]);
     } else {
       this.map.setSourceData('hover');
     }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -175,12 +175,10 @@ export class MapComponent implements OnInit, OnChanges {
     if (changes.scrollZoom) {
       changes.scrollZoom.currentValue ? this.enableZoom() : this.disableZoom();
     }
-    if (changes.activeFeatures && !this.mapLoading) {
-      if (changes.activeFeatures.currentValue.length) {
-        this.map.updateHighlightFeatures(
-          this.selectedLayer.id, changes.activeFeatures.currentValue
-        );
-      }
+    if (changes.activeFeatures && this.map.mapCreated) {
+      const features = (changes.activeFeatures.currentValue ?
+        changes.activeFeatures.currentValue : []);
+      this.map.updateHighlightFeatures(this.selectedLayer.id, features);
     }
   }
 

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -243,9 +243,16 @@ export class MapComponent implements OnInit, OnChanges {
     this.setGroupVisibility(this.selectedLayer);
     this.updateCensusYear();
     this.updateMapData();
-    this.map.isLoading$.distinctUntilChanged()
+    this.map.isLoading$
       .debounceTime(200)
-      .subscribe((state) => { this.mapLoading = state; });
+      .distinctUntilChanged()
+      .subscribe((state) => {
+        this.mapLoading = state;
+        // Whenever map finishes loading, update boundaries
+        if (!this.mapLoading) {
+          this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
+        }
+      });
     if (this.boundingBox) {
       this.map.zoomToBoundingBox(this.boundingBox);
       // Only toggle if autoSwitch is currently on
@@ -254,9 +261,6 @@ export class MapComponent implements OnInit, OnChanges {
         this.restoreAutoSwitch = true; // restore auto switch after zoom
       }
     }
-    this.map.updateHighlightFeatures(
-      this.selectedLayer.id, this.activeFeatures
-    );
   }
 
   /**
@@ -460,5 +464,6 @@ export class MapComponent implements OnInit, OnChanges {
   private updateMapData() {
     this.updateMapBubbles();
     this.updateMapChoropleths();
+    this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
   }
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -180,8 +180,6 @@ export class MapComponent implements OnInit, OnChanges {
         this.map.updateHighlightFeatures(
           this.selectedLayer.id, changes.activeFeatures.currentValue
         );
-      } else if (!changes.activeFeatures.firstChange) {
-        this.map.setSourceData('highlight');
       }
     }
   }
@@ -295,6 +293,7 @@ export class MapComponent implements OnInit, OnChanges {
       .map(v => Math.round(v * 1000) / 1000);
     this.boundingBoxChange.emit(this._store.bounds);
     if (this.restoreAutoSwitch) { this.autoSwitch = true; }
+    this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
   }
 
   /**

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -2459,13 +2459,24 @@
       }
     },
     {
+      "id": "highlight-outline",
+      "type": "line",
+      "source": "highlight",
+      "layout": {},
+      "paint": {
+        "line-width": 5,
+        "line-opacity": 0.75,
+        "line-color": "#ffffff"
+      }
+    },
+    {
       "id": "highlight",
       "type": "line",
       "source": "highlight",
       "layout": {},
       "paint": {
-        "line-width": 3,
-        "line-opacity": 0.5,
+        "line-width": 2,
+        "line-opacity": 0.9,
         "line-color": {
           "property": "color",
           "type": "identity"

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -81,6 +81,13 @@
         "https://tiles.evictionlab.org/staging/evictions-states-10/{z}/{x}/{y}.pbf"
       ]
     },
+    "highlight": {
+      "type": "geojson",
+      "data": {
+        "type": "FeatureCollection",
+        "features": []
+      }
+    },
     "hover": {
       "type": "geojson",
       "data": {
@@ -2449,6 +2456,20 @@
         "line-color": "rgba(255,255,255,0.8)",
         "line-width": 3,
         "line-opacity": 0.5
+      }
+    },
+    {
+      "id": "highlight",
+      "type": "line",
+      "source": "highlight",
+      "layout": {},
+      "paint": {
+        "line-width": 3,
+        "line-opacity": 0.5,
+        "line-color": {
+          "property": "color",
+          "type": "identity"
+        }
       }
     },
     {


### PR DESCRIPTION
The basics of this feature are working, implementing #150, but there are a couple quirks in behavior that we would need to decide how to handle before merging this.

The big question is how we should handle displaying shapes for features whose layers haven't loaded yet. Should we only display the outlines of features in the currently selected layer? The reason for this is if the layer isn't visible, on page load it will pull the small square for the zoom 10 tile (shown below). We could alternatively just try to ignore anything that's only loaded from `getTileData`, and wait until it uses `queryRenderedFeatures` to get the shape

Here's an example of how it's currently working (you can see some of the quirks, like the small square being loaded for Iowa):

![location-outlines](https://user-images.githubusercontent.com/8291663/34063409-87b00fcc-e1b7-11e7-899a-6b609eb20e33.gif)
