### PR TITLE
Fix touchend conditional

### DIFF
--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -97,7 +97,7 @@ export class UiSliderComponent implements AfterViewInit {
   }
 
   @HostListener('touchend', ['$event']) onTouchEnd(e) {
-    if (this.pressed && e.touches && e.touches.length === 1) {
+    if (this.pressed) {
       this.updatePosition();
       this.pressed = false;
     }


### PR DESCRIPTION
Closes #235. `touchend` events don't have any actual touch events associated, so the update was never fired. With this fix, `updatePosition()` is now called