### PR TITLE
Set geom type on bbox polygon

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -245,6 +245,7 @@ export class MapService {
           sf => sf['properties']['GEOID'] === f['properties']['GEOID']
         )[0];
       } else {
+        f.geometry['type'] = 'Polygon';
         f.geometry['coordinates'] = this.bboxPolygon(f.bbox);
         feat = f;
       }


### PR DESCRIPTION
Closes #334. This was a dumb bug where setting the coordinates of a `MultiPolygon` geometry to a `Polygon` without actually changing the type broke the `polylabel` function