### PR TITLE
Fix software button selector on desktop

### DIFF
--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -70,7 +70,7 @@ app-progress-bar {
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-tablet) {
+:host-context(.gt-tablet), :host-context(.gt-tablet.software-button) {
   .app-wrapper {
     app-map, app-map.cards-active {
       margin-top: $headerHeightLg;


### PR DESCRIPTION
Tweaking CSS on the software button query, because currently `.gt-mobile.software-button` is taking precedence and including the padding even on desktop