### PR TITLE
PowerPoint export format updates

### DIFF
--- a/src/app/map-tool/data-panel/download-form/download-form.component.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.ts
@@ -31,12 +31,16 @@ export class DownloadFormComponent implements OnInit {
       .filter(f => f.checked).map(f => f.value);
     this.exportService.sendFileRequest(filetypes)
       .subscribe(res => {
-        this.loading = false;
         if (!res.hasOwnProperty('path')) {
           console.log(`Error occured: ${res}`);
+          this.loading = false;
         } else {
-          window.location.href = res['path'];
-          this.dismiss({ accepted: true });
+          // Download after slight delay to make sure file is ready
+          setTimeout(() => {
+            window.location.href = res['path'];
+            this.dismiss({ accepted: true });
+            this.loading = false;
+          }, 500);
         }
       });
   }

--- a/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
@@ -40,6 +40,12 @@ describe('FileExportService', () => {
     'should include formats in request if more than one filetype selected',
     inject(
       [FileExportService], (service: FileExportService) => {
+        service.setExportValues({
+          lang: 'en',
+          features: [],
+          startYear: '2001',
+          endYear: '2004'
+        });
         const downloadRequest = service.createDownloadRequest(['pptx', 'xlsx']);
         expect(downloadRequest.formats).toEqual(['pptx', 'xlsx']);
       }

--- a/src/app/map-tool/data-panel/download-form/file-export.service.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.ts
@@ -79,7 +79,7 @@ export class FileExportService {
    */
   createDownloadRequest(fileValues: string[]): DownloadRequest {
     const exportFeatures = this.features.map(f => {
-      f.bbox = bbox(f);
+      if (!f.hasOwnProperty('bbox')) { f.bbox = bbox(f); }
       return f;
     });
     const downloadRequest: DownloadRequest = {

--- a/src/app/map-tool/data-panel/download-form/file-export.service.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { MapFeature } from '../../map/map-feature';
+import * as bbox from '@turf/bbox';
 
 export interface DownloadRequest {
   lang: string;
@@ -77,8 +78,12 @@ export class FileExportService {
    * Create the file request data
    */
   createDownloadRequest(fileValues: string[]): DownloadRequest {
+    const exportFeatures = this.features.map(f => {
+      f.bbox = bbox(f);
+      return f;
+    });
     const downloadRequest: DownloadRequest = {
-      lang: this.lang, years: [this.startYear, this.endYear], features: this.features
+      lang: this.lang, years: [this.startYear, this.endYear], features: exportFeatures
     };
     if (this.filetypes.filter(f => fileValues.indexOf(f.value) !== -1).length > 1) {
       downloadRequest.formats = fileValues;


### PR DESCRIPTION
Progress on #314. Adds a slight delay before downloading exports and adds `bbox` to each one (needed for PowerPoint)