### PR TITLE
Fix link focus state

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,7 +28,7 @@ html, body {
 body {
   height:auto;
   overflow-x:hidden;
-  :focus, .form-control:focus {
+  :focus, .form-control:focus, a:focus {
     @include focusState();
   }
 }


### PR DESCRIPTION
On Chrome links still had the blue focus ring in addition to the orange glow, this removes that.

Before:
![image](https://user-images.githubusercontent.com/21034/35058704-07b79320-fb76-11e7-8394-18153bf39e08.png)

After:
![image](https://user-images.githubusercontent.com/21034/35058722-1335e81e-fb76-11e7-8418-0e7d0dcf5968.png)
