### PR TITLE
Add transition for scroll indicator

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -18,6 +18,12 @@
   @include dataPanelHeader(14px);
   text-align: center;
   margin: grid(1) grid(4);
+  opacity: 1;
+  transition: opacity 0.6s;
+}
+
+:host-context(.map-inactive) {
+  .mobile-scroll-indicator p { opacity: 0; }
 }
 
 // Data panel header text

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -50,6 +50,7 @@
       [locations]="dataService.activeFeatures" 
       (locationRemoved)="dataService.removeLocation($event); updateRoute()"
       (locationAdded)="onSearchSelect($event, false)"
+      [class.map-inactive]="!enableZoom"
   >
     <button (click)="goToTop()" class="btn btn-large btn-primary btn-map">
       <svg class="up-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Closes #289. Adds a class to the data panel to detect when the map is inactive, then uses that to toggle a transition on the scroll indicator. I made the transition a bit slower than the others, otherwise it's harder to see

![scroll-indicator-transition](https://user-images.githubusercontent.com/8291663/34888681-d4ceb9cc-f790-11e7-9e09-4cfcdb2f1c21.gif)
