### PR TITLE
Fix conditional for auto switching

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -95,8 +95,9 @@ export class MapComponent implements OnInit, OnChanges {
       }
     } else {
       // if there is no value yet, set it, and turn off auto-switch
+      // if layer zoom range is outside the current zoom
       this._store.layer = newLayer;
-      this.autoSwitch = false;
+      this.autoSwitch = newLayer.zoom[0] <= this.zoom && newLayer.zoom[1] >= this.zoom;
     }
   }
   get selectedLayer(): MapLayerGroup {


### PR DESCRIPTION
Fixes #423. The last PR for this turned off auto switching by default for the first page load. Now it checks whether or not the zoom is within the initial layer's auto-zoom bounds and only turns auto-zoom off if it's outside (previously it would be changed to whatever layer should be visible at that zoom)