### PR TITLE
Use display instead of ngIf for data panel

### DIFF
--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -49,7 +49,7 @@
   <div #divider></div>
   <app-data-panel
       id="data-panel"
-      *ngIf="dataService.activeFeatures.length > 0"
+      [style.display]="dataService.activeFeatures.length > 0 ? 'inherit' : 'none'"
       [year]="dataService.activeYear"
       [locations]="dataService.activeFeatures" 
       (locationRemoved)="dataService.removeLocation($event); updateRoute()"

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -23,6 +23,7 @@ export class DataServiceStub {
   get bubbleAttributes() { return BubbleAttributes; }
   activeYear = 2010;
   activeFeatures = [];
+  locations$ = Observable.of([]);
   activeDataLevel = DataLevels[0];
   activeDataHighlight = DataAttributes[0];
   activeBubbleHighlight = BubbleAttributes[0];


### PR DESCRIPTION
Closes #410. It's a little alarming how much of a difference it makes. It's not always super visible because we're talking about fractions of a second, but here's a waterfall chart on Firefox for clicking on the first feature currently (with `ngIf`):

<img width="497" alt="screen shot 2018-01-11 at 9 56 11 am" src="https://user-images.githubusercontent.com/8291663/34833822-f7be24a8-f6b5-11e7-8261-0b2377b36545.png">

Here it is after this change to `style.display`:

<img width="497" alt="screen shot 2018-01-11 at 9 55 31 am" src="https://user-images.githubusercontent.com/8291663/34833839-02d31db2-f6b6-11e7-94b1-6b03c05a4c87.png">

The click event itself takes a bit less time, there's significantly less time spent on updating styles, and in general the worst case scenario for performance isn't as bad in this case.
