### PR TITLE
Slightly debounce graph hover to smooth

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -43,7 +43,7 @@
       </div>
       <div class="graph-area" [class.line-graph]="graphType === 'line'" [class.bar-graph]="graphType === 'bar'">
         <app-ui-toggle class="graph-type-toggle" aria-label="Graph type" [values]="[ 'Bar', 'Line' ]" (selectedValueChanged)="changeGraphType($event)"></app-ui-toggle>
-        <app-graph [data]="graphData" [settings]="graphSettings" [hoverAll]="true" (activeValuesChanged)="onGraphHover($event)">
+        <app-graph [data]="graphData" [settings]="graphSettings" [hoverAll]="true" (activeValuesChanged)="graphHover.emit($event)">
           <div class="line-tooltips" *ngIf="graphType === 'line'">
             <div class="line-tooltip" *ngFor="let tooltip of tooltips; trackBy: trackTooltips"
                 [style.transform]="'translate('+ tooltip.xPos +'px, ' + tooltip.yPos + 'px)'"

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -94,6 +94,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
   lineEndYear: number = this.maxYear;
   dollarProps = DollarProps;
   percentProps = PercentProps;
+  graphHover = new EventEmitter();
   private graphTimeout; // tracks if a timeout is set to update graph settings
 
   constructor(
@@ -117,6 +118,8 @@ export class DataPanelComponent implements OnInit, OnChanges {
       this.setGraphData();
       this.updateTwitterText();
     });
+    this.graphHover.debounceTime(50)
+      .subscribe(e => this.onGraphHover(e));
   }
 
   /**


### PR DESCRIPTION
Fixes #449. The original problem didn't show up in gifs, but this addresses it and smooths out the hover line and tooltips