### PR TITLE
Keep attribution in view

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -150,6 +150,12 @@ export class MapComponent implements OnInit, OnChanges {
       (this.selectedChoropleth && !this.selectedChoropleth.id.includes('none')) ||
       this.cardsActive;
   }
+   /** Gets if the legend should be shown or not */
+  @HostBinding('class.legend-active') get showLegend(): boolean {
+    return this.selectedLayer &&
+      this.selectedChoropleth &&
+      !this.selectedChoropleth.id.includes('none');
+  }
   @ViewChild('pop') mapTooltip;
   @ViewChild('mapEl') mapEl: ElementRef;
   /** Tracks if the "start here" tooltip is enabled */
@@ -170,12 +176,6 @@ export class MapComponent implements OnInit, OnChanges {
   get selectDataLevels(): Array<MapLayerGroup> {
     const selectOptions = (this.layerOptions.filter((l) => l.minzoom <= this.zoom) || []);
     return [ this.autoSelect, ...selectOptions ];
-  }
-  /** Gets if the legend should be shown or not */
-  get showLegend(): boolean {
-    return this.selectedLayer &&
-      this.selectedChoropleth &&
-      !this.selectedChoropleth.id.includes('none');
   }
   /** Sets if the map is loading and informs the service */
   set mapLoading(isLoading: boolean) {

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -47,3 +47,70 @@
     border-left: none;
   }
 }
+
+:host-context(.slider-active) {
+  ::ng-deep {
+    .mapboxgl-ctrl-bottom-right {
+      bottom: grid(5);
+    }
+    @media(min-width: $gtMobile) {
+      .mapboxgl-ctrl-bottom-right {
+        bottom: grid(11);
+      }
+    }
+  }
+}
+
+:host-context(.slider-active.legend-active) {
+  ::ng-deep {
+    @media(max-width: $gtMobile) {
+      .mapboxgl-ctrl-bottom-right {
+        bottom: grid(10);
+      }
+    }
+  }
+}
+
+:host-context(.slider-active.cards-active) {
+  ::ng-deep {
+    .mapboxgl-ctrl-bottom-right {
+      bottom: grid(25);
+    }
+    @media(min-width: $gtMobile) {
+      .mapboxgl-ctrl-bottom-right {
+        bottom: grid(31);
+      }
+    }
+    @media(min-width: $gtTablet) {
+      .mapboxgl-ctrl-bottom-right {
+        bottom: grid(11);
+      }
+    }
+  }
+}
+
+::ng-deep {
+  @media(max-width: $gtMobile) {
+    .software-button .slider-active.cards-active .mapboxgl-ctrl-bottom-right {
+      bottom: calc(50px + #{grid(25)});
+    }
+  }
+}
+
+:host-context(.slider-active.cards-active.legend-active) {
+  ::ng-deep {
+    @media(max-width: $gtMobile) {
+      .mapboxgl-ctrl-bottom-right {
+        bottom: grid(30);
+      }
+    }
+  }
+}
+
+::ng-deep {
+  @media(max-width: $gtMobile) {
+    .software-button .slider-active.cards-active.legend-active .mapboxgl-ctrl-bottom-right {
+      bottom: calc(50px + #{grid(30)});
+    }
+  }
+}


### PR DESCRIPTION
It looks like we have to keep the OpenMapTiles attribution in view even if we're self-hosting, which seems fair, so I updated the attribution to stay visible even though the map is `position: fixed`.