### PR TITLE
Update mobile Safari, attribution

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,11 +47,9 @@ export class AppComponent implements OnInit {
     this.translate.setDefaultLang('en');
     this.translate.use('en');
     this.onWindowResize();
-    // Add software-button class if browser is Android or iOS Safari
+    // Add software-button class if browser is Android
     const userAgent = navigator.userAgent.toLowerCase();
-    this.softwareButton = userAgent.indexOf('android') > -1 ||
-      ((userAgent.indexOf('iphone') > -1 || userAgent.indexOf('ipad') > -1) &&
-       userAgent.indexOf('crios') === -1);
+    this.softwareButton = userAgent.indexOf('android') > -1;
   }
 
   /** Fired when a route is activated */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit {
     this.onWindowResize();
     // Add user agent-specific classes
     const userAgent = navigator.userAgent.toLowerCase();
-    this.iosSafari = ((userAgent.includes('iphone') || userAgent.indexOf('ipad') > -1) &&
+    this.iosSafari = ((userAgent.includes('iphone') || userAgent.includes('ipad')) &&
       (!userAgent.includes('crios') && !userAgent.includes('fxios')));
     this.android = userAgent.includes('android') && !userAgent.includes('firefox');
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,9 +47,12 @@ export class AppComponent implements OnInit {
     this.translate.setDefaultLang('en');
     this.translate.use('en');
     this.onWindowResize();
-    // Add software-button class if browser is Android
+    // Add software-button class if browser is Android (not Firefox) or iOS Safari
     const userAgent = navigator.userAgent.toLowerCase();
-    this.softwareButton = userAgent.indexOf('android') > -1;
+    this.softwareButton = (
+      userAgent.indexOf('android') > -1 && userAgent.indexOf('firefox') === -1
+    ) || ((userAgent.indexOf('iphone') > -1 || userAgent.indexOf('ipad') > -1) &&
+       (userAgent.indexOf('crios') === -1 && userAgent.indexOf('fxios') === -1));
   }
 
   /** Fired when a route is activated */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,7 +26,8 @@ export class AppComponent implements OnInit {
   @HostBinding('class.gt-tablet') largerThanTablet: boolean;
   @HostBinding('class.gt-small-desktop') largerThanSmallDesktop: boolean;
   @HostBinding('class.gt-large-desktop') largerThanLargeDesktop: boolean;
-  @HostBinding('class.software-button') softwareButton = false;
+  @HostBinding('class.ios-safari') iosSafari = false;
+  @HostBinding('class.android') android = false;
   private activeMenuItem;
 
   constructor(
@@ -47,12 +48,11 @@ export class AppComponent implements OnInit {
     this.translate.setDefaultLang('en');
     this.translate.use('en');
     this.onWindowResize();
-    // Add software-button class if browser is Android (not Firefox) or iOS Safari
+    // Add user agent-specific classes
     const userAgent = navigator.userAgent.toLowerCase();
-    this.softwareButton = (
-      userAgent.indexOf('android') > -1 && userAgent.indexOf('firefox') === -1
-    ) || ((userAgent.indexOf('iphone') > -1 || userAgent.indexOf('ipad') > -1) &&
-       (userAgent.indexOf('crios') === -1 && userAgent.indexOf('fxios') === -1));
+    this.iosSafari = ((userAgent.includes('iphone') || userAgent.indexOf('ipad') > -1) &&
+      (!userAgent.includes('crios') && !userAgent.includes('fxios')));
+    this.android = userAgent.includes('android') && !userAgent.includes('firefox');
   }
 
   /** Fired when a route is activated */

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -31,13 +31,10 @@
 :host-context(.software-button), :host-context(.gt-mobile.software-button) {
   .app-wrapper {
     app-map.legend-active, app-map.slider-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight});
-    }
-    app-map.legend-active.slider-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight});
+      height: calc(100vh - #{$headerHeightSm} - #{$softButtonPadding} - #{$timeSliderHeight});
     }
     app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight} - #{$softButtonPadding});
