### PR TITLE
Generalize geocoder functions, add Mapbox

### DIFF
--- a/src/app/ui/location-search/location-search.component.spec.ts
+++ b/src/app/ui/location-search/location-search.component.spec.ts
@@ -11,7 +11,6 @@ describe('LocationSearchComponent', () => {
   let fixture: ComponentFixture<LocationSearchComponent>;
   const searchServiceStub = {
     queryGeocoder: () => {},
-    getLayerName: () => {},
     query: ''
   };
 

--- a/src/app/ui/location-search/location-search.component.ts
+++ b/src/app/ui/location-search/location-search.component.ts
@@ -21,8 +21,6 @@ export class LocationSearchComponent {
    */
   onSearchSelect(feature) {
     if (feature) {
-      feature.properties['layerId'] =
-        this.search.getLayerName(feature.properties['layer']);
       this.locationSelected.emit(feature);
     }
   }

--- a/src/app/ui/location-search/search/search-sources.ts
+++ b/src/app/ui/location-search/search/search-sources.ts
@@ -36,11 +36,14 @@ export const MapzenSource: SearchSource = {
 };
 
 export const MapboxSource: SearchSource = {
-    key: '',
+    key: 'pk.eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.4et5d5nstXWM5P0JG67XEQ',
     baseUrl: 'https://api.mapbox.com/geocoding/v5/mapbox.places/',
     query: function(text: string) {
         const queryParams = [
-            'country=us', 'autocomplete=true', 'types=region,district,place,locality,address'
+            `access_token=${this.key}`,
+            'country=us',
+            'autocomplete=true',
+            'types=region,district,place,locality,address'
         ];
         return `${this.baseUrl}${text}.json?${queryParams.join('&')}`;
     },
@@ -53,7 +56,7 @@ export const MapboxSource: SearchSource = {
         };
 
         return results['features'].map(r => {
-            r.properties.label = r.matching_place_name;
+            r.properties.label = r.place_name;
             r.properties.layerId = layerMap.hasOwnProperty(r.place_type[0]) ?
                 layerMap[r.place_type[0]] : 'block-groups';
             return r;

--- a/src/app/ui/location-search/search/search-sources.ts
+++ b/src/app/ui/location-search/search/search-sources.ts
@@ -1,0 +1,68 @@
+import { MapFeature } from '../../../map-tool/map/map-feature';
+
+export interface SearchSource {
+    key: string;
+    baseUrl: string;
+    query(text: string): string;
+    results(results: Object): MapFeature[];
+}
+
+export const MapzenSource: SearchSource = {
+    key: 'mapzen-FgUaZ97',
+    baseUrl: 'https://search.mapzen.com/v1/autocomplete?',
+    query: function (text: string): string {
+        const mapzenParams = [
+            'sources=whosonfirst,openstreetmap',
+            'layers=address,localadmin,locality,county,region,postalcode',
+            'boundary.country=USA',
+            'api_key=' + this.key
+        ];
+        return `${this.baseUrl}text=${text}&${mapzenParams.join('&')}`;
+    },
+    results: function(results: Object): MapFeature[] {
+        const layerMap = {
+            'region': 'states',
+            'county': 'counties',
+            'locality': 'cities',
+            'localadmin': 'cities',
+            'postalcode': 'zip-codes'
+        };
+        return results['features'].map(f => {
+            f.properties.layerId = layerMap.hasOwnProperty(f.properties.layer) ?
+                layerMap[f.properties.layer] : 'block-groups';
+            return f;
+        });
+    }
+};
+
+export const OSMNamesSource: SearchSource = {
+    key: 'ECgM5z4CQXQEdoCqJpBt',
+    baseUrl: 'https://geocoder.tilehosting.com/us/q/',
+    query: function (text: string): string {
+        return `${this.baseUrl}${text}.js?key=${this.key}`;
+    },
+    results: function(results: Object): MapFeature[] {
+        return results['results'].map(r => {
+            // Determine layer
+            let layerId = 'cities';
+            if (r.name === r.county) {
+                layerId = 'counties';
+            } else if (r.name === r.state) {
+                layerId = 'states';
+            }
+
+            return {
+                bbox: r.boundingbox,
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [r.lon, r.lat]
+                },
+                properties: {
+                    ...r, layerId: layerId,
+                    label: `${r.name}, ${r.name_suffix}`,
+                }
+            };
+        });
+    }
+};

--- a/src/app/ui/location-search/search/search-sources.ts
+++ b/src/app/ui/location-search/search/search-sources.ts
@@ -35,6 +35,32 @@ export const MapzenSource: SearchSource = {
     }
 };
 
+export const MapboxSource: SearchSource = {
+    key: '',
+    baseUrl: 'https://api.mapbox.com/geocoding/v5/mapbox.places/',
+    query: function(text: string) {
+        const queryParams = [
+            'country=us', 'autocomplete=true', 'types=region,district,place,locality,address'
+        ];
+        return `${this.baseUrl}${text}.json?${queryParams.join('&')}`;
+    },
+    results: function(results: Object) {
+        const layerMap = {
+            'region': 'states',
+            'district': 'cities',
+            'place': 'cities',
+            'locality': 'cities'
+        };
+
+        return results['features'].map(r => {
+            r.properties.label = r.matching_place_name;
+            r.properties.layerId = layerMap.hasOwnProperty(r.place_type[0]) ?
+                layerMap[r.place_type[0]] : 'block-groups';
+            return r;
+        });
+    }
+};
+
 export const OSMNamesSource: SearchSource = {
     key: 'ECgM5z4CQXQEdoCqJpBt',
     baseUrl: 'https://geocoder.tilehosting.com/us/q/',

--- a/src/app/ui/location-search/search/search.service.ts
+++ b/src/app/ui/location-search/search/search.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { SearchSource, MapzenSource } from './search-sources';
+import { SearchSource, MapboxSource } from './search-sources';
 
 @Injectable()
 export class SearchService {
-  source: SearchSource = MapzenSource;
+  source: SearchSource = MapboxSource;
   query: string;
   results: Observable<Object[]>;
 

--- a/src/app/ui/location-search/search/search.service.ts
+++ b/src/app/ui/location-search/search/search.service.ts
@@ -1,25 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-
-const MapzenLayerMap = {
-  'region': 'states',
-  'county': 'counties',
-  'locality': 'cities',
-  'localadmin': 'cities',
-  'postalcode': 'zip-codes'
-};
+import { SearchSource, MapzenSource } from './search-sources';
 
 @Injectable()
 export class SearchService {
-  apiKey = 'mapzen-FgUaZ97';
-  mapzenParams = [
-    'sources=whosonfirst,openstreetmap',
-    'layers=address,localadmin,locality,county,region,postalcode',
-    'boundary.country=USA',
-    'api_key=' + this.apiKey
-  ];
-  mapzenBase = 'https://search.mapzen.com/v1/autocomplete?';
+  source: SearchSource = MapzenSource;
   query: string;
   results: Observable<Object[]>;
 
@@ -33,20 +19,12 @@ export class SearchService {
   }
 
   /**
-   * Queries Mapzen geocoder and returns an observable with results
-   * @param query string to be sent to Mapzen API
+   * Queries geocoder and returns an observable with results
+   * @param query string to be sent to API
    */
   queryGeocoder(query: string): Observable<Object[]> {
-    return this.http.get(`${this.mapzenBase}text=${query}&${this.mapzenParams.join('&')}`)
-      .map(res => res['features']);
-  }
-
-  /**
-   * Accepts a Mapzen layer string, returns the name of the tile layer to query
-   * @param layerStr Mapzen layer name
-   */
-  getLayerName(layerStr: string) {
-    return MapzenLayerMap.hasOwnProperty(layerStr) ? MapzenLayerMap[layerStr] : 'block-groups';
+    return this.http.get(this.source.query(query))
+      .map(res => this.source.results(res));
   }
 
 }


### PR DESCRIPTION
Closes #363. Generalizes the search providers so that any specific geocoder needs to implement the `SearchSource` interface. Also adds Mapbox geocoder. This will make it easier to switch out providers. I added [OSM Names](http://osmnames.org/) as another example, and it could be a potential option since it might be cheaper given that it only does cities, counties, and states. It's through OpenMapTiles

**NOTE:** The Mapbox geocoder doesn't seem to have counties, but since that's not an incredible long list (3,007), we could potentially modify the search source to also go through a static list of counties to produce results.
  