### PR TITLE
Only throw mailto error if not mobile

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.spec.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.spec.ts
@@ -7,6 +7,7 @@ import { DataPanelComponent } from './data-panel.component';
 import { DataPanelModule } from './data-panel.module';
 import { FileExportService } from './download-form/file-export.service';
 import { DownloadFormComponent } from './download-form/download-form.component';
+import { PlatformService } from '../../platform.service';
 
 export class FileExportStub {
   getFileTypes() { 

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -1,8 +1,12 @@
-import { Component, OnInit, Input, Output, EventEmitter, SimpleChanges, OnChanges } from '@angular/core';
+import {
+  Component, OnInit, Input, Output, EventEmitter, SimpleChanges, OnChanges
+} from '@angular/core';
 import { DownloadFormComponent } from './download-form/download-form.component';
 import { UiDialogService } from '../../ui/ui-dialog/ui-dialog.service';
 import { MapFeature } from '../map/map-feature';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { PlatformService } from '../../platform.service';
+import { PlatformLocation } from '@angular/common';
 
 @Component({
   selector: 'app-data-panel',
@@ -83,9 +87,10 @@ export class DataPanelComponent implements OnInit, OnChanges {
   lineEndYear: number = this.maxYear;
 
   constructor(
-    public dialogService: UiDialogService, 
+    public dialogService: UiDialogService,
     private translatePipe: TranslatePipe,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private platform: PlatformService
   ) {}
 
   ngOnInit() {
@@ -218,6 +223,10 @@ export class DataPanelComponent implements OnInit, OnChanges {
    * @param e
    */
   checkMailto(e) {
+    // Cancel if on mobile, since behavior isn't the same
+    if (this.platform.isMobile) {
+      return;
+    }
     // https://www.uncinc.nl/articles/dealing-with-mailto-links-if-no-mail-client-is-available
     let timeout;
 

--- a/src/app/map-tool/data-panel/data-panel.module.ts
+++ b/src/app/map-tool/data-panel/data-panel.module.ts
@@ -9,6 +9,7 @@ import { UiModule } from '../../ui/ui.module';
 import { DataPanelComponent } from './data-panel.component';
 import { DownloadFormComponent } from './download-form/download-form.component';
 import { SocialSharePopupDirective } from './social-share-popup.directive';
+import { PlatformService } from '../../platform.service';
 
 @NgModule({
   exports: [ DataPanelComponent ],
@@ -21,6 +22,7 @@ import { SocialSharePopupDirective } from './social-share-popup.directive';
     PopoverModule.forRoot()
   ],
   declarations: [ DataPanelComponent, DownloadFormComponent, SocialSharePopupDirective ],
+  providers: [ PlatformService ],
   entryComponents: [ DataPanelComponent, DownloadFormComponent ]
 })
 export class DataPanelModule { }


### PR DESCRIPTION
Closes #224. Mobile browsers seem to automatically prompt for configuring a mail client, but this doesn't open a new window so the error message is always displayed. Disabling the error message event listener on mobile