### PR TITLE
Improve map event performance

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -62,10 +62,10 @@ export class MapService {
     this.popup = new mapboxgl.Popup({ closeButton: false });
     this.zone.runOutsideAngular(() => {
       Observable.fromEvent(this.map, 'mousemove')
-        .debounceTime(500)
-        .subscribe(e => this.updateHoverFeature(e, layerIds));
+        .debounceTime(200)
+        .subscribe(e => this.updateHoverTooltip(e, layerIds));
       Observable.fromEvent(this.map, 'mouseout')
-        .debounceTime(500)
+        .debounceTime(200)
         .subscribe(e => this.popup.remove());
     });
   }
@@ -318,7 +318,10 @@ export class MapService {
     ], { padding: 50 });
   }
 
-  private updateHoverFeature(e: any, layerIds: string[]) {
+  /**
+   * Update hover tooltip content
+   */
+  private updateHoverTooltip(e: any, layerIds: string[]) {
     const features = this.map.queryRenderedFeatures(e.point, { layers: layerIds });
     if (features.length) {
       const feat: MapFeature = features[0];

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -154,20 +154,24 @@ export class MapService {
    * @param layerId ID of vector tile layer to query
    * @param feature feature with attributes to query
    */
-  getUnionFeature(layerId: string, feature: MapFeature): GeoJSON.Feature<GeoJSON.Polygon> {
-    return this.map.queryRenderedFeatures(undefined, {
+  getUnionFeature(layerId: string, feature: MapFeature): GeoJSON.Feature<GeoJSON.Polygon> | null {
+    const queryFeatures = this.map.queryRenderedFeatures(undefined, {
       layers: [layerId],
       filter: [
         'all',
         ['==', 'n', feature.properties.n],
         ['==', 'pl', feature.properties.pl]
       ]
-    }).reduce((currFeat, nextFeat) => {
-      return union(
-        currFeat as GeoJSON.Feature<GeoJSON.Polygon>,
-        nextFeat as GeoJSON.Feature<GeoJSON.Polygon>
-      );
-    }) as GeoJSON.Feature<GeoJSON.Polygon>;
+    });
+    if (queryFeatures.length > 0) {
+      return queryFeatures.reduce((currFeat, nextFeat) => {
+        return union(
+          currFeat as GeoJSON.Feature<GeoJSON.Polygon>,
+          nextFeat as GeoJSON.Feature<GeoJSON.Polygon>
+        );
+      }) as GeoJSON.Feature<GeoJSON.Polygon>;
+    }
+    return null;
   }
 
   /**

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/distinct';
+import 'rxjs/add/observable/fromEvent';
 import * as bbox from '@turf/bbox';
 import * as union from '@turf/union';
 import * as polylabel from 'polylabel';
@@ -20,7 +21,7 @@ export class MapService {
   private colors = ['#e24000', '#434878', '#2c897f'];
   get mapCreated() { return this.map !== undefined; }
 
-  constructor() { }
+  constructor(private zone: NgZone) { }
 
   /** Expose any MapboxGL API functions that are needed  */
   // https://www.mapbox.com/mapbox-gl-js/api/#map#setpaintproperty
@@ -59,40 +60,13 @@ export class MapService {
    */
   setupHoverPopup(layerIds: string[]) {
     this.popup = new mapboxgl.Popup({ closeButton: false });
-    this.map.on('mousemove', (e) => {
-      const features = this.map.queryRenderedFeatures(e.point, { layers: layerIds });
-      if (features.length) {
-        const feat: MapFeature = features[0];
-        const labelFeatures = this.map.queryRenderedFeatures(undefined, {
-          layers: [`${feat['layer']['id']}_text`],
-          filter: [
-            'all',
-            ['==', 'n', feat.properties.n],
-          ]
-        });
-        // Check if labels are visible, don't display tooltip if so
-        const labelLayerOpacity = this.map.getPaintProperty(
-          `${feat['layer']['id']}_text`, 'text-opacity'
-        );
-        let labelsVisible;
-        if (labelLayerOpacity) {
-          labelsVisible = labelLayerOpacity['stops'][0][0] >= this.map.getZoom();
-        } else {
-          labelsVisible = false;
-        }
-        if (labelFeatures.length && !labelsVisible && labelLayerOpacity !== 0) {
-          this.popup.remove();
-        } else {
-          this.popup.setLngLat(e.lngLat)
-            .setHTML(`${feat.properties.n}, ${feat.properties.pl}`)
-            .addTo(this.map);
-        }
-      } else {
-        this.popup.remove();
-      }
-    });
-    this.map.on('mouseout', (e) => {
-      this.popup.remove();
+    this.zone.runOutsideAngular(() => {
+      Observable.fromEvent(this.map, 'mousemove')
+        .debounceTime(500)
+        .subscribe(e => this.updateHoverFeature(e, layerIds));
+      Observable.fromEvent(this.map, 'mouseout')
+        .debounceTime(500)
+        .subscribe(e => this.popup.remove());
     });
   }
 
@@ -342,6 +316,39 @@ export class MapService {
       [box[0], box[1]],
       [box[2], box[3]]
     ], { padding: 50 });
+  }
+
+  private updateHoverFeature(e: any, layerIds: string[]) {
+    const features = this.map.queryRenderedFeatures(e.point, { layers: layerIds });
+    if (features.length) {
+      const feat: MapFeature = features[0];
+      const labelFeatures = this.map.queryRenderedFeatures(undefined, {
+        layers: [`${feat['layer']['id']}_text`],
+        filter: [
+          'all',
+          ['==', 'n', feat.properties.n],
+        ]
+      });
+      // Check if labels are visible, don't display tooltip if so
+      const labelLayerOpacity = this.map.getPaintProperty(
+        `${feat['layer']['id']}_text`, 'text-opacity'
+      );
+      let labelsVisible;
+      if (labelLayerOpacity) {
+        labelsVisible = labelLayerOpacity['stops'][0][0] >= this.map.getZoom();
+      } else {
+        labelsVisible = false;
+      }
+      if (labelFeatures.length && !labelsVisible && labelLayerOpacity !== 0) {
+        this.popup.remove();
+      } else {
+        this.popup.setLngLat(e.lngLat)
+          .setHTML(`${feat.properties.n}, ${feat.properties.pl}`)
+          .addTo(this.map);
+      }
+    } else {
+      this.popup.remove();
+    }
   }
 
   /**

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -4,10 +4,10 @@
   <app-mapbox
     [mapConfig]="mapConfig" 
     [eventLayers]="mapEventLayers"
+    [selectedLayer]="selectedLayer"
     (ready)="onMapReady($event)"
     (zoom)="onMapZoom($event)"
     (featureClick)="onFeatureClick($event)"
-    (hoverChanged)="onFeatureHover($event)"
     (moveEnd)="onMapMoveEnd($event)"
   >
   </app-mapbox>

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -338,20 +338,6 @@ export class MapComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Sets the tooltip and highlighted shape on the map
-   * @param feature the feature being hovered (or null if no longer hovering)
-   */
-  onFeatureHover(feature) {
-    this.featureHover.emit(feature);
-    if (feature && feature.layer.id === this.selectedLayer.id) {
-      const union = this.map.getUnionFeature(this.selectedLayer.id, feature);
-      this.map.setSourceData('hover', [union]);
-    } else {
-      this.map.setSourceData('hover');
-    }
-  }
-
-  /**
    * Gets the currently active data attribute with the year appended
    * @param type either 'choropleth' or 'bubble'
    */

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -1,9 +1,10 @@
 import {
-  Component, OnInit, Input, Output, AfterViewInit, EventEmitter, ViewChild, ElementRef
+  Component, OnInit, Input, Output, AfterViewInit, EventEmitter, ViewChild, ElementRef, NgZone
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { MapService } from '../map.service';
 import { MapLayerGroup } from '../../map/map-layer-group';
+import 'rxjs/add/observable/fromEvent';
 
 @Component({
   selector: 'app-mapbox',
@@ -16,16 +17,13 @@ export class MapboxComponent implements AfterViewInit {
   @ViewChild('map') mapEl: ElementRef;
   @Input() mapConfig: Object;
   @Input() eventLayers: Array<string> = [];
+  @Input() selectedLayer: MapLayerGroup;
   @Output() ready: EventEmitter<any> = new EventEmitter();
   @Output() zoom: EventEmitter<number> = new EventEmitter();
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
-  @Output() featureMouseEnter: EventEmitter<any> = new EventEmitter();
-  @Output() featureMouseLeave: EventEmitter<any> = new EventEmitter();
-  @Output() featureMouseMove: EventEmitter<any> = new EventEmitter();
-  @Output() hoverChanged: EventEmitter<any> = new EventEmitter();
 
-  constructor(private mapService: MapService) { }
+  constructor(private mapService: MapService, private zone: NgZone) { }
 
   /**
    * Create map object from mapEl ViewChild
@@ -58,7 +56,6 @@ export class MapboxComponent implements AfterViewInit {
   onMouseLeaveFeature() {
     this.map.getCanvas().style.cursor = '';
     this.activeFeature = null;
-    this.hoverChanged.emit(this.activeFeature);
   }
 
   onMouseMoveFeature(e) {
@@ -70,7 +67,12 @@ export class MapboxComponent implements AfterViewInit {
         this.activeFeature.properties.pl !== feature.properties.pl
       ) {
         this.activeFeature = feature;
-        this.hoverChanged.emit(this.activeFeature);
+        if (feature && feature.layer.id === this.selectedLayer.id) {
+          const union = this.mapService.getUnionFeature(this.selectedLayer.id, feature);
+          this.mapService.setSourceData('hover', [union]);
+        } else {
+          this.mapService.setSourceData('hover');
+        }
       }
     }
   }
@@ -82,9 +84,13 @@ export class MapboxComponent implements AfterViewInit {
   onMapInstance(map) {
     this.map = map;
     this.setupEmitters();
-    this.featureMouseEnter.subscribe(this.onMouseEnterFeature.bind(this));
-    this.featureMouseLeave.subscribe(this.onMouseLeaveFeature.bind(this));
-    this.featureMouseMove.subscribe(this.onMouseMoveFeature.bind(this));
+    this.zone.runOutsideAngular(() => {
+      this.eventLayers.forEach((layer) => {
+        // this.map.on('mouseenter', layer, (e) => this.onMouseEnterFeature());
+        // this.map.on('mouseleave', layer, (e) => this.onMouseLeaveFeature());
+        // this.map.on('mousemove', layer, (e) => this.onMouseMoveFeature(e));
+      });
+    });
     this.ready.emit(this.map);
   }
 
@@ -93,25 +99,20 @@ export class MapboxComponent implements AfterViewInit {
    */
   private setupEmitters() {
     // Emit all zoom end events from map
-    this.map.on('moveend', (e) => { this.moveEnd.emit(e); });
-    this.map.on('zoom', (zoomEvent) => { this.zoom.emit(this.map.getZoom()); });
+    this.map.on('moveend', (e) => this.moveEnd.emit(e));
     // Emit feature on zoom end to account for geography details changing across zooms
-    this.map.on('zoomend', () => {
-      if (this.activeFeature) {
-        this.hoverChanged.emit(this.activeFeature);
-      }
-    });
+    this.map.on('zoomend', () => this.zoom.emit(this.map.getZoom()));
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {
       this.map.on('click', layer, (e) => {
         if (e.features.length) {
           this.featureClick.emit(e.features[0]);
+          this.map.on('mouseenter', layer, (ev) => this.onMouseEnterFeature());
+          this.map.on('mouseleave', layer, (ev) => this.onMouseLeaveFeature());
+          this.map.on('mousemove', layer, (ev) => this.onMouseMoveFeature(e));
         }
       });
-      this.map.on('mouseenter', layer, (e) => { this.featureMouseEnter.emit(e); });
-      this.map.on('mouseleave', layer, (e) => { this.featureMouseLeave.emit(e); });
-      this.map.on('mousemove', layer, (e) => { this.featureMouseMove.emit(e); });
     });
   }
 }


### PR DESCRIPTION
This is a general performance improvement pulling from some of the ideas here https://medium.com/paramsingh-66174/catalysing-your-angular-4-app-performance-9211979075f6

The map hover and zoom events slow things down significantly, and for the most part the consistent events aren't actually needed in Angular. I debounced the hover state updates for both the tooltip and hover outline updates since it's a major draw on the memory. The catch is that now the tooltip doesn't follow the cursor, but unless you're using Chrome at top performance it lags now anyway.

Try it out locally and let me know what you think, but I'm seeing improvements from 3-5 fps to 20-30 while moving the mouse around and panning on the map on Firefox