### PR TITLE
Fix card transitions

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
 import { TranslateModule, TranslateLoader, TranslatePipe } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ToastModule } from 'ng2-toastr';
+import { ToastModule, ToastOptions } from 'ng2-toastr';
 
 // local imports
 import { AppComponent } from './app.component';
@@ -24,6 +24,12 @@ import { LoadingService } from './loading.service';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+export class CustomOption extends ToastOptions {
+  showCloseButton = true;
+  positionClass = 'toast-bottom-left';
+  maxShown = 1;
 }
 
 @NgModule({
@@ -48,7 +54,12 @@ export function createTranslateLoader(http: HttpClient) {
     TooltipModule.forRoot(),
     ToastModule.forRoot()
   ],
-  providers: [ PlatformService, DataService, LoadingService ],
+  providers: [
+    PlatformService,
+    DataService,
+    LoadingService,
+    {provide: ToastOptions, useClass: CustomOption}
+  ],
   bootstrap: [AppComponent],
   entryComponents: [ MapToolComponent, RankingToolComponent ]
 })

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -192,6 +192,9 @@ export class DataService {
    * @returns feature if one is removed to make room for the new one, null if not
    */
   addLocation(feature): MapFeature {
+    const exists = this.activeFeatures
+      .find(f => f.properties.GEOID === feature.properties.GEOID);
+    if (exists) { return null; }
     // Process feature if bbox and layerId not included based on current data level
     if (!(feature.properties.bbox && feature.properties.bbox)) {
       feature = this.processMapFeature(feature);

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -189,7 +189,7 @@ export class DataService {
   /**
    * Adds or updates a location to the cards and data panel
    * @param feature the feature for the corresponding location to add
-   * @returns feature if one is removed to make room for the new one, null if not
+   * @returns boolean based on if the max number of locations is reached or not
    */
   addLocation(feature): boolean {
     const exists = this.activeFeatures

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -191,7 +191,7 @@ export class DataService {
    * @param feature the feature for the corresponding location to add
    * @returns feature if one is removed to make room for the new one, null if not
    */
-  addLocation(feature): MapFeature {
+  addLocation(feature): boolean {
     const exists = this.activeFeatures
       .find(f => f.properties.GEOID === feature.properties.GEOID);
     if (exists) { return null; }
@@ -199,11 +199,12 @@ export class DataService {
     if (!(feature.properties.bbox && feature.properties.bbox)) {
       feature = this.processMapFeature(feature);
     }
-    const removedLocation =
-      (this.activeFeatures.length < 3) ? null : this.activeFeatures.shift();
-    this.activeFeatures = [...this.activeFeatures, feature];
-    this._locations.next(this.activeFeatures);
-    return removedLocation;
+    const maxLocations = (this.activeFeatures.length >= 3);
+    if (!maxLocations) {
+      this.activeFeatures = [...this.activeFeatures, feature];
+      this._locations.next(this.activeFeatures);
+    }
+    return maxLocations;
   }
 
   /**

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,8 +1,4 @@
-<div id="top" 
-  class="app-wrapper" 
-  [class.map-active]="dataService.activeFeatures.length === 0" 
-  [class.data-active]="dataService.activeFeatures.length > 0"
->
+<div id="top" class="app-wrapper">
   <app-map
     [mapConfig]="dataService.mapConfig"
     [bubbleOptions]="dataService.bubbleAttributes"

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -105,8 +105,8 @@
     }
     .btn-map {
       position:fixed;
-      top:0;
-      bottom:0;
+      top:grid(20);
+      bottom:auto;
     }
   }
 }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -140,7 +140,7 @@
 
 :host-context(.gt-tablet) {
   .map-overlay .btn-compare { display:block; }
-  .map-overlay {
+  .slider-active .map-overlay {
     height: calc(100% - #{$timeSliderLg});
   }
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -11,9 +11,9 @@ import 'rxjs/add/operator/first';
 import 'rxjs/add/observable/combineLatest';
 import {scaleLinear} from 'd3-scale';
 import { TranslateService, TranslatePipe, TranslateDirective } from '@ngx-translate/core';
-import { ToastsManager } from 'ng2-toastr';
-import { LoadingService } from '../loading.service';
+import { ToastsManager, ToastOptions } from 'ng2-toastr';
 
+import { LoadingService } from '../loading.service';
 import { MapFeature } from './map/map-feature';
 import { MapComponent } from './map/map/map.component';
 import { DataService } from '../data/data.service';
@@ -39,7 +39,7 @@ export function debounce(delay: number = 300): MethodDecorator {
 @Component({
   selector: 'app-map-tool',
   templateUrl: './map-tool.component.html',
-  styleUrls: ['./map-tool.component.scss']
+  styleUrls: ['./map-tool.component.scss'],
 })
 export class MapToolComponent implements OnInit, AfterViewInit {
   title = 'Eviction Lab - Map';
@@ -55,7 +55,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   @ViewChild(MapComponent) map;
   @ViewChild('divider') dividerEl: ElementRef;
   urlParts;
-  private removeToastShown = false;
 
   constructor(
     public loader: LoadingService,
@@ -189,13 +188,11 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   onFeatureSelect(feature: MapFeature) {
     const featureLonLat = this.dataService.getFeatureLonLat(feature);
     this.loader.start('feature');
-    const removedLocation = this.dataService.addLocation(feature);
-    if (removedLocation && !this.removeToastShown) {
+    const maxLocations = this.dataService.addLocation(feature);
+    if (maxLocations) {
       this.toast.error(
-        'The card for ' + removedLocation.properties.n + ' has been removed. ' +
-        'Only 3 locations can be active at once.'
+        'Maximum limit reached. Please remove a location to add another.'
       );
-      this.removeToastShown = true;
     }
     this.dataService.getTileData(feature['layer']['id'], featureLonLat, null, true)
       .subscribe(data => {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -191,7 +191,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     this.loader.start('feature');
     const removedLocation = this.dataService.addLocation(feature);
     if (removedLocation && !this.removeToastShown) {
-      this.toast.warning(
+      this.toast.error(
         'The card for ' + removedLocation.properties.n + ' has been removed. ' +
         'Only 3 locations can be active at once.'
       );

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -39,7 +39,7 @@ export function debounce(delay: number = 300): MethodDecorator {
 @Component({
   selector: 'app-map-tool',
   templateUrl: './map-tool.component.html',
-  styleUrls: ['./map-tool.component.scss'],
+  styleUrls: ['./map-tool.component.scss']
 })
 export class MapToolComponent implements OnInit, AfterViewInit {
   title = 'Eviction Lab - Map';

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -14,6 +14,7 @@
 <div class="map-ui-wrapper">
   <app-ui-map-legend *ngIf="showLegend" [choropleth]="selectedChoropleth" [bubbles]="selectedBubble" [layer]="selectedLayer"></app-ui-map-legend>   
   <app-location-cards
+    [collapsible]="gtTablet"
     [class.cards-2]="activeFeatures.length === 2"
     [class.cards-3]="activeFeatures.length === 3"
     [class.no-census-data]="!selectedChoropleth || selectedChoropleth.id.includes('none')"

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -14,7 +14,6 @@
 <div class="map-ui-wrapper">
   <app-ui-map-legend *ngIf="showLegend" [choropleth]="selectedChoropleth" [bubbles]="selectedBubble" [layer]="selectedLayer"></app-ui-map-legend>   
   <app-location-cards
-    *ngIf="activeFeatures.length > 0"
     [class.cards-2]="activeFeatures.length === 2"
     [class.cards-3]="activeFeatures.length === 3"
     [class.no-census-data]="!selectedChoropleth || selectedChoropleth.id.includes('none')"

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -105,6 +105,9 @@ app-location-cards {
   align-items: flex-end;
   width:100%;
   overflow:auto;
+  &.no-cards {
+    height: 0;
+  }
 }
 // greater than tablet:
 //    Adjust cards container to account for the larger header height

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -124,36 +124,14 @@ app-location-cards {
         // position:absolute;
         // margin:auto;
         // top:0;bottom:0;left:0;right:auto;
-        transform: translateX(0);
         transition: transform 0.2s ease;
         transform: translateX(0);
         position:relative;
       }
       .location-card:nth-child(1) { z-index: 17; }
       .location-card:nth-child(2) { z-index: 18; margin-left: -200px; }
-      .location-card:nth-child(3) { z-index: 19; margin-left: -200px; }      
-    }
-    &.cards-2 {
-      ::ng-deep {
-        .location-card:nth-child(1) { transform: translateX(7%); }
-        .location-card:nth-child(2) { transform: translateX(0); }
-      }
-      &.expanded ::ng-deep {
-        .location-card:nth-child(1) { transform: translateX(0%); }
-        .location-card:nth-child(2) { transform: translateX(100%); }
-      }
-    }
-    &.cards-3 {
-      ::ng-deep {
-        .location-card:nth-child(1) { transform: translateX(15%);}
-        .location-card:nth-child(2) { transform: translateX(7%); }
-        .location-card:nth-child(3) { transform: translateX(0); }
-      }
-      &.expanded ::ng-deep {
-        .location-card:nth-child(1) { transform: translateX(0%); }
-        .location-card:nth-child(2) { transform: translateX(100%); }
-        .location-card:nth-child(3) { transform: translateX(200%); }
-      }
+      .location-card:nth-child(3) { z-index: 19; margin-left: -200px; }
+      .location-card:nth-child(4) { z-index: 20; margin-left: -200px; }
     }
   }
 }

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -7,6 +7,7 @@ import { MapboxComponent } from '../mapbox/mapbox.component';
 import { UiModule } from '../../../ui/ui.module';
 import { MapService } from '../map.service';
 import { LoadingService } from '../../../loading.service';
+import { PlatformService } from '../../../platform.service';
 
 class MapServiceStub {
   updateCensusSource() {}
@@ -26,7 +27,11 @@ describe('MapComponent', () => {
     });
     TestBed.overrideComponent(MapComponent, {
       set: {
-        providers: [ {provide: MapService, useValue: new MapServiceStub() }, LoadingService ],
+        providers: [
+          PlatformService,
+          { provide: MapService, useValue: new MapServiceStub() },
+          LoadingService
+        ],
       }
     })
     .compileComponents();

--- a/src/app/ui/location-cards/location-cards.component.html
+++ b/src/app/ui/location-cards/location-cards.component.html
@@ -1,4 +1,8 @@
-<div @fadeIn *ngFor="let f of features" class="location-card card" (mouseenter)="expanded = true" (mouseleave)="expanded = false">
+<div 
+  [@cards]="'card' + (expanded ? '-e-' : '-') + (i+1) + '-' + features.length" 
+  *ngFor="let f of features; let i = index" 
+  [class]="'location-card card card-' + i"
+>
   <div class="card-header" [class.clickable]="clickedHeader.observers.length > 0" (click)="clickedHeader.emit(f)">
     <svg class="marker" viewBox="0 0 40 58" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <path d="M20,0 C29.8203125,0 40,6.75551115 40,19.0800608 C40,27.2964272 33.3333333,40.2697402 20,58 C6.66666667,40.3015304 3.48313052e-16,27.3282173 0,19.0800608 C0,6.70782593 10.1796875,0 20,0 Z M19.5,29.7038377 C24.4705627,29.7038377 28.5,25.6678161 28.5,20.6891311 C28.5,15.7104461 24.4705627,11.6744245 19.5,11.6744245 C14.5294373,11.6744245 10.5,15.7104461 10.5,20.6891311 C10.5,25.6678161 14.5294373,29.7038377 19.5,29.7038377 Z" id="Combined-Shape"></path>

--- a/src/app/ui/location-cards/location-cards.component.html
+++ b/src/app/ui/location-cards/location-cards.component.html
@@ -1,5 +1,5 @@
 <div 
-  [@cards]="'card' + (expanded ? '-e-' : '-') + (i+1) + '-' + features.length" 
+  [@cards]="getCardState(i+1)" 
   *ngFor="let f of features; let i = index" 
   [class]="'location-card card card-' + i"
 >

--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -50,7 +50,7 @@
       bottom:-1*$cardBarHeight;
       left:0;
       height: $cardBarHeight;
-      width:100%
+      width:100%;
     }
   }
   .card-heading { 

--- a/src/app/ui/location-cards/location-cards.component.ts
+++ b/src/app/ui/location-cards/location-cards.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter, HostBinding } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, HostListener } from '@angular/core';
 import { trigger, transition, style, animate, state } from '@angular/animations';
 import { DecimalPipe } from '@angular/common';
 @Component({
@@ -6,15 +6,43 @@ import { DecimalPipe } from '@angular/common';
   templateUrl: './location-cards.component.html',
   styleUrls: ['./location-cards.component.scss'],
   animations: [
-    trigger('fadeIn', [
+    trigger('cards', [
+      state('card-1-1', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-1-2', style({ transform: 'translate3d(7%,0,0)' })),
+      state('card-1-3', style({ transform: 'translate3d(15%,0,0)' })),
+      state('card-e-1-1', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-e-1-2', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-e-1-3', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-2-2', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-2-3', style({ transform: 'translate3d(7%,0,0)' })),
+      state('card-e-2-2', style({ transform: 'translate3d(100%,0,0)' })),
+      state('card-e-2-3', style({ transform: 'translate3d(100%,0,0)' })),
+      state('card-3-3', style({ transform: 'translate3d(0%,0,0)' })),
+      state('card-e-3-3', style({ transform: 'translate3d(200%,0,0)' })),
+      transition('void => card-3-3', [
+        style({ opacity: '0', transform: 'translate3d(-100%,0,0)' }),
+        animate('0.4s 0.2s ease-in', style({ opacity: '1', transform: 'translate3d(0%, 0%, 0)' }))
+      ]),
+      transition('card-1-3 => void', [
+        animate('1s ease-out', style({ opacity: '0', transform: 'translate3d(100%, 0%, 0)' }))
+      ]),
+      transition('card-e-3-3 => void', [
+        animate('0.4s ease-out', style({ opacity: '0', transform: 'translate3d(200%, 50%, 0)' }))
+      ]),
+      transition('card-e-2-3 => void', [
+        animate('0.4s ease-out', style({ opacity: '0', transform: 'translate3d(100%, 50%, 0)' }))
+      ]),
+      transition('card-e-2-2 => void', [
+        animate('0.4s ease-out', style({ opacity: '0', transform: 'translate3d(100%, 50%, 0)' }))
+      ]),
       transition(':enter', [
-        style({ opacity: '0', transform: 'translateX(-100%)' }),
-        animate('0.2s ease-out', style({ opacity: '1', transform: 'translateX(0)' }))
+        style({ opacity: '0', transform: 'translate3d(-100%,0,0)' }),
+        animate('0.2s ease-in', style({ opacity: '1', transform: 'translate3d(0,0,0)' }))
       ]),
       transition(':leave', [
         style({ opacity: '1' }),
-        animate('0.2s ease-out', style({ opacity: '0', transform: 'translateX(-100%)' })),
-      ]),
+        animate('0.4s ease-out', style({ opacity: '0', transform: 'translate3d(0,50%,0)' })),
+      ])
     ])
   ],
 })
@@ -35,22 +63,27 @@ export class LocationCardsComponent {
   @Output() dismissedCard = new EventEmitter();
   @Output() locationAdded = new EventEmitter();
   @Output() clickedHeader = new EventEmitter();
-  @HostBinding('class.expanded') expanded = false;
+  expanded = false;
   clickHeader = false;
   cardPropertyKeys: Array<string>;
   get abbrYear() { return this.year.toString().slice(-2); }
   private _cardProps;
-  constructor() { }
+  private collapseTimeout = null;
+
+  @HostListener('mouseenter', ['$event']) onmouseenter(e) {
+    this.expandCards();
+  }
+
+  @HostListener('mouseleave', ['$event']) onmouseleave(e) {
+    this.collapseCards();
+  }
 
   /**
    * Return $ or other prefix if in property list
    * @param prop
    */
   prefix(prop: string) {
-    if (this.dollarProps.indexOf(prop) !== -1) {
-      return '$';
-    }
-    return null;
+    return (this.dollarProps.indexOf(prop) !== -1) ? '$' : null;
   }
 
   /**
@@ -58,10 +91,16 @@ export class LocationCardsComponent {
    * @param prop
    */
   suffix(prop: string) {
-    if (this.percentProps.indexOf(prop) !== -1) {
-      return '%';
-    }
-    return null;
+    return (this.percentProps.indexOf(prop) !== -1) ? '%' : null;
+  }
+
+  expandCards() {
+
+    this.expanded = true;
+  }
+
+  collapseCards() {
+    this.expanded = false;
   }
 
 }

--- a/src/app/ui/location-cards/location-cards.component.ts
+++ b/src/app/ui/location-cards/location-cards.component.ts
@@ -52,6 +52,7 @@ export class LocationCardsComponent implements OnInit {
   @Input() dollarProps: Array<string>;
   @Input()
   set cardProperties(value) {
+    if (!value) { return; }
     this._cardProps = value;
     this.cardPropertyKeys = Object.keys(value);
   }

--- a/src/app/ui/location-cards/location-cards.component.ts
+++ b/src/app/ui/location-cards/location-cards.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, Input, Output, EventEmitter, HostListener } from '@angular/core';
+import {
+  Component, OnInit, Input, Output, EventEmitter, HostBinding, HostListener
+} from '@angular/core';
 import { trigger, transition, style, animate, state } from '@angular/animations';
 import { DecimalPipe } from '@angular/common';
 @Component({
@@ -19,10 +21,6 @@ import { DecimalPipe } from '@angular/common';
       state('card-e-2-3', style({ transform: 'translate3d(100%,0,0)' })),
       state('card-3-3', style({ transform: 'translate3d(0%,0,0)' })),
       state('card-e-3-3', style({ transform: 'translate3d(200%,0,0)' })),
-      transition('void => card-3-3', [
-        style({ opacity: '0', transform: 'translate3d(-100%,0,0)' }),
-        animate('0.4s 0.2s ease-in', style({ opacity: '1', transform: 'translate3d(0%, 0%, 0)' }))
-      ]),
       transition('card-1-3 => void', [
         animate('1s ease-out', style({ opacity: '0', transform: 'translate3d(100%, 0%, 0)' }))
       ]),
@@ -46,9 +44,9 @@ import { DecimalPipe } from '@angular/common';
     ])
   ],
 })
-export class LocationCardsComponent {
+export class LocationCardsComponent implements OnInit {
   @Input() allowAddLocation = false;
-  @Input() features: Array<any>;
+  @Input() features: Array<any> = [];
   @Input() year = 2010;
   @Input() percentProps: Array<string>;
   @Input() dollarProps: Array<string>;
@@ -60,22 +58,36 @@ export class LocationCardsComponent {
   get cardProperties() {
     return this._cardProps;
   }
+  @Input() collapsible = false;
   @Output() dismissedCard = new EventEmitter();
   @Output() locationAdded = new EventEmitter();
   @Output() clickedHeader = new EventEmitter();
-  expanded = false;
+  @HostBinding('class.no-cards') get noCards() {
+    return this.features.length === 0;
+  }
+  expanded = true;
   clickHeader = false;
   cardPropertyKeys: Array<string>;
   get abbrYear() { return this.year.toString().slice(-2); }
   private _cardProps;
-  private collapseTimeout = null;
 
-  @HostListener('mouseenter', ['$event']) onmouseenter(e) {
-    this.expandCards();
+  ngOnInit() {
+    if (this.collapsible) { this.expanded = false; }
   }
 
+  /** Expand cards on mouse enter */
+  @HostListener('mouseenter', ['$event']) onmouseenter(e) {
+    this.expanded = true;
+  }
+
+  /** Collapse cards on mouse leave, if enabled */
   @HostListener('mouseleave', ['$event']) onmouseleave(e) {
-    this.collapseCards();
+    this.expanded = this.collapsible ? false : true;
+  }
+
+  getCardState(cardNum: number) {
+    return this.collapsible ?
+      'card' + (this.expanded ? '-e-' : '-') + cardNum + '-' + this.features.length : 'card';
   }
 
   /**
@@ -92,15 +104,6 @@ export class LocationCardsComponent {
    */
   suffix(prop: string) {
     return (this.percentProps.indexOf(prop) !== -1) ? '%' : null;
-  }
-
-  expandCards() {
-
-    this.expanded = true;
-  }
-
-  collapseCards() {
-    this.expanded = false;
   }
 
 }

--- a/src/theme/base/toast.scss
+++ b/src/theme/base/toast.scss
@@ -74,8 +74,8 @@ button.toast-close-button {
   bottom: 12px;
 }
 .toast-bottom-left {
-  bottom: 12px;
-  left: 12px;
+  bottom: 104px;
+  left: 16px;
 }
 #toast-container {
   pointer-events: none;


### PR DESCRIPTION
Fixes card transitions so they down flip around when dismissing, which closes #312 

![dismiss-transition](https://user-images.githubusercontent.com/21034/34884508-2e484584-f77a-11e7-9955-3c1b5415e6de.gif)


Also moves the toast message to the bottom left of the screen.

![image](https://user-images.githubusercontent.com/21034/34884500-292b5280-f77a-11e7-9982-d3a5ad23deb8.png)
