### PR TITLE
Add card on click, then update data

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -170,21 +170,24 @@ export class DataService {
   }
 
   /**
-   * Adds a location to the cards and data panel
+   * Adds or updates a location to the cards and data panel
    * @param feature the feature for the corresponding location to add
    */
   addLocation(feature): boolean {
+    // Process feature if bbox and layerId not included based on current data level
+    if (!(feature.properties.bbox && feature.properties.bbox)) {
+      feature = this.processMapFeature(feature);
+    }
+    const geoids = this.activeFeatures.map(f => f.properties.GEOID);
+    const featIndex = geoids.indexOf(feature.properties.GEOID);
+
+    if (featIndex !== -1) {
+      this.activeFeatures[featIndex] = feature;
+      return true;
+    }
     if (this.activeFeatures.length < 3) {
-      const i = this.activeFeatures.findIndex((f) => {
-        return f.properties.n === feature.properties.n &&
-          f.properties.pl === feature.properties.pl;
-      });
-      if (!(i > -1)) {
-        this.activeFeatures = [ ...this.activeFeatures, feature ];
-        return true;
-      } else {
-        return false;
-      }
+      this.activeFeatures = [ ...this.activeFeatures, feature ];
+      return true;
     }
     return false;
   }
@@ -243,6 +246,29 @@ export class DataService {
     return [ ((bbox[0] + bbox[2]) / 2), ((bbox[1] + bbox[3]) / 2) ];
   }
 
+
+  /**
+   * Processes the bounding box and properties of a feature returned
+   * from the
+   * @param layerId
+   * @param feature
+   */
+  processMapFeature(feature: MapFeature, layerId?: string): MapFeature {
+    // Add layer if specified or included on feature (usually on click)
+    if (layerId) {
+      feature.properties.layerId = layerId;
+    } else if (feature['layer']) {
+      feature.properties.layerId = feature['layer']['id'];
+    }
+    feature.bbox = [
+      +feature.properties['west'],
+      +feature.properties['south'],
+      +feature.properties['east'],
+      +feature.properties['north']
+    ];
+    return feature;
+  }
+
   private stripYearFromAttr(attr: string) {
     return attr.split('-')[0];
   }
@@ -273,14 +299,7 @@ export class DataService {
       }
 
       if (matchFeat) {
-        matchFeat.properties.layerId = layerId;
-        matchFeat.bbox = [
-          matchFeat.properties['west'],
-          matchFeat.properties['south'],
-          matchFeat.properties['east'],
-          matchFeat.properties['north']
-        ];
-        return matchFeat;
+        return this.processMapFeature(matchFeat, layerId);
       }
 
       return {} as MapFeature;

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -182,7 +182,10 @@ export class DataService {
     const featIndex = geoids.indexOf(feature.properties.GEOID);
 
     if (featIndex !== -1) {
-      this.activeFeatures[featIndex] = feature;
+      // Assigning properties and geometry rather than the whole feature
+      // so that a state change isn't triggered
+      this.activeFeatures[featIndex].properties = feature.properties;
+      this.activeFeatures[featIndex].geometry = feature.geometry;
       return true;
     }
     if (this.activeFeatures.length < 3) {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -154,14 +154,11 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   onFeatureSelect(feature: MapFeature) {
     const featureLonLat = this.dataService.getFeatureLonLat(feature);
     this.dataService.isLoading = true;
+    this.dataService.addLocation(feature);
     this.dataService.getTileData(feature['layer']['id'], featureLonLat, null, true)
       .subscribe(data => {
-        if (this.dataService.activeFeatures.length < 3) {
-          const locationAdded = this.dataService.addLocation(data);
-          if (!locationAdded) {
-            this.toast.display('You have already selected this location.');
-          }
-        } else {
+        const locationUpdated = this.dataService.addLocation(data);
+        if (!locationUpdated) {
           this.toast.display(
             'Maximum limit reached. Please remove a location to add another.'
           );


### PR DESCRIPTION
Closes #299. Changes `addLocation` into an add or update, adds clicked features to card locations immediately, then loads additional data later. It's working great overall, the only issue is that it is triggering a transition on the location cards on update as well as add.

I can't figure out where to prevent this, but I think if we get the sorted list of GEOIDs and check for equality (was initially thinking length being the same, but that wouldn't work with #290) we can verify if an event was an update rather than add. Where should I fix that?