### PR TITLE
Increase data panel card min-width

### DIFF
--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -382,7 +382,7 @@
   padding: 0 grid(4) grid(6);
   .location-card {
     margin-right: grid(4);
-    min-width: grid(34);
+    min-width: grid(45);
     flex:1;
     &:last-child { margin-right: 0; }
     .card-header svg {


### PR DESCRIPTION
Fixes #364. Using the map card min-width in the data panel causes the text to overflow and change the scroll position on transitions. Increasing the min-width makes sure the text doesn't overflow any more than expected and maintains the scroll position.

![location-card-fix](https://user-images.githubusercontent.com/8291663/34653169-eb7c95cc-f3ad-11e7-8944-e90cc743bfd9.gif)
