### PR TITLE
Split prod/dev deployment, remove script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,28 @@ deploy:
   provider: s3
   access_key_id: $AWS_KEY
   secret_access_key: $AWS_SECRET
+  bucket: eviction-maps-prod
+  acl: public_read
+  local_dir: dist
+  on:
+    branch: master
+- provider: script
+  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_PROD --paths="/*"
+  on:
+    branch: master
+- skip_cleanup: true
+  provider: s3
+  access_key_id: $AWS_KEY
+  secret_access_key: $AWS_SECRET
   bucket: eviction-maps
   acl: public_read
   local_dir: dist
   on:
     branch: development
 - provider: script
-  script: scripts/invalidate-cache.sh
+  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_DEV --paths="/*"
   on:
-    branch: master
+    branch: development
 - skip_cleanup: true
   provider: script
   script: bash -c "if [[ $TRAVIS_BRANCH == prototypes/* ]]; then aws s3 cp dist/ s3://eviction-lab-prototypes/${TRAVIS_BRANCH:11} --recursive --acl=public-read; fi"

--- a/scripts/invalidate-cache.sh
+++ b/scripts/invalidate-cache.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-export AWS_ACCESS_KEY_ID=$AWS_KEY
-export AWS_SECRET_ACCESS_KEY=$AWS_SECRET
-
-aws cloudfront create-invalidation \
-    --distribution-id E2B71641SO51XO \
-    --paths "/*"


### PR DESCRIPTION
Closes #437. I created a separate bucket and CloudFront distro for production, and I added the IDs for each to Travis environment variables so we don't have to hard code them. I also removed the cache invalidation script since it's easy enough to include inline