### PR TITLE
Show loading indicator on data, not render

### DIFF
--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -19,7 +19,6 @@ export class MapboxComponent implements AfterViewInit {
   @Output() ready: EventEmitter<any> = new EventEmitter();
   @Output() zoom: EventEmitter<number> = new EventEmitter();
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
-  @Output() render: EventEmitter<any> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   @Output() featureMouseEnter: EventEmitter<any> = new EventEmitter();
   @Output() featureMouseLeave: EventEmitter<any> = new EventEmitter();
@@ -102,10 +101,8 @@ export class MapboxComponent implements AfterViewInit {
         this.hoverChanged.emit(this.activeFeature);
       }
     });
-    this.map.on('render', (e) => {
-      this.render.emit(e);
-      this.mapService.setLoading(!this.map.loaded());
-    });
+    this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
+    this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {
       this.map.on('click', layer, (e) => {
         if (e.features.length) {


### PR DESCRIPTION
Potential fix for #336. You can try out the prototype here http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/dataloading-indicator

Instead of looking for whether the full map has loaded, it's now just looking at whether source data is loaded. It doesn't totally resolve the issue of loading showing up on hover, but it seems much more rare from the testing I've done. I was never able to get the flickering issue, but this could potentially resolve that as well