### PR TITLE
Show indication to scroll on mobile/tablet

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -1,5 +1,9 @@
 <div class="data-wrapper">
   <ng-content></ng-content>
+  <div class="mobile-scroll-indicator">
+    <p *ngIf="locations.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
+    <p *ngIf="locations.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
+  </div>
   <div class="data-header">
       <p [innerHTML]="'DATA.CARD_HEADING' | translate:{'year':year}"></p>
   </div>

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -13,6 +13,12 @@
   border-top: 1px solid #eee;
 }
 
+.mobile-scroll-indicator p {
+  @include dataPanelHeader(14px);
+  text-align: center;
+  margin: grid(1) grid(4);
+}
+
 // Data panel header text
 // ----
 .data-header {
@@ -23,6 +29,7 @@
 // increase spacing for devices larger than tablet
 :host-context(.gt-tablet) {
   .data-header { margin: grid(8) 0 grid(4); }
+  .mobile-scroll-indicator { display: none; }
 }
 
 .data-content {

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -22,6 +22,9 @@ app-progress-bar {
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
   }
+  app-map.cards-active {
+    height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
+  }
   app-data-panel {
     display:block;
     position:relative;
@@ -31,10 +34,26 @@ app-progress-bar {
   }
 }
 
+// Larger than mobile:
+//    Adjust height of map / location cards to reflect large header.
+:host-context(.gt-mobile) {
+  .app-wrapper {
+    app-map {
+      margin-top: $headerHeightLg;
+      height: calc(100vh - #{$headerHeightLg});
+    }
+  }
+  .app-wrapper {
+    app-map.cards-active {
+      height: calc(100vh - #{$headerHeightLg} - #{grid(5)});
+    }
+  }
+}
+
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-mobile) {
+:host-context(.gt-tablet) {
   .app-wrapper {
     app-map {
       margin-top: $headerHeightLg;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -43,7 +43,9 @@
     "ZOOM_HINT": "Zoom for More",
     "LEGEND_HINT": "The colored {{geography}} on the map represent {{attribute}} from {{min}} to {{max}}.",
     "DATA_LINK_SINGLE": "View More Data",
-    "DATA_LINK_MULTIPLE": "View Full Comparison"     
+    "DATA_LINK_MULTIPLE": "View Full Comparison",
+    "SCROLL_DATA_SINGLE": "Scroll for More Data",
+    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison"
   },
   "STATS": {
     "DEMOGRAPHICS": "Demographic Breakdown",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -43,7 +43,9 @@
     "ZOOM_HINT": "Zoom for More",
     "LEGEND_HINT": "{{geography}} = {{attribute}}, {{min}} - {{max}}.",
     "DATA_LINK_SINGLE": "View More Data",
-    "DATA_LINK_MULTIPLE": "View Full Comparison" 
+    "DATA_LINK_MULTIPLE": "View Full Comparison",
+    "SCROLL_DATA_SINGLE": "Scroll for More Data",
+    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison"
   },
   "STATS": {
     "DEMOGRAPHICS": "Desglose Demográfico",


### PR DESCRIPTION
Closes #289. Took a stab at an indication of scrolling on mobile and tablet sizes. I think having it just on the last card could work too, but this seemed more obvious, and we have more space for it

<img width="583" alt="screen shot 2017-12-22 at 12 31 24 pm" src="https://user-images.githubusercontent.com/8291663/34307056-4691dc8e-e714-11e7-898c-5350169d4030.png">

<img width="909" alt="screen shot 2017-12-22 at 12 31 34 pm" src="https://user-images.githubusercontent.com/8291663/34307059-49d895cc-e714-11e7-9c09-6d27fa620ed4.png">

<img width="558" alt="screen shot 2017-12-22 at 12 31 48 pm" src="https://user-images.githubusercontent.com/8291663/34307068-507edb0c-e714-11e7-8d72-bfb2caa3c33e.png">

