### PR TITLE
Float last prop right on mobile cards

### DIFF
--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -140,7 +140,7 @@
       li { 
         float:left; 
         padding-right: grid(2); 
-        max-width: 33.3333%;
+        max-width: 50%;
         span {
           display:block;
           width:100%;
@@ -154,6 +154,8 @@
       li:nth-child(2) { display:none; }
       // show the second stat if there is no selected choropleth
       li:nth-child(2):last-child { display: block; }
+      // On smaller screens, float the latter of two displayed stats to the right
+      li:nth-child(2):last-child, li:nth-child(3) { float: right; }
     }
   }
 }
@@ -163,7 +165,8 @@
   :host-context(.map-ui-wrapper) {
     .location-card {
       .card-content { 
-        li:nth-child(2) { display: block; } 
+        li:nth-child(2) { display: block; }
+        li:nth-child(2):last-child, li:nth-child(3) { float: left; }
       }
     }
   }


### PR DESCRIPTION
Closes #288. If two properties are displayed, float the second to the right, otherwise float the third to the right and still hide the second.

<img width="341" alt="screen shot 2017-12-26 at 10 39 13 am" src="https://user-images.githubusercontent.com/8291663/34359824-40a75bd8-ea29-11e7-9edd-c71db58a937f.png">
<img width="342" alt="screen shot 2017-12-26 at 10 39 22 am" src="https://user-images.githubusercontent.com/8291663/34359826-41f36888-ea29-11e7-9243-3f276f34a59b.png">
