### PR TITLE
Style/mapbox style cleanup

### DIFF
--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1171,9 +1171,6 @@
       "source-layer": "block-groups",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {
-        "fill-color": "rgba(67,72,120,0.7)"
       }
     },
     {
@@ -1220,34 +1217,6 @@
       "source-layer": "tracts",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {
-        "fill-color": {
-          "property": "pr-10",
-          "default": "rgba(0, 0, 0, 0)",
-          "stops": [
-            [
-              0,
-              "rgba(215, 227, 244, 0.7)"
-            ],
-            [
-              7,
-              "rgba(170, 191, 226, 0.75)"
-            ],
-            [
-              13,
-              "rgba(133, 157, 204, 0.8)"
-            ],
-            [
-              20,
-              "rgba(81, 101, 165, 0.85)"
-            ],
-            [
-              26,
-              "rgba(37, 51, 132, 0.9)"
-            ]
-          ]
-        }
       }
     },
     {
@@ -1294,9 +1263,6 @@
       "source-layer": "counties",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {
-        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {
@@ -1741,236 +1707,12 @@
       }
     },
     {
-      "id": "place_state",
-      "type": "symbol",
-      "source": "openmaptiles",
-      "source-layer": "place",
-      "minzoom": 3,
-      "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "class",
-          "state"
-        ]
-      ],
-      "layout": {
-        "visibility": "none",
-        "text-field": "{name_en}",
-        "text-font": {
-          "stops": [
-            [
-              4,
-              [
-                "Metropolis+Medium"
-              ]
-            ],
-            [
-              5,
-              [
-                "Metropolis+Medium"
-              ]
-            ]
-          ]
-        },
-        "text-transform": {
-          "stops": [
-            [
-              4,
-              "uppercase"
-            ],
-            [
-              5,
-              "uppercase"
-            ]
-          ]
-        },
-        "text-size": {
-          "stops": [
-            [
-              4,
-              11
-            ],
-            [
-              5,
-              13
-            ]
-          ]
-        },
-        "text-letter-spacing": 0.1,
-        "text-justify": "center",
-        "text-anchor": "top",
-        "icon-allow-overlap": true,
-        "icon-ignore-placement": false,
-        "text-padding": 2
-      },
-      "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 0.7)",
-        "text-halo-width": {
-          "stops": [
-            [
-              5,
-              2
-            ],
-            [
-              6,
-              2.5
-            ]
-          ]
-        },
-        "text-halo-blur": 0,
-        "icon-color": "rgba(57, 57, 57, 1)",
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(255, 255, 255, 0)",
-        "text-opacity": {
-          "stops": [
-            [
-              4,
-              1
-            ],
-            [
-              5,
-              0.7
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "place_country_other",
-      "type": "symbol",
-      "source": "openmaptiles",
-      "source-layer": "place",
-      "maxzoom": 8,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "class",
-            "country"
-          ],
-          [
-            ">=",
-            "rank",
-            2
-          ]
-        ]
-      ],
-      "layout": {
-        "visibility": "none",
-        "text-field": "{name_en}",
-        "text-font": [
-          "Metropolis+Medium"
-        ],
-        "text-transform": "uppercase",
-        "text-size": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              10
-            ],
-            [
-              6,
-              12
-            ]
-          ]
-        }
-      },
-      "paint": {
-        "text-halo-width": 1.4,
-        "text-halo-color": "rgba(236,236,234,0.7)",
-        "text-color": "rgba(49, 53, 62, 1)"
-      }
-    },
-    {
-      "id": "place_country_major",
-      "type": "symbol",
-      "source": "openmaptiles",
-      "source-layer": "place",
-      "minzoom": 0,
-      "maxzoom": 4,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "all",
-          [
-            "<=",
-            "rank",
-            1
-          ],
-          [
-            "==",
-            "class",
-            "country"
-          ]
-        ]
-      ],
-      "layout": {
-        "visibility": "none",
-        "text-field": "{name_en}",
-        "text-font": [
-          "Metropolis+Medium"
-        ],
-        "text-transform": "uppercase",
-        "text-size": {
-          "base": 1.4,
-          "stops": [
-            [
-              0,
-              10
-            ],
-            [
-              3,
-              15
-            ],
-            [
-              4,
-              14
-            ]
-          ]
-        },
-        "text-anchor": "center",
-        "text-letter-spacing": 0.1,
-        "text-allow-overlap": true,
-        "text-ignore-placement": false
-      },
-      "paint": {
-        "text-halo-width": 0,
-        "text-halo-color": "rgba(255, 255, 255, 0.7)",
-        "text-color": "rgba(49, 54, 62, 1)",
-        "text-opacity": 1
-      }
-    },
-    {
       "id": "cities",
       "type": "fill",
       "source": "us-cities-10",
       "source-layer": "cities",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {
-        "fill-color": "rgba(67,72,120,0.7)"
       }
     },
     {

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -259,322 +259,6 @@
       }
     },
     {
-      "id": "highway_major_subtle-copy-copy",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "secondary",
-          "tertiary",
-          "trunk"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "none"
-      },
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 0.69)",
-        "line-width": 2,
-        "line-opacity": 0.5
-      }
-    },
-    {
-      "id": "highway_motorway_casing",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 6,
-      "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter",
-        "visibility": "none"
-      },
-      "paint": {
-        "line-color": "rgb(213, 213, 213)",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              5.8,
-              0
-            ],
-            [
-              6,
-              3
-            ],
-            [
-              20,
-              40
-            ]
-          ]
-        },
-        "line-dasharray": [
-          2,
-          0
-        ],
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "highway_path",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "class",
-          "path"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "none"
-      },
-      "paint": {
-        "line-color": "rgba(255, 2, 2, 1)",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              13,
-              1
-            ],
-            [
-              20,
-              10
-            ]
-          ]
-        },
-        "line-opacity": 0.9
-      }
-    },
-    {
-      "id": "highway_minor",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 14,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "class",
-          "minor",
-          "service",
-          "track"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-width": 1.3,
-        "line-opacity": {
-          "stops": [
-            [
-              13,
-              0.7
-            ],
-            [
-              14,
-              0.7
-            ],
-            [
-              15,
-              0.7
-            ],
-            [
-              16,
-              1
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "highway_major_casing",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "secondary",
-          "tertiary",
-          "trunk"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-dasharray": [
-          12,
-          0
-        ],
-        "line-width": 3,
-        "line-opacity": 0.7
-      }
-    },
-    {
-      "id": "highway_motorway_inner",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": {
-          "base": 1,
-          "stops": [
-            [
-              5.8,
-              "hsla(0, 0%, 85%, 0.53)"
-            ],
-            [
-              6,
-              "#fff"
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              4,
-              2
-            ],
-            [
-              6,
-              1.3
-            ],
-            [
-              7,
-              1.3
-            ],
-            [
-              8,
-              1.3
-            ],
-            [
-              9,
-              1.3
-            ],
-            [
-              10,
-              1.3
-            ],
-            [
-              11,
-              2
-            ]
-          ]
-        },
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.8
-            ],
-            [
-              9,
-              0.7
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id": "railway_transit",
       "type": "line",
       "source": "openmaptiles",
@@ -817,149 +501,6 @@
           3,
           3
         ]
