### PR TITLE
Use current language for doc export

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -162,7 +162,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
 
   showDownloadDialog(e) {
     const config = {
-      lang: 'en',
+      lang: this.translate.currentLang,
       startYear: this.year,
       endYear: this.lineEndYear,
       features: this.locations


### PR DESCRIPTION
Small update so that the current language is used for document exports rather than just defaulting to English