### PR TITLE
Add legend display of graph value

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -52,6 +52,10 @@
             </svg>
             <span class="legend-label">{{ location.properties["n"] }}</span>
             <button class="btn btn-close" (click)="locationRemoved.emit(location)">&times;</button>
+            <p class="legend-data">
+              <span *ngIf="graphType === 'bar'">{{ barYear }}: {{ location.properties[graphProp + "-" + abbrYear(barYear)] >= 0 ? location.properties[graphProp + "-" + abbrYear(barYear)] : "Unavailable" }}</span>
+              <span *ngIf="graphType === 'line' && tooltips[0]">{{ tooltips[0].x }}: {{ location.properties[graphProp + "-" + abbrYear(tooltips[0].x)]>= 0 ? location.properties[graphProp + "-" + abbrYear(tooltips[0].x)] : "Unavailable" }}</span>
+            </p>
           </li>
         </ul>
       </div>

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -213,6 +213,10 @@
       line-height: 24px;
       @include defaultFontBold(18px);
     }
+    .legend-data {
+      margin-left: grid(5);
+      margin-top: grid(1);
+    }
     .btn-close { 
       position:absolute;
       right:0;

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -244,6 +244,8 @@ export class DataPanelComponent implements OnInit, OnChanges {
     }, 1000);
   }
 
+  abbrYear(year) { return year.toString().slice(-2); }
+
   /**
    * Genrates line graph data from the features in `locations`
    */


### PR DESCRIPTION
Progress on #249. Not 100% sure what is in mind here, but I took a stab at updating the legend with the current values. It disappears if nothing is hovered over for the line graph, and shows the currently selected year's value for the bar graph.

The styling isn't the greatest here, but I figured I'd at least make an initial attempt

<img width="1058" alt="screen shot 2017-12-26 at 1 33 03 pm" src="https://user-images.githubusercontent.com/8291663/34362463-c06d1bf6-ea41-11e7-9f36-56e0fc313ff2.png">
<img width="1051" alt="screen shot 2017-12-26 at 1 33 15 pm" src="https://user-images.githubusercontent.com/8291663/34362464-c1c5829a-ea41-11e7-9a99-ea6df81ed253.png">
