### PR TITLE
Remove setTimeout from graph data update, update map loading function call

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -89,6 +89,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
   lineEndYear: number = this.maxYear;
   dollarProps = DollarProps;
   percentProps = PercentProps;
+  private graphTimeout; // tracks if a timeout is set to update graph settings
 
   constructor(
     public dialogService: UiDialogService,
@@ -107,12 +108,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
         this.barGraphSettings : this.lineGraphSettings;
     });
     this.dataService.locations$.subscribe(d => this.setGraphData());
-    // HACK: something with the dimensions is not set correctly when updating settings
-    //    for now, update in timeout until this is fixed
-    setInterval(() => {
-      const settings = this.graphType === 'line' ? this.lineGraphSettings : this.barGraphSettings;
-      this.graphSettings = { ...settings };
-    }, 1250);
+
   }
 
   /**
@@ -209,6 +205,21 @@ export class DataPanelComponent implements OnInit, OnChanges {
       this.graphSettings = this.barGraphSettings;
       this.graphData = [...this.createBarGraphData()];
     }
+    this.setGraphSettings();
+  }
+
+  /**
+   * Sets the settings for the graph
+   * WARNING: something with the dimensions is not set correctly when updating settings
+   *  delaying the update in a timeout seems to fix the issue.
+   */
+  setGraphSettings() {
+    if (this.graphTimeout) { clearTimeout(this.graphTimeout); } // clear timeout if one is set
+    this.graphTimeout = setTimeout(() => {
+      const settings = this.graphType === 'line' ? this.lineGraphSettings : this.barGraphSettings;
+      this.graphSettings = { ...settings };
+      this.graphTimeout = null;
+    }, 1250);
   }
 
   /**

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -107,6 +107,12 @@ export class DataPanelComponent implements OnInit, OnChanges {
         this.barGraphSettings : this.lineGraphSettings;
     });
     this.dataService.locations$.subscribe(d => this.setGraphData());
+    // HACK: something with the dimensions is not set correctly when updating settings
+    //    for now, update in timeout until this is fixed
+    setInterval(() => {
+      const settings = this.graphType === 'line' ? this.lineGraphSettings : this.barGraphSettings;
+      this.graphSettings = { ...settings };
+    }, 1250);
   }
 
   /**
@@ -199,13 +205,9 @@ export class DataPanelComponent implements OnInit, OnChanges {
     if (this.graphType === 'line') {
       this.graphSettings = this.lineGraphSettings;
       this.graphData = [...this.createLineGraphData()];
-      // HACK: something with the dimensions is not set correctly when updating settings
-      //    for now, update in timeout until this is fixed
-      setTimeout(() => { this.graphSettings = { ...this.lineGraphSettings }; }, 1250);
     } else {
       this.graphSettings = this.barGraphSettings;
       this.graphData = [...this.createBarGraphData()];
-      setTimeout(() => { this.graphSettings = { ...this.barGraphSettings }; }, 1250);
     }
   }
 

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -62,10 +62,10 @@ export class MapService {
     this.popup = new mapboxgl.Popup({ closeButton: false });
     this.zone.runOutsideAngular(() => {
       Observable.fromEvent(this.map, 'mousemove')
-        .debounceTime(200)
+        .debounceTime(100)
         .subscribe(e => this.updateHoverTooltip(e, layerIds));
       Observable.fromEvent(this.map, 'mouseout')
-        .debounceTime(200)
+        .debounceTime(100)
         .subscribe(e => this.popup.remove());
     });
   }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -273,8 +273,8 @@ export class MapComponent implements OnInit, OnChanges {
     this.updateCensusYear();
     this.updateMapData();
     this.map.isLoading$
+      .debounceTime(150)
       .distinctUntilChanged()
-      .debounceTime(500)
       .subscribe((state) => {
         this.mapLoading = state;
         // Whenever map finishes loading, update boundaries

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -91,10 +91,10 @@ export class MapboxComponent implements AfterViewInit {
     this.setupEmitters();
     this.zone.runOutsideAngular(() => {
       this.featureMouseMove
-        .debounceTime(200)
+        .debounceTime(100)
         .subscribe(e => this.onMouseMoveFeature(e));
       this.featureMouseLeave
-        .debounceTime(200)
+        .debounceTime(100)
         .subscribe(e => this.onMouseLeaveFeature());
     });
     this.ready.emit(this.map);


### PR DESCRIPTION
This seems to fix the main performance bottlenecks for me. It looks like this problem was introduced in #351 with the "soft update" for locations. That causes `setGraphData` to be called much more frequently, and each time that method is called it creates a new `setTimeout`. This was causing memory problems because of a bunch of abandoned timeouts, and matches up with seeing errors about `setTimeout` on Chrome as well as the garbage collection errors on Firefox.

EDIT: Also fixing the debounce statement for the map loading, which wasn't using `distinctUntilChanged` correctly. Reducing the debounce times now that performance seems better

Let me know if you're getting the same fix with this locally, but I think it should handle it