### PR TITLE
Update README, add code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,149 +1,19 @@
+# Eviction Lab Map Tool
+
 [![Build Status](https://travis-ci.org/EvictionLab/eviction-maps.svg?branch=master)](https://travis-ci.org/EvictionLab/eviction-maps)
 
-# EvictionMaps
+Data visualization tool for [the Eviction Lab at Princeton University](https://evictionlab.org) displaying information on evictions and demographics for the United States.
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.3.0.
+## Setup
 
-## Development server
+This project uses [Angular](https://angular.io/), and can be installed by cloning a local copy of the repo and running `npm install`. Use the Angular CLI to run a local development server with `ng serve` and access the site in your browser at `http://localhost:4200`.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+## Contributing
 
-## Code scaffolding
+If you run into anything that isn't working correctly, please report it as a bug here: https://github.com/EvictionLab/eviction-maps/issues
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+If you're interested in contributing to the project check out our list of issues first, and then fork the repository and submit a pull request. All project participants are expected to abide by the project [code of conduct](docs/CODE_OF_CONDUCT.md).
 
-## Build
+## License
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
-
-## Running unit tests
-
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
-Before running the tests make sure you are serving the app via `ng serve`.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
-
-# Deep Linking
-
-The following options can be set through app routes or URL parameters:
-
-  - Locations
-  - Map Bounds
-  - Eviction Type
-  - Choropleth Highlight
-  - Geography Layer
-
-## Routes
-
-Routes for the app are as follows:
-
-http://{{BASE_URL}}/:locations/:year/:geography/:type/:choropleth/:bounds
-
-With the following options
-
-  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{lon}},{{lat}}`.  Set to `none` for no active locations.
-    - e.g. `states,-92.285,38.41+states,-93.34,42.163` would activate Missouri and Iowa
-  - `:year`: a year anywhere from 1990 to 2016
-  - `:geography`: `states`, `counties`, `cities`, `zip-codes`, `tracts`, or `block-groups`. 
-  - `:type`: an ID for the corresponding `BubbleAttribute` (`er` or `efr`)
-  - `:choropleth`: an ID for the corresponding choropleth `DataAttribute` (`p` or `pr`, more to come)
-  - `:bounds` a comma separated bounding box for the map to zoom to `{{west}},{{south}},{{east}},{{north}}`
-
-Data must be set through routes in this order `:locations/:year/:geography/:type/:choropleth/:bounds`.  If you want to set only one of these parameters, use the URL Parameters.
-
-## URL Parameters
-
-Map settings can also be set through URL parameters instead of routes, with the following format:
-
-http://{{BASE_URL}}/link;locations={{locations}};year={{year}};geography={{geography}};type={{type}};choropleth={{choropleth}};bounds={{bounds}}
-
-All settings are optional, so you could set only the year, eviction rate bubbles, and bounds with:
-
-http://{{BASE_URL}}/link;year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76
-
-### Getting the Current URL Parameters / Route Array
-
-A string of the URL parameters based on the current view is available using `DataService.getUrlParameters()`, which returns a string of parameters based on the current view.  (e.g. `year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76`).
-
-An array containing all of the route parameter values is also available with `DataService.getRouteArray()`
-
-# App Components 
-
-## `app-map`
-
-### Inputs
-
-    - boundingBox: used to set the location displayed in the map
-    - autoSwitch: determines if the data levels should auto switch based on zoom level
-
-### Outputs
-
-    - yearChange: emits the year when it is changed
-    - evictionTypeChange: emits the eviction type string when changed
-    - featureClick: emits a feature when on is clicked on the map
-    - featureHover: emits a feature when one is hovered in the map
-    - bboxChange: emits the bounding box anytime the map finished moving
-
-### Methods
-
-    - enableZoom(): enables scroll to zoom on map
-    - disableZoom(): disables scroll to zoom on map
-
-
-## `app-location-cards`
-
-### Inputs
-
-    - features: an array of features to display cards form
-    - year: the year to display data for in the card
-    - cardProperties: an object containing the property names to show, and the corresponding label.  e.g. `{ 'e': 'Eviction Rate' }`
-
-### Outputs
-
-    - viewMore: emits when the "View More" button is clicked
-    - dismissCard: emits the feature when the close button is clicked
-
-
-## `app-data-panel`
-
-### Inputs
-
-    - locations: an array of features representing different locations
-    - year: the year to display data for
-    
-### Outputs
-
-    - locationAdded: TODO
-    - locationRemoved: emits the feature that remove was triggered for
-
-# UI Components 
-
-## `app-ui-slider`
-
-## `app-ui-toggle`
-
-## `app-ui-select`
-
-### Inputs
-  - `values`: an aray of values or objects to select from
-  - `selectedValue`: an optional value to select by default
-  - `labelProperty`: an optional property to use for the item label if an object array is passed to `values`
-  - `label`: label the input field
-
-### Outputs
-  - `change`: emits the selected value on change
-
-## `app-ui-hint`
-
-## `app-ui-dialog`
-
-## `app-progress-bar`
-
-## `app-predictive-search`
-
+This application is open source code under the [MIT License](LICENSE).

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [the project team](https://github.com/orgs/EvictionLab/people). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,119 @@
+# Technical Documentation
+
+## Deep Linking
+
+The following options can be set through app routes or URL parameters:
+
+  - Locations
+  - Map Bounds
+  - Eviction Type
+  - Choropleth Highlight
+  - Geography Layer
+
+## Routes
+
+Routes for the app are as follows:
+
+http://{{BASE_URL}}/:locations/:year/:geography/:type/:choropleth/:bounds
+
+With the following options
+
+  - `:locations`: a list of locations separated by `+`.  Each location is formatted as `{{layerId}},{{lon}},{{lat}}`.  Set to `none` for no active locations.
+    - e.g. `states,-92.285,38.41+states,-93.34,42.163` would activate Missouri and Iowa
+  - `:year`: a year anywhere from 1990 to 2016
+  - `:geography`: `states`, `counties`, `cities`, `zip-codes`, `tracts`, or `block-groups`. 
+  - `:type`: an ID for the corresponding `BubbleAttribute` (`er` or `efr`)
+  - `:choropleth`: an ID for the corresponding choropleth `DataAttribute` (`p` or `pr`, more to come)
+  - `:bounds` a comma separated bounding box for the map to zoom to `{{west}},{{south}},{{east}},{{north}}`
+
+Data must be set through routes in this order `:locations/:year/:geography/:type/:choropleth/:bounds`.  If you want to set only one of these parameters, use the URL Parameters.
+
+## URL Parameters
+
+Map settings can also be set through URL parameters instead of routes, with the following format:
+
+http://{{BASE_URL}}/link;locations={{locations}};year={{year}};geography={{geography}};type={{type}};choropleth={{choropleth}};bounds={{bounds}}
+
+All settings are optional, so you could set only the year, eviction rate bubbles, and bounds with:
+
+http://{{BASE_URL}}/link;year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76
+
+### Getting the Current URL Parameters / Route Array
+
+A string of the URL parameters based on the current view is available using `DataService.getUrlParameters()`, which returns a string of parameters based on the current view.  (e.g. `year=2015;type=er;bounds=-92.52,38.25,-86.53,41.76`).
+
+An array containing all of the route parameter values is also available with `DataService.getRouteArray()`
+
+# App Components 
+
+## `app-map`
+
+### Inputs
+
+    - boundingBox: used to set the location displayed in the map
+    - autoSwitch: determines if the data levels should auto switch based on zoom level
+
+### Outputs
+
+    - yearChange: emits the year when it is changed
+    - evictionTypeChange: emits the eviction type string when changed
+    - featureClick: emits a feature when on is clicked on the map
+    - featureHover: emits a feature when one is hovered in the map
+    - bboxChange: emits the bounding box anytime the map finished moving
+
+### Methods
+
+    - enableZoom(): enables scroll to zoom on map
+    - disableZoom(): disables scroll to zoom on map
+
+
+## `app-location-cards`
+
+### Inputs
+
+    - features: an array of features to display cards form
+    - year: the year to display data for in the card
+    - cardProperties: an object containing the property names to show, and the corresponding label.  e.g. `{ 'e': 'Eviction Rate' }`
+
+### Outputs
+
+    - viewMore: emits when the "View More" button is clicked
+    - dismissCard: emits the feature when the close button is clicked
+
+
+## `app-data-panel`
+
+### Inputs
+
+    - locations: an array of features representing different locations
+    - year: the year to display data for
+    
+### Outputs
+
+    - locationAdded: TODO
+    - locationRemoved: emits the feature that remove was triggered for
+
+# UI Components 
+
+## `app-ui-slider`
+
+## `app-ui-toggle`
+
+## `app-ui-select`
+
+### Inputs
+  - `values`: an aray of values or objects to select from
+  - `selectedValue`: an optional value to select by default
+  - `labelProperty`: an optional property to use for the item label if an object array is passed to `values`
+  - `label`: label the input field
+
+### Outputs
+  - `change`: emits the selected value on change
+
+## `app-ui-hint`
+
+## `app-ui-dialog`
+
+## `app-progress-bar`
+
+## `app-predictive-search`


### PR DESCRIPTION
Closes #323. Figured it would be better to do this now while we have some time. I moved the technical docs to `docs/components.md`, but given we aren't really planning on exposing this as a standalone package it could make sense to just get rid of it rather than try and keep it up to date?