-      }
-    },
-    {
-      "id": "highway_motorway_bridge_casing",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              5.8,
-              0
-            ],
-            [
-              6,
-              5
-            ],
-            [
-              7,
-              5
-            ],
-            [
-              8,
-              5
-            ],
-            [
-              9,
-              5
-            ],
-            [
-              10,
-              5
-            ],
-            [
-              11,
-              5
-            ],
-            [
-              12,
-              2
-            ]
-          ]
-        },
-        "line-dasharray": [
-          2,
-          0
-        ],
-        "line-opacity": 1
-      }
-    },
-    {
-      "id": "highway_motorway_bridge_inner",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "none"
-      },
-      "paint": {
-        "line-color": {
-          "base": 1,
-          "stops": [
-            [
-              5.8,
-              "rgba(48, 48, 48, 1)"
-            ],
-            [
-              6,
-              "#fff"
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              4,
-              2
-            ],
-            [
-              6,
-              1.3
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
       }
     },
     {
@@ -1753,50 +1294,7 @@
       }
     },
     {
-      "id": "highway_name_motorway",
-      "type": "symbol",
-      "source": "openmaptiles",
-      "source-layer": "transportation_name",
-      "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "layout": {
-        "text-size": 10,
-        "symbol-spacing": 350,
-        "text-font": [
-          "Metropolis+Medium"
-        ],
-        "symbol-placement": "line",
-        "visibility": "visible",
-        "text-rotation-alignment": "viewport",
-        "text-pitch-alignment": "viewport",
-        "text-field": "{ref}",
-        "text-letter-spacing": 0.07
-      },
-      "paint": {
-        "text-color": "rgba(48, 48, 48, 1)",
-        "text-halo-color": "hsl(0, 0%, 100%)",
-        "text-translate": [
-          0,
-          2
-        ],
-        "text-halo-width": 0,
-        "text-halo-blur": 0
-      }
-    },
-    {
-      "id": "major_streets",
+      "id": "highway_major_subtle",
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
@@ -1811,35 +1309,84 @@
         [
           "in",
           "class",
-          "motorway",
+          "primary",
+          "secondary",
+          "tertiary",
           "trunk"
         ]
       ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
-        "visibility": "visible"
+        "visibility": "none"
       },
       "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-opacity": 0.9,