+      height: calc(100vh - #{$headerHeightSm} - #{$softButtonPadding} - #{$cardMobileHeight});
     }
   }
 }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -15,8 +15,14 @@
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
   }
+  app-map.slider-active {
+    height: calc(100vh - #{$headerHeightSm} - #{grid(2)});
+  }
+  app-map.slider-active.legend-active {
+    height: calc(100vh - #{$headerHeightSm} - #{grid(3)})
+  }
   app-map.cards-active {
-    height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
+    height: calc(100vh - #{$headerHeightSm} - #{grid(6)});
   }
   app-data-panel {
     display:block;
@@ -30,6 +36,12 @@
 // Additional spacing for software button
 :host-context(.software-button) {
   .app-wrapper {
+    app-map.legend-active, app-map.slider-active {
+      height: calc(100vh - #{$headerHeightSm} - #{grid(9)});
+    }
+    app-map.legend-active.slider-active {
+      height: calc(100vh - #{$headerHeightSm} - #{grid(10)});
+    }
     app-map.cards-active {
       height: calc(100vh - #{$headerHeightSm} - #{grid(12)});
     }
@@ -55,6 +67,12 @@
 // Additional spacing for software button
 :host-context(.gt-mobile.software-button) {
   .app-wrapper {
+    app-map.legend-active, app-map.slider-active {
+      height: calc(100vh - #{$headerHeightLg} - #{grid(9)});
+    }
+    app-map.legend-active.slider-active {
+      height: calc(100vh - #{$headerHeightLg} - #{grid(10)});
+    }
     app-map.cards-active {
       height: calc(100vh - #{$headerHeightLg} - #{grid(10)});
     }
@@ -65,7 +83,8 @@
 //    Adjust height of map / location cards to reflect large header.
 :host-context(.gt-tablet), :host-context(.gt-tablet.software-button) {
   .app-wrapper {
-    app-map, app-map.cards-active {
+    app-map, app-map.legend-active, app-map.slider-active,
+    app-map.legend-active.slider-active, app-map.cards-active {
       margin-top: $headerHeightLg;
       height: calc(100vh - #{$headerHeightLg});
     }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -15,14 +15,8 @@
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
   }
-  app-map.slider-active {
-    height: calc(100vh - #{$headerHeightSm} - #{grid(2)});
-  }
-  app-map.slider-active.legend-active {
-    height: calc(100vh - #{$headerHeightSm} - #{grid(3)})
-  }
   app-map.cards-active {
-    height: calc(100vh - #{$headerHeightSm} - #{grid(6)});
+    height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
   }
   app-data-panel {
     display:block;
@@ -34,16 +28,16 @@
 }
 
 // Additional spacing for software button
-:host-context(.software-button) {
+:host-context(.software-button), :host-context(.gt-mobile.software-button) {
   .app-wrapper {
     app-map.legend-active, app-map.slider-active {
-      height: calc(100vh - #{$headerHeightSm} - #{grid(9)});
+      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight});
     }
     app-map.legend-active.slider-active {
-      height: calc(100vh - #{$headerHeightSm} - #{grid(10)});
+      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight});
     }
     app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{grid(12)});
+      height: calc(100vh - #{$headerHeightSm} - #{$timeSliderHeight} - #{$softButtonPadding});
     }
   }
 }
@@ -60,21 +54,6 @@
   .app-wrapper {
     app-map.cards-active {
       height: calc(100vh - #{$headerHeightLg} - #{grid(5)});
-    }
-  }
-}
-
-// Additional spacing for software button
-:host-context(.gt-mobile.software-button) {
-  .app-wrapper {
-    app-map.legend-active, app-map.slider-active {
-      height: calc(100vh - #{$headerHeightLg} - #{grid(9)});
-    }
-    app-map.legend-active.slider-active {
-      height: calc(100vh - #{$headerHeightLg} - #{grid(10)});
-    }
-    app-map.cards-active {
-      height: calc(100vh - #{$headerHeightLg} - #{grid(10)});
     }
   }
 }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -27,14 +27,26 @@
   }
 }
 
-// Additional spacing for software button
-:host-context(.software-button), :host-context(.gt-mobile.software-button) {
+// Additional spacing for iOS Safari
+:host-context(.ios-safari), :host-context(.gt-mobile.ios-safari) {
   .app-wrapper {
     app-map.legend-active, app-map.slider-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$softButtonPadding} - #{$timeSliderHeight});
+      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight});
     }
     app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$softButtonPadding} - #{$cardMobileHeight});
+      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$cardMobileHeight});
+    }
+  }
+}
+
+// Additional spacing for Android 
+:host-context(.android), :host-context(.gt-mobile.android) {
+  .app-wrapper {
+    app-map.legend-active, app-map.slider-active {
+      height: calc(100vh - #{$headerHeightSm} - #{$androidPadding} - #{$timeSliderHeight});
+    }
+    app-map.cards-active {
+      height: calc(100vh - #{$headerHeightSm} - #{$androidPadding} - #{$timeSliderHeight} - #{$legendHeight});
     }
   }
 }
@@ -57,7 +69,9 @@
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-tablet), :host-context(.gt-tablet.software-button) {
+:host-context(.gt-tablet),
+:host-context(.gt-tablet.ios-safari),
+:host-context(.gt-tablet.andrdoid) {
   .app-wrapper {
     app-map, app-map.legend-active, app-map.slider-active,
     app-map.legend-active.slider-active, app-map.cards-active {

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -34,7 +34,7 @@
       height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight});
     }
     app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$cardMobileHeight});
+      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight} - #{$legendHeight});
     }
   }
 }

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -56,7 +56,7 @@ app-mapbox ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
 // center controls vertically on the right side of the map
 app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
   top: 0;
-  bottom:$timeSliderHeight;
+  bottom: calc(#{$timeSliderHeight} + #{grid(5)});
   margin:auto;
   height:grid(18);
   right:$pageMargin;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -58,10 +58,11 @@ app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
   top: 0;
   bottom: calc(#{$timeSliderHeight} + #{grid(5)});
   margin:auto;
-  height:grid(18);
+  height:grid(22);
   right:$pageMargin;
   left: auto;
   .mapboxgl-ctrl-group {
+    float: right;
     border-radius:0;
     box-shadow: $z1shadow;
      & > button {

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -46,17 +46,55 @@
   .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
     border-left: none;
   }
+  .mapboxgl-ctrl-bottom-left {
+    bottom: auto;
+    top: calc(100vh - #{grid(3)});
+    .mapboxgl-ctrl-attrib.mapboxgl-compact {
+      padding-left: 24px;
+      padding-right: 8px;
+      border-radius: 12px 3px 3px 12px;
+    }
+    .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+      left: 0;
+    }
+  }
+  @media(max-width: $gtMobile) {
+    .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{grid(6)})
+    }
+  }
+}
+
+:host-context(.software-button) {
+  ::ng-deep {
+    .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{grid(12)});
+    }
+  }
 }
 
 :host-context(.slider-active) {
   ::ng-deep {
-    .mapboxgl-ctrl-bottom-right {
-      bottom: grid(5);
+    .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(6)});
     }
     @media(min-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-right {
-        bottom: grid(11);
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightLg} - #{grid(11)});
       }
+    }
+    @media(min-width: $gtTablet) {
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightLg} - #{grid(3)});
+      }
+    }
+  }
+}
+
+::ng-deep {
+  @media(max-width: $gtMobile) {
+    .software-button .slider-active .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(11)});
     }
   }
 }
