### PR TITLE
Min export year is min line year

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -169,7 +169,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
   showDownloadDialog(e) {
     const config = {
       lang: this.translate.currentLang,
-      startYear: this.year,
+      startYear: this.lineStartYear,
       endYear: this.lineEndYear,
       features: this.locations
     };


### PR DESCRIPTION
Closes #376 if we decide to go that way. It seems more intuitive to use the line graph defaults, otherwise if someone selects a feature on the map and exports to a PowerPoint, the default line chart is only for 2016 and 2017