### PR TITLE
Update export parameters

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -99,7 +99,6 @@ export class DataPanelComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit() {
-    this.updateLineYears(this.year, this.maxYear);
     this.barYear = this.year;
     this.barYearSelect = this.generateYearArray(this.minYear, this.maxYear);
     // Update graph axis settings on language change

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -169,9 +169,12 @@ export class DataPanelComponent implements OnInit, OnChanges {
   showDownloadDialog(e) {
     const config = {
       lang: this.translate.currentLang,
+      year: this.year,
       startYear: this.lineStartYear,
       endYear: this.lineEndYear,
-      features: this.locations
+      features: this.locations,
+      dataProp: this.dataService.activeDataHighlight.id,
+      bubbleProp: this.dataService.activeBubbleHighlight.id
     };
     this.dialogService.showDownloadDialog(DownloadFormComponent, config);
   }

--- a/src/app/map-tool/data-panel/download-form/file-export.service.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.ts
@@ -5,6 +5,9 @@ import * as bbox from '@turf/bbox';
 
 export interface DownloadRequest {
   lang: string;
+  year: number;
+  dataProp: string;
+  bubbleProp: string;
   years: number[];
   features: MapFeature[];
   formats?: string[];
@@ -23,8 +26,11 @@ export class FileExportService {
   downloadBase = 'https://exports.evictionlab.org';
   lang: string;
   features: MapFeature[];
+  year: number;
   startYear: number;
   endYear: number;
+  dataProp: string;
+  bubbleProp: string;
   description: string;
   filetypes: ExportType[] = [
     {
@@ -62,8 +68,11 @@ export class FileExportService {
   setExportValues(config: Object) {
     this.lang = config['lang'];
     this.features = config['features'];
+    this.year = config['year'];
     this.startYear = config['startYear'];
     this.endYear = config['endYear'];
+    this.dataProp = config['dataProp'];
+    this.bubbleProp = config['bubbleProp'];
   }
 
   /**
@@ -75,7 +84,8 @@ export class FileExportService {
       return f;
     });
     const downloadRequest: DownloadRequest = {
-      lang: this.lang, years: [this.startYear, this.endYear], features: exportFeatures
+      lang: this.lang, year: this.year, years: [this.startYear, this.endYear],
+      features: exportFeatures, dataProp: this.dataProp, bubbleProp: this.bubbleProp
     };
     if (this.filetypes.filter(f => fileValues.indexOf(f.value) !== -1).length > 1) {
       downloadRequest.formats = fileValues;


### PR DESCRIPTION
Closes #391. Adds additional properties needed for PowerPoint export. Also removes the call to `updateLineYears` on init which canceled out the changes in #377 by overriding the `minYear` anyway