### PR TITLE
Add Array.includes polyfill for line chart

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -33,6 +33,7 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+import 'core-js/es7/array';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
Fixes #435. `d3-line-chunked` calls `Array.includes`, but that's not included in our current array polyfills