### PR TITLE
Base hover outline color on selected features

### DIFF
--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -51,6 +51,7 @@
     [mapConfig]="mapConfig" 
     [eventLayers]="mapEventLayers"
     [selectedLayer]="selectedLayer"
+    [featureCount]="activeFeatures.length"
     (ready)="onMapReady($event)"
     (zoom)="onMapZoom($event)"
     (featureClick)="onFeatureClick($event)"

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -19,12 +19,16 @@ export class MapboxComponent implements AfterViewInit {
   @Input() mapConfig: Object;
   @Input() eventLayers: Array<string> = [];
   @Input() selectedLayer: MapLayerGroup;
+  @Input() featureCount = 0;
   @Output() ready: EventEmitter<any> = new EventEmitter();
   @Output() zoom: EventEmitter<number> = new EventEmitter();
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   featureMouseMove: EventEmitter<any> = new EventEmitter();
   featureMouseLeave: EventEmitter<any> = new EventEmitter();
+  hoverColors = [
+    'rgba(226,64,0,0.8)', 'rgba(67,72,120,0.8)', 'rgba(44,137,127,0.8)', 'rgba(255,255,255,0.8)'
+  ];
 
   constructor(private mapService: MapService, private zone: NgZone) { }
 
@@ -81,6 +85,7 @@ export class MapboxComponent implements AfterViewInit {
         if (feature && feature.layer.id === this.selectedLayer.id) {
           const union = this.mapService.getUnionFeature(this.selectedLayer.id, feature);
           if (union !== null) {
+            union.properties['color'] = this.hoverColors[this.featureCount];
             this.mapService.setSourceData('hover', [union]);
           }
         } else {

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1806,17 +1806,28 @@
       }
     },
     {
+      "id": "hover-outline",
+      "type": "line",
+      "source": "hover",
+      "layout": {},
+      "paint": {
+        "line-width": 5,
+        "line-opacity": 0.75,
+        "line-color": "#ffffff"
+      }
+    },
+    {
       "id": "hover",
       "type": "line",
       "source": "hover",
       "layout": {},
       "paint": {
+        "line-width": 2,
+        "line-opacity": 0.9,
         "line-color": {
           "property": "color",
           "type": "identity"
-        },
-        "line-width": 3,
-        "line-opacity": 0.5
+        }
       }
     },
     {

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -1811,7 +1811,10 @@
       "source": "hover",
       "layout": {},
       "paint": {
-        "line-color": "rgba(255,255,255,0.8)",
+        "line-color": {
+          "property": "color",
+          "type": "identity"
+        },
         "line-width": 3,
         "line-opacity": 0.5
       }


### PR DESCRIPTION
Closes #462. The only concern I have about this is that you can't see the blue hover outline in areas that have the darker choropleth shade. I don't think this is that big of an issue though, since we still have the hover tooltip

![hover-colors](https://user-images.githubusercontent.com/8291663/35048305-3a5c3cf4-fb62-11e7-8bac-d92688b2d485.gif)
