### PR TITLE
Smooth out zoom expressions, update minzoom

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,7 @@ const defaultData = {
     style: './assets/style.json',
     center: [-98.5795, 39.8283],
     zoom: 3,
-    minZoom: 3,
+    minZoom: 2,
     maxZoom: 14
   },
   year: 2016

--- a/src/app/data/data-attributes.ts
+++ b/src/app/data/data-attributes.ts
@@ -303,11 +303,11 @@ export const BubbleAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          4, ['/', ['var', 'data_prop'], 16],
-          6, ['/', ['var', 'data_prop'], 8],
-          8, ['/', ['var', 'data_prop'], 2.5],
-          9, ['/', ['var', 'data_prop'], 0.8],
-          10, ['/', ['var', 'data_prop'], 0.8]
+          4, ['/', ['var', 'data_prop'], 4],
+          6, ['/', ['var', 'data_prop'], 3],
+          8, ['/', ['var', 'data_prop'], 2],
+          9, ['/', ['var', 'data_prop'], 1],
+          10, ['/', ['var', 'data_prop'], 0.5]
         ]
       ],
       'states': [
@@ -323,38 +323,39 @@ export const BubbleAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          2, ['/', ['var', 'data_prop'], 2.5],
-          4, ['/', ['var', 'data_prop'], 2.5],
-          5, ['/', ['var', 'data_prop'], 0.8]
+          2, ['/', ['var', 'data_prop'], 4],
+          4, ['/', ['var', 'data_prop'], 2],
+          6, ['/', ['var', 'data_prop'], 1],
+          8, ['/', ['var', 'data_prop'], 0.5]
         ]
       ],
       'cities': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          4, ['/', ['var', 'data_prop'], 16],
-          6, ['/', ['var', 'data_prop'], 8],
-          8, ['/', ['var', 'data_prop'], 2.5],
-          9, ['/', ['var', 'data_prop'], 0.8],
-          10, ['/', ['var', 'data_prop'], 0.8]
+          4, ['/', ['var', 'data_prop'], 4],
+          6, ['/', ['var', 'data_prop'], 3],
+          8, ['/', ['var', 'data_prop'], 2],
+          9, ['/', ['var', 'data_prop'], 1],
+          10, ['/', ['var', 'data_prop'], 0.5]
         ]
       ],
       'tracts': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          7, ['/', ['var', 'data_prop'], 8],
-          10, ['/', ['var', 'data_prop'], 2.5],
-          12, ['/', ['var', 'data_prop'], 0.8]
+          8, ['/', ['var', 'data_prop'], 4],
+          10, ['/', ['var', 'data_prop'], 1],
+          12, ['/', ['var', 'data_prop'], 0.5]
         ]
       ],
       'block-groups': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          7, ['/', ['var', 'data_prop'], 8],
-          10, ['/', ['var', 'data_prop'], 2.5],
-          12, ['/', ['var', 'data_prop'], 0.8]
+          8, ['/', ['var', 'data_prop'], 8],
+          10, ['/', ['var', 'data_prop'], 2],
+          12, ['/', ['var', 'data_prop'], 1]
         ]
       ]
     }
@@ -369,10 +370,11 @@ export const BubbleAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          4, ['/', ['var', 'data_prop'], ['*', 16, 1.5]],
-          6, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
-          8, ['/', ['var', 'data_prop'], ['*', 2.5, 1.5]],
-          9, ['/', ['var', 'data_prop'], ['*', 0.8, 1.5]]
+          4, ['/', ['var', 'data_prop'], ['*', 4, 1.5]],
+          6, ['/', ['var', 'data_prop'], ['*', 3, 1.5]],
+          8, ['/', ['var', 'data_prop'], ['*', 2, 1.5]],
+          9, ['/', ['var', 'data_prop'], ['*', 1, 1.5]],
+          10, ['/', ['var', 'data_prop'], ['*', 0.5, 1.5]]
         ]
       ],
       'states': [
@@ -388,38 +390,39 @@ export const BubbleAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          2, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
-          4, ['/', ['var', 'data_prop'], ['*', 2.5, 1.5]],
-          6, ['/', ['var', 'data_prop'], ['*', 0.8, 1.5]],
-          8, ['/', ['var', 'data_prop'], ['*', 0.4, 1.5]]
+          2, ['/', ['var', 'data_prop'], ['*', 4, 1.5]],
+          4, ['/', ['var', 'data_prop'], ['*', 2, 1.5]],
+          6, ['/', ['var', 'data_prop'], ['*', 1, 1.5]],
+          8, ['/', ['var', 'data_prop'], ['*', 0.5, 1.5]]
         ]
       ],
       'cities': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          4, ['/', ['var', 'data_prop'], ['*', 16, 1.5]],
