### PR TITLE
Fix mouseleave bug

### DIFF
--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -23,6 +23,7 @@ export class MapboxComponent implements AfterViewInit {
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   featureMouseMove: EventEmitter<any> = new EventEmitter();
+  featureMouseLeave: EventEmitter<any> = new EventEmitter();
 
   constructor(private mapService: MapService, private zone: NgZone) { }
 
@@ -92,6 +93,9 @@ export class MapboxComponent implements AfterViewInit {
       this.featureMouseMove
         .debounceTime(200)
         .subscribe(e => this.onMouseMoveFeature(e));
+      this.featureMouseLeave
+        .debounceTime(200)
+        .subscribe(e => this.onMouseLeaveFeature());
     });
     this.ready.emit(this.map);
   }
@@ -108,7 +112,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {
       this.map.on('mouseenter', layer, (ev) => this.onMouseEnterFeature());
-      this.map.on('mouseleave', layer, (ev) => this.onMouseLeaveFeature());
+      this.map.on('mouseleave', layer, (ev) => this.featureMouseLeave.emit(ev));
       this.map.on('mousemove', layer, (ev) => this.featureMouseMove.emit(ev));
       this.map.on('click', layer, (e) => {
         if (e.features.length) {


### PR DESCRIPTION
Runs `mouseleave` in same context as `mousemove` to make sure hover state is cleared on the mouse leaving the map.

Current behavior:
![mouseleave-bug](https://user-images.githubusercontent.com/8291663/34774492-2596c150-f5d5-11e7-970f-d344247f7e90.gif)

Fix:
![mouseleave-fix](https://user-images.githubusercontent.com/8291663/34774496-2a2e49c2-f5d5-11e7-841f-12da144ae160.gif)
