### PR TITLE
Fix auto-switching layers from URL

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -33,7 +33,6 @@ export class DataService {
   activeDataLevel: MapLayerGroup = DataLevels[0];
   activeDataHighlight: MapDataAttribute = DataAttributes[0];
   activeBubbleHighlight: MapDataAttribute = BubbleAttributes[0];
-  autoSwitchLayers = true;
   mapView;
   mapConfig;
 

--- a/src/app/map-tool/data-panel/data-panel.component.spec.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.spec.ts
@@ -35,7 +35,6 @@ export class DataServiceStub {
   activeDataLevel = DataLevels[0];
   activeDataHighlight = DataAttributes[0];
   activeBubbleHighlight = BubbleAttributes[0];
-  autoSwitchLayers = true;
   mapView;
   mapConfig;
   locations$ = Observable.of([]);

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -27,7 +27,6 @@ export class DataServiceStub {
   activeDataLevel = DataLevels[0];
   activeDataHighlight = DataAttributes[0];
   activeBubbleHighlight = BubbleAttributes[0];
-  autoSwitchLayers = true;
   mapView;
   mapConfig;
   getRouteArray() { return []; }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -44,7 +44,6 @@ export function debounce(delay: number = 300): MethodDecorator {
 export class MapToolComponent implements OnInit, AfterViewInit {
   title = 'Eviction Lab - Map';
   id = 'map-tool';
-  // autoSwitchLayers = true;
   enableZoom = true; // controls if map scroll zoom is enabled
   wheelEvent = false; // tracks if there is an active wheel event
   currentRoute = [];
@@ -131,7 +130,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
       const geo = params['geography'];
       if (geo !== 'auto') {
         this.dataService.setGeographyLevel(geo);
-        // this.autoSwitchLayers = false;
       }
     }
     if (params['bounds']) {
@@ -208,7 +206,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
    * @param updateMap moves the map to the selected location if true
    */
   onSearchSelect(feature: MapFeature | null, updateMap = true) {
-    // this.autoSwitchLayers = false;
     if (feature) {
       this.loader.start('search');
       const layerId = feature.properties['layerId'];

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -93,8 +93,9 @@ export class MapComponent implements OnInit, OnChanges {
         this.updateMapData();
       }
     } else {
-      // if there is no value yet, set it
+      // if there is no value yet, set it, and turn off auto-switch
       this._store.layer = newLayer;
+      this.autoSwitch = false;
     }
   }
   get selectedLayer(): MapLayerGroup {


### PR DESCRIPTION
Fixes #423. It was more simple than I initially thought, we just weren't turning off `autoSwitch` on the map on setting a layer. It works even if the layer isn't immediately selectable. Also removed unused `autoSwitchLayers` properties and references to them