@@ -64,26 +102,34 @@
 :host-context(.slider-active.legend-active) {
   ::ng-deep {
     @media(max-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-right {
-        bottom: grid(10);
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightSm} - #{grid(12)});
       }
+    }
+  }
+}
+
+::ng-deep {
+  @media(max-width: $gtMobile) {
+    .software-button .slider-active.legend-active .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(20)});
     }
   }
 }
 
 :host-context(.slider-active.cards-active) {
   ::ng-deep {
-    .mapboxgl-ctrl-bottom-right {
-      bottom: grid(25);
+    .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(25)});
     }
     @media(min-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-right {
-        bottom: grid(31);
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightLg} - #{grid(23)});
       }
     }
     @media(min-width: $gtTablet) {
-      .mapboxgl-ctrl-bottom-right {
-        bottom: grid(11);
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightLg} - #{grid(3)});
       }
     }
   }
@@ -91,17 +137,25 @@
 
 ::ng-deep {
   @media(max-width: $gtMobile) {
-    .software-button .slider-active.cards-active .mapboxgl-ctrl-bottom-right {
-      bottom: calc(50px + #{grid(25)});
+    .software-button .slider-active.cards-active .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(31)});
     }
   }
 }
 
 :host-context(.slider-active.cards-active.legend-active) {
   ::ng-deep {
-    @media(max-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-right {
-        bottom: grid(30);
+    .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(28)});
+    }
+    @media(min-width: $gtMobile) {
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightSm} - #{grid(27)});
+      }
+    }
+    @media(min-width: $gtTablet) {
+      .mapboxgl-ctrl-bottom-left {
+        top: calc(100vh - #{$headerHeightSm} - #{grid(7)});
       }
     }
   }
