### PR TITLE
Add additional polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5413,6 +5413,11 @@
       "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
+    "intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -6505,7 +6510,7 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "git://github.com/EvictionLab/mapbox-gl-js.git#fc0d2766210a2f428d976706d27ba4e1d119537f",
+      "version": "git://github.com/EvictionLab/mapbox-gl-js.git#ea372d6f818e29fffe39979b94b53dd4763636a4",
       "requires": {
         "@mapbox/gl-matrix": "0.0.1",
         "@mapbox/mapbox-gl-supported": "1.3.0",
@@ -10828,6 +10833,11 @@
       "requires": {
         "minimalistic-assert": "1.0.0"
       }
+    },
+    "web-animations-js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.1.tgz",
+      "integrity": "sha1-Om2bwVGWN3qQ+OKAP6UmIWWwRRA="
     },
     "webdriver-js-extender": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "core-js": "^2.4.1",
     "d3-dsv": "^1.0.8",
     "debounce-decorator": "^1.0.6",
+    "intl": "^1.2.5",
     "lodash.isequal": "^4.5.0",
     "mapbox-gl": "git://github.com/EvictionLab/mapbox-gl-js.git",
     "ng2-page-scroll": "^4.0.0-beta.11",
@@ -45,6 +46,7 @@
     "pbf": "^3.1.0",
     "polylabel": "^1.0.2",
     "rxjs": "^5.5.2",
+    "web-animations-js": "^2.3.1",
     "zone.js": "^0.8.14"
   },
   "devDependencies": {

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -46,7 +46,7 @@ import 'core-js/es7/reflect';
  * Required to support Web Animations `@angular/animation`.
  * Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
  **/
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
 
@@ -65,7 +65,7 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Date, currency, decimal and percent pipes.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
  */
-// import 'intl';  // Run `npm install --save intl`.
+import 'intl';  // Run `npm install --save intl`.
 /**
  * Need to import at least one locale-data with intl.
  */


### PR DESCRIPTION
Adding more polyfills based off of the recommendations of `polyfills.ts`. It looks like Safari 9 has slightly over 1% usage for browsers, so we need `intl`, and Safari and IE in general need `web-animations-js`.