-        "line-width": {
-          "base": 2,
-          "stops": [
-            [
-              10,
-              2
-            ],
-            [
-              20,
-              10
-            ]
-          ]
-        }
+        "line-color": "rgba(255, 255, 255, 0.69)",
+        "line-width": 1,
+        "line-opacity": 0.5
       }
     },
     {
-      "id": "streets",
+      "id": "highway_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "none"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              5.8,
+              0
+            ],
+            [
+              6,
+              3
+            ],
+            [
+              20,
+              40
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          0
+        ],
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "highway_major_casing",
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
@@ -1855,7 +1402,52 @@
           "in",
           "class",
           "primary",
-          "secondary"
+          "secondary",
+          "tertiary",
+          "trunk"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-dasharray": [
+          12,
+          0
+        ],
+        "line-width": 2,
+        "line-opacity": 0.7
+      }
+    },
+    {
+      "id": "highway_motorway_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
         ]
       ],
       "layout": {
@@ -1864,18 +1456,204 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-opacity": 0.9,
-        "line-width": {
-          "base": 2,
+        "line-color": {
+          "base": 1,
           "stops": [
             [
-              10,
+              5.8,
+              "hsla(0, 0%, 85%, 0.53)"
+            ],
+            [
+              6,
+              "#fff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              4,
               2
             ],
             [
+              6,
+              1.3
+            ],
+            [
+              7,
+              1.3
+            ],
+            [
+              8,
+              1.3
+            ],
+            [
+              9,
+              1.3
+            ],
+            [
+              10,
+              1.3
+            ],
+            [
+              11,
+              2
+            ]
+          ]
+        },
+        "line-opacity": {
+          "stops": [
+            [
+              6,
+              0.8
+            ],
+            [
+              9,
+              0.7
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              5.8,
+              0
+            ],
+            [
+              6,
+              5
+            ],
+            [
+              7,
+              5
+            ],
+            [
+              8,
+              5
+            ],
+            [
+              9,
+              5
+            ],
+            [
+              10,
+              5
+            ],
+            [
+              11,
+              5
+            ],
+            [
+              12,
+              2
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          0
+        ],
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_inner",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "none"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [
+              5.8,
+              "rgba(48, 48, 48, 1)"
+            ],
+            [
+              6,
+              "#fff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              4,
+              2
+            ],
+            [
+              6,
+              1.3
+            ],
+            [
               20,
-              6
+              30
             ]
           ]
         }


### PR DESCRIPTION
Remove unneeded layers and properties (mostly for data-driven styles set dynamically), and move highway layers early in the style down rather than copy them in both places.