### PR TITLE
Add vh padding for software button

### DIFF
--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -34,6 +34,15 @@ app-progress-bar {
   }
 }
 
+// Additional spacing for software button
+:host-context(.software-button) {
+  .app-wrapper {
+    app-map.cards-active {
+      height: calc(100vh - #{$headerHeightSm} - #{grid(12)});
+    }
+  }
+}
+
 // Larger than mobile:
 //    Adjust height of map / location cards to reflect large header.
 :host-context(.gt-mobile) {
@@ -50,6 +59,14 @@ app-progress-bar {
   }
 }
 
+// Additional spacing for software button
+:host-context(.gt-mobile.software-button) {
+  .app-wrapper {
+    app-map.cards-active {
+      height: calc(100vh - #{$headerHeightLg} - #{grid(10)});
+    }
+  }
+}
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -1,4 +1,7 @@
-import { Component, ChangeDetectorRef, OnInit, AfterViewInit, ViewChild, Inject, HostListener } from '@angular/core';
+import {
+  Component, ChangeDetectorRef, OnInit, AfterViewInit, ViewChild, Inject, HostListener,
+  HostBinding
+} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import { PageScrollConfig, PageScrollService, PageScrollInstance } from 'ng2-page-scroll';
@@ -59,6 +62,12 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   }
   @ViewChild(MapComponent) map;
   @ViewChild('divider') dividerEl;
+
+  // Add software-button class if browser is Android or iOS Safari
+  @HostBinding('class.software-button') get softwareButton() {
+    const userAgent = navigator.userAgent.toLowerCase();
+    return userAgent.indexOf('android') > -1 || userAgent.indexOf('safari') > -1;
+  }
   urlParts;
 
   constructor(


### PR DESCRIPTION
Closes #357. Adds additional height padding when the user agent has Android or Safari in it. Doesn't apply to desktop Safari.

<img width="286" alt="screen shot 2018-01-04 at 12 01 11 pm" src="https://user-images.githubusercontent.com/8291663/34577591-46d08db6-f147-11e7-988d-b92dd62f3e1f.png">
<img width="286" alt="screen shot 2018-01-04 at 12 01 37 pm" src="https://user-images.githubusercontent.com/8291663/34577597-4b918742-f147-11e7-9471-af4a4e16b2c4.png">

