### PR TITLE
Switch debounce order to fix loading

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -269,7 +269,7 @@ export class MapComponent implements OnInit, OnChanges {
     this.updateMapData();
     this.map.isLoading$
       .distinctUntilChanged()
-      .debounceTime(200)
+      .debounceTime(500)
       .subscribe((state) => {
         this.mapLoading = state;
         // Whenever map finishes loading, update boundaries

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -268,8 +268,8 @@ export class MapComponent implements OnInit, OnChanges {
     this.updateCensusYear();
     this.updateMapData();
     this.map.isLoading$
-      .debounceTime(200)
       .distinctUntilChanged()
+      .debounceTime(200)
       .subscribe((state) => {
         this.mapLoading = state;
         // Whenever map finishes loading, update boundaries


### PR DESCRIPTION
Fixes #336. Switching the order of debounce and distinct seemed to be enough. I retried your example and it works
![loading](https://user-images.githubusercontent.com/8291663/34280953-5c0f40f0-e689-11e7-84f7-b6a1bc427ecf.gif)