@@ -109,8 +163,8 @@
 
 ::ng-deep {
   @media(max-width: $gtMobile) {
-    .software-button .slider-active.cards-active.legend-active .mapboxgl-ctrl-bottom-right {
-      bottom: calc(50px + #{grid(30)});
+    .software-button .slider-active.cards-active.legend-active .mapboxgl-ctrl-bottom-left {
+      top: calc(100vh - #{$headerHeightSm} - #{grid(34)});
     }
   }
 }

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -46,125 +46,35 @@
   .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
     border-left: none;
   }
-  .mapboxgl-ctrl-bottom-left {
+  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact {
+    margin: grid(1);
+  }
+  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+    top: 0;
     bottom: auto;
-    top: calc(100vh - #{grid(3)});
-    .mapboxgl-ctrl-attrib.mapboxgl-compact {
-      padding-left: 24px;
-      padding-right: 8px;
-      border-radius: 12px 3px 3px 12px;
+  }
+  .mapboxgl-ctrl-bottom-left {
+    display: none;
+  }
+  @media(min-width: $gtTablet) {
+    .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib {
+      display: none;
     }
-    .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+    .mapboxgl-ctrl-bottom-left {
+      display: inherit;
+      top: auto;
+      bottom: 0;
       left: 0;
+      right: auto;
     }
-  }
-  @media(max-width: $gtMobile) {
-    .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{grid(6)})
-    }
-  }
-}
-
-:host-context(.software-button) {
-  ::ng-deep {
-    .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{grid(12)});
-    }
+    
   }
 }
 
 :host-context(.slider-active) {
   ::ng-deep {
     .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(6)});
