### PR TITLE
Connect bar year and general map year

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -70,9 +70,9 @@
               <span aria-hidden="true">&times;</span>
             </button>
             <p class="legend-data">
-              <span *ngIf="graphType === 'bar' && location.properties[graphProp + '-' + abbrYear(barYear)] >= 0; else unavailableBar">{{ barYear }}: {{ location.properties[graphProp + "-" + abbrYear(barYear)] }}{{ suffix(graphProp) }}</span>
+              <span *ngIf="graphType === 'bar' && location.properties[graphProp + '-' + abbrYear(year)] >= 0; else unavailableBar">{{ year }}: {{ location.properties[graphProp + "-" + abbrYear(year)] }}{{ suffix(graphProp) }}</span>
               <span *ngIf="graphType === 'line' && tooltips[i] && tooltips[i].y !== undefined && location.properties[graphProp + '-' + abbrYear(tooltips[i].x)] >= 0; else unavailableLine">{{ tooltips[i].x }}: {{ location.properties[graphProp + "-" + abbrYear(tooltips[i].x)] }}{{ suffix(graphProp) }}</span>
-              <ng-template #unavailableBar><span *ngIf="graphType === 'bar'">{{ barYear }}: Unavailable</span></ng-template>
+              <ng-template #unavailableBar><span *ngIf="graphType === 'bar'">{{ year }}: Unavailable</span></ng-template>
               <ng-template #unavailableLine><span *ngIf="graphType === 'line' && tooltips[i] && getTooltipsYear(tooltips) !== null">{{ getTooltipsYear(tooltips) }}: Unavailable</span></ng-template>
             </p>
           </li>

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -17,9 +17,16 @@ import { DollarProps, PercentProps } from '../../data/data-attributes';
   providers: [ TranslatePipe ]
 })
 export class DataPanelComponent implements OnInit, OnChanges {
-
+  private _year: number;
+  @Input() set year(newYear: number) {
+    if (newYear !== this._year) {
+      this.yearChange.emit(newYear);
+    }
+    this._year = newYear;
+  }
+  get year() { return this._year; }
+  @Output() yearChange = new EventEmitter();
   @Input() locations: MapFeature[] = [];
-  @Input() year: number;
   @Output() locationRemoved = new EventEmitter();
   @Output() locationAdded = new EventEmitter();
   get barGraphSettings() {
@@ -86,7 +93,6 @@ export class DataPanelComponent implements OnInit, OnChanges {
   tweetParams = {};
 
   endSelect: Array<number>;
-  barYear: number;
   barYearSelect: Array<number>;
   minYear = 2000;
   lineStartYear: number = this.minYear;
@@ -105,7 +111,6 @@ export class DataPanelComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit() {
-    this.barYear = this.year;
     this.barYearSelect = this.generateYearArray(this.minYear, this.maxYear);
     // Update graph axis settings on language change
     this.translate.onLangChange.subscribe(() => {
@@ -134,7 +139,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
    * @param year
    */
   updateBarYear(year: number) {
-    this.barYear = year;
+    this.year = year;
     this.setGraphData();
   }
 
@@ -338,7 +343,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
    */
   private createBarGraphData() {
     return this.locations.map((f, i) => {
-      const yVal = (f.properties[`${this.graphProp}-${('' + this.barYear).slice(2)}`]);
+      const yVal = (f.properties[`${this.graphProp}-${('' + this.year).slice(2)}`]);
       return {
         id: 'sample' + i,
         data: [{

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -46,7 +46,8 @@
   <app-data-panel
       id="data-panel"
       [style.display]="dataService.activeFeatures.length > 0 ? 'inherit' : 'none'"
-      [year]="dataService.activeYear"
+      [(year)]="dataService.activeYear"
+      (yearChange)="updateRoute()"
       [locations]="dataService.activeFeatures" 
       (locationRemoved)="dataService.removeLocation($event); updateRoute()"
       (locationAdded)="onSearchSelect($event, false)"

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -112,7 +112,9 @@ export class MapComponent implements OnInit, OnChanges {
       this.yearChange.emit(newYear);
       if (this._mapInstance) {
         this.updateCensusYear();
-        this.updateMapData();
+        // Don't update highlight features on year change
+        this.updateMapBubbles();
+        this.updateMapChoropleths();
       }
     }
   }

--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -15,6 +15,7 @@ export class UiSliderComponent implements AfterViewInit {
     const boundsValue = (this.min && this.max) ?
       Math.min(this.max, Math.max(this.min, value)) : value;
     this._currentValue = this.getStepValue(boundsValue);
+    this.updatePosition();
   }
   get value(): number {
     return this._currentValue;


### PR DESCRIPTION
Closes #439. This should be set, but is WIP until we get final confirmation on updating this (sounds like everyone is on the same page though).

Removes `barYear` on the data panel component, and updates the general data service year instead. Also sets the `ui-slider` component to update its position when the year input is changed, and doesn't call `updateHighlightFeatures` when the year is updated because it can run into errors when the tile layer switches.