### PR TITLE
Drop parallax for fixed position

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<!-- <app-progress-bar *ngIf="loader.isLoading"></app-progress-bar> -->
+<app-progress-bar *ngIf="loader.isLoading"></app-progress-bar>
 <app-header-bar
   [languageOptions]="dataService.languageOptions"
   [selectedLanguage]="dataService.selectedLanguage"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<app-progress-bar *ngIf="loader.isLoading"></app-progress-bar>
+<!-- <app-progress-bar *ngIf="loader.isLoading"></app-progress-bar> -->
 <app-header-bar
   [languageOptions]="dataService.languageOptions"
   [selectedLanguage]="dataService.selectedLanguage"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,1 +1,8 @@
 app-progress-bar {  top: 0; z-index: 1000;}
+app-header-bar { position: fixed; top:0; left:0; right:0; width:100%; z-index:999;}
+
+app-footer {
+  display:block;
+  position:relative;
+  z-index:998;
+}

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -2,7 +2,6 @@
 
 footer {
   width:100%;
-  margin-top: grid(3);
   background: linear-gradient(180deg, #393939 0%, #2F2D2B 100%);
   padding: grid(6) $pageMargin grid(8);
   color: #fff;

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -11,6 +11,7 @@
 
 .data-wrapper {
   border-top: 1px solid #eee;
+
 }
 
 .mobile-scroll-indicator p {
@@ -38,7 +39,7 @@
   box-sizing: border-box;
   overflow:auto;
   // padding at the bottom to leave space for "back to map" button
-  padding: 0 $defaultPadding grid(12); 
+  padding: 0 $defaultPadding grid(15); 
   .data-content-inner {
     max-width: $maxContentWidth;
     padding: $defaultPadding;

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -36,8 +36,8 @@
         <span *ngIf="dataService.activeFeatures.length > 1">{{ 'MAP.DATA_LINK_MULTIPLE' | translate}}</span>        
         <svg class="down-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline></svg>
       </button>
-      <div *ngIf="!enableZoom" class="show-map-overlay" (click)="goToTop()">
-        <button [style.transform]="'translateY(' + offsetToTranslate(verticalOffset) + 'px)'" class="btn btn-large btn-primary btn-map z1">
+      <div class="show-map-overlay" (click)="goToTop()" [class.hide]="enableZoom">
+        <button #mapButton class="btn btn-large btn-primary btn-map z1" >
           <svg class="up-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline>
           </svg>
@@ -56,7 +56,7 @@
       (locationRemoved)="dataService.removeLocation($event); updateRoute()"
       (locationAdded)="onSearchSelect($event, false)"
   >
-    <button (click)="goToTop()" class="btn btn-large btn-primary btn-map" [class.fixed]="isDataButtonFixed">
+    <button (click)="goToTop()" class="btn btn-large btn-primary btn-map">
       <svg class="up-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <g><polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline></g>
       </svg>

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -10,7 +10,6 @@
     [choroplethOptions]="dataService.dataAttributes"
     [scrollZoom]="enableZoom"
     [activeFeatures]="dataService.activeFeatures"
-    [verticalOffset]="verticalOffset"
     [activeMenuItem]="activeMenuItem"
     [(boundingBox)]="dataService.mapView"
     [(year)]="dataService.activeYear"
@@ -36,8 +35,8 @@
         <span *ngIf="dataService.activeFeatures.length > 1">{{ 'MAP.DATA_LINK_MULTIPLE' | translate}}</span>        
         <svg class="down-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline></svg>
       </button>
-      <div class="show-map-overlay" (click)="goToTop()" [class.hide]="enableZoom">
-        <button #mapButton class="btn btn-large btn-primary btn-map z1" >
+      <div class="show-map-overlay" (click)="goToTop()" [class.inactive]="enableZoom">
+        <button class="btn btn-large btn-primary btn-map z1" >
           <svg class="up-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <polyline points="1 1 6.81226514 6 8.34418334 4.76222126 13 1.00035534"></polyline>
           </svg>

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -107,6 +107,9 @@ app-progress-bar {
     @include fill-parent();
     pointer-events:all;
     z-index:51;
+    &.hide {
+      display:none;
+    }
   }
 }
 .btn-map, 

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -1,12 +1,5 @@
 @import '../../theme';
 
-// Fixed progress bar
-app-progress-bar {
-  position: fixed;
-  top: 0;
-  z-index: 1000;
-}
-
 // Page Layout
 .app-wrapper {
   min-height:100%;
@@ -107,8 +100,13 @@ app-progress-bar {
     @include fill-parent();
     pointer-events:all;
     z-index:51;
-    &.hide {
-      display:none;
+    &.inactive {
+      pointer-events:none;
+    }
+    .btn-map {
+      position:fixed;
+      top:0;
+      bottom:0;
     }
   }
 }
@@ -126,6 +124,7 @@ app-progress-bar {
 // bring button above data panel content
 .btn-map {
   z-index:2;
+  bottom: grid(6);
 }
 .btn-compare {
   pointer-events: all;

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -344,7 +344,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     if (this.verticalOffset < this.panelOffset && !this.enableZoom) {
       window.requestAnimationFrame(() => {
         this.mapButton.nativeElement.style.transform =
-          'translateY(' + this.offsetToTranslate(this.verticalOffset) + 'px)';
+          'translate3d(0, ' + this.offsetToTranslate(this.verticalOffset).toFixed(2) + 'px, 0)';
       });
     }
   }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ChangeDetectorRef, OnInit, AfterViewInit, ViewChild, Inject, HostListener
+  Component, ChangeDetectorRef, OnInit, AfterViewInit, ViewChild, Inject, HostListener, ElementRef
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
@@ -55,13 +55,9 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   panelOffset: number; // tracks the vertical offset to the data panel
   offsetToTranslate; // function that maps vertical offset to the
   activeMenuItem; // tracks the active menu item on mobile
-  /** gets if the page has scrolled enough to fix the "back to map" button */
-  get isDataButtonFixed() {
-    if (!this.panelOffset || !this.verticalOffset) { return false; }
-    return (this.verticalOffset - this.panelOffset) > 0;
-  }
   @ViewChild(MapComponent) map;
-  @ViewChild('divider') dividerEl;
+  @ViewChild('divider') dividerEl: ElementRef;
+  @ViewChild('mapButton') mapButton: ElementRef;
   urlParts;
 
   /**
@@ -111,6 +107,8 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.panelOffset = this.dividerEl.nativeElement.getBoundingClientRect().bottom;
     this.setOffsetToTranslate();
+    // set interval for parallax animation
+    setInterval(this.parallaxMapButton.bind(this), 10);
   }
 
   /**
@@ -340,5 +338,14 @@ export class MapToolComponent implements OnInit, AfterViewInit {
         lonLat: [ parseFloat(locArray[1]), parseFloat(locArray[2]) ]
       };
     }).filter(loc => loc); // filter null values
+  }
+
+  private parallaxMapButton() {
+    window.requestAnimationFrame(() => {
+      if (this.verticalOffset < this.panelOffset && !this.enableZoom) {
+        this.mapButton.nativeElement.style.transform =
+          'translateY(' + this.offsetToTranslate(this.verticalOffset) + 'px)';
+      }
+    });
   }
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -341,11 +341,11 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   }
 
   private parallaxMapButton() {
-    window.requestAnimationFrame(() => {
-      if (this.verticalOffset < this.panelOffset && !this.enableZoom) {
+    if (this.verticalOffset < this.panelOffset && !this.enableZoom) {
+      window.requestAnimationFrame(() => {
         this.mapButton.nativeElement.style.transform =
           'translateY(' + this.offsetToTranslate(this.verticalOffset) + 'px)';
-      }
-    });
+      });
+    }
   }
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -107,8 +107,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.panelOffset = this.dividerEl.nativeElement.getBoundingClientRect().bottom;
     this.setOffsetToTranslate();
-    // set interval for parallax animation
-    setInterval(this.parallaxMapButton.bind(this), 10);
   }
 
   /**
@@ -338,14 +336,5 @@ export class MapToolComponent implements OnInit, AfterViewInit {
         lonLat: [ parseFloat(locArray[1]), parseFloat(locArray[2]) ]
       };
     }).filter(loc => loc); // filter null values
-  }
-
-  private parallaxMapButton() {
-    if (this.verticalOffset < this.panelOffset && !this.enableZoom) {
-      window.requestAnimationFrame(() => {
-        this.mapButton.nativeElement.style.transform =
-          'translate3d(0, ' + this.offsetToTranslate(this.verticalOffset).toFixed(2) + 'px, 0)';
-      });
-    }
   }
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -57,7 +57,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   activeMenuItem; // tracks the active menu item on mobile
   @ViewChild(MapComponent) map;
   @ViewChild('divider') dividerEl: ElementRef;
-  @ViewChild('mapButton') mapButton: ElementRef;
   urlParts;
 
   /**

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -1,6 +1,5 @@
 <div class="map-wrapper" #mapEl>
-  <div class="test-parallax"></div>
-  <!-- <app-mapbox
+  <app-mapbox
     [mapConfig]="mapConfig" 
     [eventLayers]="mapEventLayers"
     (ready)="onMapReady($event)"
@@ -9,7 +8,7 @@
     (hoverChanged)="onFeatureHover($event)"
     (moveEnd)="onMapMoveEnd($event)"
   >
-  </app-mapbox> -->
+  </app-mapbox>
 </div>
 <ng-content></ng-content>
 <div class="map-ui-wrapper">

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -1,6 +1,4 @@
-<div class="map-wrapper" 
-  [style.transform]="'translateY('+ (verticalOffset > 90 ? (verticalOffset-90)/3 : 0) +'px)'"
->
+<div class="map-wrapper" #mapEl>
   <app-mapbox
     [mapConfig]="mapConfig" 
     [eventLayers]="mapEventLayers"

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -1,5 +1,6 @@
 <div class="map-wrapper" #mapEl>
-  <app-mapbox
+  <div class="test-parallax"></div>
+  <!-- <app-mapbox
     [mapConfig]="mapConfig" 
     [eventLayers]="mapEventLayers"
     (ready)="onMapReady($event)"
@@ -8,7 +9,7 @@
     (hoverChanged)="onFeatureHover($event)"
     (moveEnd)="onMapMoveEnd($event)"
   >
-  </app-mapbox>
+  </app-mapbox> -->
 </div>
 <ng-content></ng-content>
 <div class="map-ui-wrapper">

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -1,23 +1,11 @@
 @import '../../../../theme';
 
-.test-parallax {
-  background: repeating-linear-gradient(
-    45deg,
-    #606dbc,
-    #606dbc 10px,
-    #465298 10px,
-    #465298 20px
-  );
-  width:100%;
-  height:100%;
-  display:block;
-}
 
 // Map UI Layout
 // ----
 // Map fills the component width and height
 .map-wrapper {
-  position:absolute;
+  position:fixed;
   top:0;
   width:100%;
   height:100%;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -1,9 +1,24 @@
 @import '../../../../theme';
 
+.test-parallax {
+  background: repeating-linear-gradient(
+    45deg,
+    #606dbc,
+    #606dbc 10px,
+    #465298 10px,
+    #465298 20px
+  );
+  width:100%;
+  height:100%;
+  display:block;
+}
+
 // Map UI Layout
 // ----
 // Map fills the component width and height
 .map-wrapper {
+  position:absolute;
+  top:0;
   width:100%;
   height:100%;
   display:block;

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, OnInit, OnChanges, HostBinding, Input, Output, EventEmitter, SimpleChanges, ViewChild,
-  HostListener
+  HostListener, ElementRef
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/distinctUntilChanged';
@@ -150,6 +150,7 @@ export class MapComponent implements OnInit, OnChanges {
       this.cardsActive;
   }
   @ViewChild('pop') mapTooltip;
+  @ViewChild('mapEl') mapEl: ElementRef;
   tooltipEnabled = true;
   @HostListener('document:click', ['$event']) dismissTooltip() {
     this.mapTooltip.hide();
@@ -196,6 +197,8 @@ export class MapComponent implements OnInit, OnChanges {
     this.updateCardProperties();
     // Show tooltip 1 second after init
     setTimeout(() => { this.mapTooltip.show(); }, 1000);
+    // Update the animation on an interval
+    setInterval(this.parallaxMap.bind(this), 10);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -493,5 +496,18 @@ export class MapComponent implements OnInit, OnChanges {
     this.updateMapBubbles();
     this.updateMapChoropleths();
     this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
+  }
+
+  /** Animate the map based on scroll position */
+  private parallaxMap() {
+    window.requestAnimationFrame(() => {
+      if (window.scrollY > 0 && window.scrollY < window.innerHeight) {
+        this.mapEl.nativeElement.style.transform =
+          'translateY(' + ((window.scrollY - 90) / 3) + 'px)';
+      } else if (window.scrollY <= 0) {
+        this.mapEl.nativeElement.style.transform = 'translateY(0)';
+      }
+    });
+
   }
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -125,8 +125,6 @@ export class MapComponent implements OnInit, OnChanges {
   @Input() layerOptions: MapLayerGroup[] = [];
   /** Handles if zoom is enabled on the map */
   @Input() scrollZoom: boolean;
-  /** Tracks the vertical (scroll) offset */
-  @Input() verticalOffset = 0;
   /** Tracks the currently selected menu item for mobile menu */
   @Input() activeMenuItem: string;
   @Input() activeFeatures: MapFeature[] = [];
@@ -198,7 +196,7 @@ export class MapComponent implements OnInit, OnChanges {
     // Show tooltip 1 second after init
     setTimeout(() => { this.mapTooltip.show(); }, 1000);
     // Update the animation on an interval
-    setInterval(this.parallaxMap.bind(this), 10);
+    // setInterval(this.parallaxMap.bind(this), 10);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -502,10 +500,10 @@ export class MapComponent implements OnInit, OnChanges {
   private parallaxMap() {
     if (window.scrollY < window.innerHeight) {
       window.requestAnimationFrame(() => {
-        if (window.scrollY > 0 && window.scrollY < window.innerHeight) {
+        if (window.scrollY > 0) {
           this.mapEl.nativeElement.style.transform =
-            'translate3d(0,' + ((window.scrollY) / 3).toFixed(2) + 'px,0)';
-        } else if (window.scrollY <= 0) {
+            'translate3d(0,' + (-(window.scrollY) / 2).toFixed(2) + 'px,0)';
+        } else {
           this.mapEl.nativeElement.style.transform = 'translate3d(0,0,0)';
         }
       });

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -500,14 +500,15 @@ export class MapComponent implements OnInit, OnChanges {
 
   /** Animate the map based on scroll position */
   private parallaxMap() {
-    window.requestAnimationFrame(() => {
-      if (window.scrollY > 0 && window.scrollY < window.innerHeight) {
-        this.mapEl.nativeElement.style.transform =
-          'translateY(' + ((window.scrollY - 90) / 3) + 'px)';
-      } else if (window.scrollY <= 0) {
-        this.mapEl.nativeElement.style.transform = 'translateY(0)';
-      }
-    });
-
+    if (window.scrollY < window.innerHeight) {
+      window.requestAnimationFrame(() => {
+        if (window.scrollY > 0 && window.scrollY < window.innerHeight) {
+          this.mapEl.nativeElement.style.transform =
+            'translateY(' + ((window.scrollY - 90) / 3) + 'px)';
+        } else if (window.scrollY <= 0) {
+          this.mapEl.nativeElement.style.transform = 'translateY(0)';
+        }
+      });
+    }
   }
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -196,6 +196,7 @@ export class MapComponent implements OnInit, OnChanges {
     // Show tooltip 1 second after init
     setTimeout(() => { this.mapTooltip.show(); }, 1000);
     // Update the animation on an interval
+    // NOTE: Parallax is disabled on the map for performance, uncomment to re-enable.
     // setInterval(this.parallaxMap.bind(this), 10);
   }
 

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -504,9 +504,9 @@ export class MapComponent implements OnInit, OnChanges {
       window.requestAnimationFrame(() => {
         if (window.scrollY > 0 && window.scrollY < window.innerHeight) {
           this.mapEl.nativeElement.style.transform =
-            'translateY(' + ((window.scrollY - 90) / 3) + 'px)';
+            'translate3d(0,' + ((window.scrollY) / 3).toFixed(2) + 'px,0)';
         } else if (window.scrollY <= 0) {
-          this.mapEl.nativeElement.style.transform = 'translateY(0)';
+          this.mapEl.nativeElement.style.transform = 'translate3d(0,0,0)';
         }
       });
     }


### PR DESCRIPTION
Made a few attempts to cut the jank from the parallax scroll of the map and fix #229 

**Attempt 1: Make parallax animation with CSS only (as per: https://keithclark.co.uk/articles/pure-css-parallax-websites/)**

Requires changing the DOM structure pretty significantly, and doesn't easily allow variable heights on the DOM elements.  Decided this was too difficult to implement for the benefit it would provide.

**Attempt 2: Optimize parallax scrolling by setting an update interval, using `requestAnimationFrame`, rounding values, setting position to fixed (as per: https://medium.com/@dhg/parallax-done-right-82ced812e61c)**

This produces about a ~8-10 FPS improvement when scrolling, but it's still janky.  The map jumps to try and catch up with the scroll position. (preview: http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/parallax-2/)

### Proposed solution: Drop parallax, used `fixed` position to give layered effect.

This is the only jank-free solution I could produce.  Even just running mapboxgl on the page cuts my frame rate to ~40FPS, so adding any transforms on top of that seems to be a recipe for jank.  I think this is a good compromise between design and performance. (preview: http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/parallax-3/)

I have the parallax code in this PR still, but the interval is commented out so it doesn't execute.  We could just uncomment if we decide to turn it on.