-          6, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
-          8, ['/', ['var', 'data_prop'], ['*', 2.5, 1.5]],
-          9, ['/', ['var', 'data_prop'], ['*', 0.8, 1.5]]
+          4, ['/', ['var', 'data_prop'], ['*', 4, 1.5]],
+          6, ['/', ['var', 'data_prop'], ['*', 3, 1.5]],
+          8, ['/', ['var', 'data_prop'], ['*', 2, 1.5]],
+          9, ['/', ['var', 'data_prop'], ['*', 1, 1.5]],
+          10, ['/', ['var', 'data_prop'], ['*', 0.5, 1.5]]
         ]
       ],
       'tracts': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          7, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
-          10, ['/', ['var', 'data_prop'], ['*', 2.5, 1.5]],
-          12, ['/', ['var', 'data_prop'], ['*', 0.8, 1.5]]
+          8, ['/', ['var', 'data_prop'], ['*', 4, 1.5]],
+          10, ['/', ['var', 'data_prop'], ['*', 1, 1.5]],
+          12, ['/', ['var', 'data_prop'], ['*', 0.5, 1.5]]
         ]
       ],
       'block-groups': [
         'let', 'data_prop', ['min', 20, ['get', 'PROP']],
         [
           'interpolate', ['linear'], ['zoom'],
-          7, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
-          10, ['/', ['var', 'data_prop'], ['*', 2.5, 1.5]],
-          12, ['/', ['var', 'data_prop'], ['*', 0.8, 1.5]]
+          8, ['/', ['var', 'data_prop'], ['*', 8, 1.5]],
+          10, ['/', ['var', 'data_prop'], ['*', 2, 1.5]],
+          12, ['/', ['var', 'data_prop'], ['*', 1, 1.5]]
         ]
       ]
     }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -12,6 +12,7 @@ import { MapFeature } from './map/map-feature';
 import { MapComponent } from './map/map/map.component';
 import { UiToastComponent } from '../ui/ui-toast/ui-toast.component';
 import { DataService } from '../data/data.service';
+import { PlatformService } from '../platform.service';
 
 // Temporarily adding debounce function here to avoid compilation errors
 // caused by the `debounce-decorator`.  See the following issues for more:
@@ -66,6 +67,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     private router: Router,
     private pageScrollService: PageScrollService,
     private translate: TranslateService,
+    private platform: PlatformService,
     public dataService: DataService,
     @Inject(DOCUMENT) private document: any
   ) {}
@@ -134,6 +136,10 @@ export class MapToolComponent implements OnInit, AfterViewInit {
    * Configures the data service with any static data passed through the route
    */
   setMapToolData(data) {
+    // Set default zoom to 2 on mobile
+    if (this.platform.isMobile) {
+      data.mapConfig.zoom = 2;
+    }
     this.dataService.mapConfig = data.mapConfig;
     if (data.hasOwnProperty('year')) {
       this.dataService.activeYear = data.year;


### PR DESCRIPTION
Closes #300. Lowers the minimum zoom on the map, sets the default zoom to 2 on mobile, and smooths out the bubble scaling zoom expressions. Now they're more even so the bubble will gradually get larger in line with zoom, and then decrease at high zooms for visibility. Before the sizes fluctuated a bit because the expressions weren't quite in line with zoom scaling.