-    }
-    @media(min-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightLg} - #{grid(11)});
-      }
-    }
-    @media(min-width: $gtTablet) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightLg} - #{grid(3)});
-      }
-    }
-  }
-}
-
-::ng-deep {
-  @media(max-width: $gtMobile) {
-    .software-button .slider-active .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(11)});
-    }
-  }
-}
-
-:host-context(.slider-active.legend-active) {
-  ::ng-deep {
-    @media(max-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightSm} - #{grid(12)});
-      }
-    }
-  }
-}
-
-::ng-deep {
-  @media(max-width: $gtMobile) {
-    .software-button .slider-active.legend-active .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(20)});
-    }
-  }
-}
-
-:host-context(.slider-active.cards-active) {
-  ::ng-deep {
-    .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(25)});
-    }
-    @media(min-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightLg} - #{grid(23)});
-      }
-    }
-    @media(min-width: $gtTablet) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightLg} - #{grid(3)});
-      }
-    }
-  }
-}
-
-::ng-deep {
-  @media(max-width: $gtMobile) {
-    .software-button .slider-active.cards-active .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(31)});
-    }
-  }
-}
-
-:host-context(.slider-active.cards-active.legend-active) {
-  ::ng-deep {
-    .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(28)});
-    }
-    @media(min-width: $gtMobile) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightSm} - #{grid(27)});
-      }
-    }
-    @media(min-width: $gtTablet) {
-      .mapboxgl-ctrl-bottom-left {
-        top: calc(100vh - #{$headerHeightSm} - #{grid(7)});
-      }
-    }
-  }
-}
-
-::ng-deep {
-  @media(max-width: $gtMobile) {
-    .software-button .slider-active.cards-active.legend-active .mapboxgl-ctrl-bottom-left {
-      top: calc(100vh - #{$headerHeightSm} - #{grid(34)});
+      bottom: grid(12);
     }
   }
 }

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -37,6 +37,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map.addControl(new mapboxgl.AttributionControl(), 'bottom-left');
     this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
     this.map.addControl(new mapboxgl.GeolocateControl({showUserLocation: false}), 'top-left');
+    this.map.addControl(new mapboxgl.AttributionControl({ compact: true }), 'top-left');
     this.map.on('load', () => {
       this.onMapInstance(this.map);
     });

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -32,8 +32,9 @@ export class MapboxComponent implements AfterViewInit {
    */
   ngAfterViewInit() {
     this.map = this.mapService.createMap({
-      ...this.mapConfig, container: this.mapEl.nativeElement
+      ...this.mapConfig, container: this.mapEl.nativeElement, attributionControl: false
     });
+    this.map.addControl(new mapboxgl.AttributionControl(), 'bottom-left');
     this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
     this.map.addControl(new mapboxgl.GeolocateControl({showUserLocation: false}), 'top-left');
     this.map.on('load', () => {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -230,7 +230,8 @@ $tooltipFontColor: #fff;
 
 // Map tool component heights, software button
 $cardMobileHeight: grid(15);
-$softButtonPadding: grid(4);
+$iosSafariPadding: grid(4);
+$androidPadding: grid(2);
 
 // TODO: 
 // - standard values for shadow levels

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -229,7 +229,6 @@ $tooltipBackground: #050403;
 $tooltipFontColor: #fff;
 
 // Map tool component heights, software button
-$cardMobileHeight: grid(15);
 $iosSafariPadding: grid(4);
 $androidPadding: grid(2);
 

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -228,6 +228,10 @@ $legendTextColor: #7f7f7f;
 $tooltipBackground: #050403;
 $tooltipFontColor: #fff;
 
+// Map tool component heights, software button
+$cardMobileHeight: grid(15);
+$softButtonPadding: grid(8);
+
 // TODO: 
 // - standard values for shadow levels
 // - type definitions / sizes

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -230,7 +230,7 @@ $tooltipFontColor: #fff;
 
 // Map tool component heights, software button
 $cardMobileHeight: grid(15);
-$softButtonPadding: grid(8);
+$softButtonPadding: grid(4);
 
 // TODO: 
 // - standard values for shadow levels


### PR DESCRIPTION
Fixes #443, #455. It got a bit complicated, and I realized midway through that if Safari doesn't have padding the year selector isn't visible unless you select a feature. I'm at the point where I think we'll just have to accept that, since the alternative is shrinking the map significantly. Here's the prototype, http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/device-tweaks

It works overall testing on BrowserStack and my iPhone, but let me know if it looks like I'm missing anything here 