### PR TITLE
Accessibility - screen reader

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, async } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
@@ -38,7 +39,8 @@ describe('AppComponent', () => {
         PlatformService,
         LoadingService,
         { provide: TranslateService, useClass: TranslateServiceStub },
-        { provide: DataService, useValue: { languageOptions: [] } }
+        { provide: DataService, useValue: { languageOptions: [] } },
+        { provide: Title, useValue: { setTitle: (...args) => {} } }
       ]
     }).compileComponents();
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, OnInit, ViewChild, ViewContainerRef, Inject, HostListener, HostBinding, ComponentRef
 } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
@@ -37,7 +38,8 @@ export class AppComponent implements OnInit {
     private translate: TranslateService,
     private router: Router,
     private toastr: ToastsManager,
-    private vRef: ViewContainerRef
+    private vRef: ViewContainerRef,
+    private titleService: Title
   ) {
       this.toastr.setRootViewContainerRef(vRef);
   }
@@ -57,8 +59,11 @@ export class AppComponent implements OnInit {
 
   /** Fired when a route is activated */
   onActivate(component: any) {
-    if (component.id && component.id === 'map-tool') {
+    if (component.constructor.name === 'MapToolComponent') {
       this.mapComponent = component;
+      this.titleService.setTitle('Eviction Lab - Map & Data'); // TODO: translate
+    } else if (component.constructor.name === 'RankingToolComponent') {
+      this.titleService.setTitle('Eviction Lab - Eviction Rankings'); // TODO: translate
     }
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { BrowserModule } from '@angular/platform-browser';
+import { BrowserModule, Title } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
@@ -58,7 +58,8 @@ export class CustomOption extends ToastOptions {
     PlatformService,
     DataService,
     LoadingService,
-    {provide: ToastOptions, useClass: CustomOption}
+    {provide: ToastOptions, useClass: CustomOption},
+    Title
   ],
   bootstrap: [AppComponent],
   entryComponents: [ MapToolComponent, RankingToolComponent ]

--- a/src/app/ui/predictive-search/predictive-search.component.html
+++ b/src/app/ui/predictive-search/predictive-search.component.html
@@ -1,5 +1,5 @@
 <div class="search-container">
-  <span class="glyphicon glyphicon-search"></span>
+  <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
   <input [ngModel]="selected"
          (ngModelChange)="selectedTextChange($event)"
          [typeahead]="options || []" 

--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -1,4 +1,4 @@
-<div class="el-select" dropdown (isOpenChange)="onIsOpenChange()">
+<div class="el-select" dropdown (onShown)="setListEls()" (isOpenChange)="onIsOpenChange()">
   <button dropdownToggle (blur)="onButtonBlur($event)" type="button" class="btn btn-small dropdown-toggle">
     <span *ngIf="label" class="el-select-label">{{label}} </span> 
     <span class="el-select-value" [innerHTML]="selectedLabel"></span>
@@ -15,10 +15,13 @@
     (touchstart)="onSelectTouchStart($event)"
     (touchmove)="onSelectTouchMove($event)"
   >
-    <li *ngFor="let value of values" role="menuitem">
+    <li *ngFor="let value of values">
       <a 
+        tabindex="0"
+        role="menuitem"
+        aria-checked="selectedValue === value"
         class="dropdown-item" 
-        [class.highlighted]="highlightedItem === value" 
+        [class.highlighted]="values[focusIndex] === value" 
         (click)="selectedValue = value">
         {{getLabel(value)}}
       </a>

--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -1,5 +1,5 @@
 <div class="el-select" dropdown (onShown)="setListEls()" (isOpenChange)="onIsOpenChange()">
-  <button dropdownToggle (blur)="onButtonBlur($event)" type="button" class="btn btn-small dropdown-toggle">
+  <button dropdownToggle type="button" class="btn btn-small dropdown-toggle">
     <span *ngIf="label" class="el-select-label">{{label}} </span> 
     <span class="el-select-value" [innerHTML]="selectedLabel"></span>
     <svg class="svg-down-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -21,7 +21,7 @@
         role="menuitem"
         aria-checked="selectedValue === value"
         class="dropdown-item" 
-        [class.highlighted]="values[focusIndex] === value" 
+        [class.highlighted]="selectedValue === value" 
         (click)="selectedValue = value">
         {{getLabel(value)}}
       </a>

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -7,7 +7,6 @@
           background: $background;
       }
       .el-select-label { color: $labelText; }
-      .highlighted { background: $highlightBackground; color: $highlightText; }
       .caret { color: $caretColor; }
   }
 }
@@ -60,6 +59,15 @@
     }
     & > li.bottom-label:hover, & > li.bottom-label > a:hover {
       background: inherit;
+    }
+    .dropdown-item {
+      &.highlighted {
+        background: $grey4;
+      }
+      &:focus {
+        outline: 0;
+        box-shadow: inset 0 0 3px $color1;
+      }
     }
   }
   .dropdown-toggle.btn {

--- a/src/app/ui/ui-select/ui-select.component.spec.ts
+++ b/src/app/ui/ui-select/ui-select.component.spec.ts
@@ -1,4 +1,6 @@
-import { async, tick, fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async, tick, fakeAsync, ComponentFixture, TestBed, flushMicrotasks, discardPeriodicTasks
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
@@ -48,16 +50,19 @@ describe('UiSelectComponent', () => {
     buttonEl.triggerEventHandler('click', null);
     tick();
     fixture.detectChanges();
+    tick(1000);
+    fixture.detectChanges();
     menuEls = fixture.debugElement.queryAll(By.css('.dropdown-item'));
     expect(menuEls[0].nativeElement.textContent).toContain(expectedValues[0].name);
     expect(menuEls[1].nativeElement.textContent).toContain(expectedValues[1].name);
   }));
 
   it('should raise the selected value when clicked', fakeAsync(() => {
-    fixture.detectChanges();
     let selectedGroup;
     buttonEl.triggerEventHandler('click', null);
     tick();
+    fixture.detectChanges();
+    tick(1000);
     fixture.detectChanges();
     menuEls = fixture.debugElement.queryAll(By.css('.dropdown-item'));
     component.change.subscribe((group) => { selectedGroup = group; });

--- a/src/app/ui/ui-select/ui-select.component.ts
+++ b/src/app/ui/ui-select/ui-select.component.ts
@@ -37,6 +37,7 @@ export class UiSelectComponent implements OnInit {
   private _selectedValue;
   private scrollMax = 0;
   private listEls = [];
+  private listTimeout = null;
 
   /**
    * set the selected value to the first item if no selected value is given
@@ -74,12 +75,18 @@ export class UiSelectComponent implements OnInit {
     }
   }
 
+  /**
+   * Set the DOM elements in the list
+   * NOTE: There is a slight delay before the dropdown list element is in the DOM
+   *  so there is a timeout that gets called to try again in 200ms if it's not there yet
+   */
   setListEls() {
     if (this.dropdownList) {
       this.listEls = this.dropdownList.nativeElement.getElementsByClassName('dropdown-item');
       this.listEls[this.focusIndex].focus();
     } else {
-      setTimeout(() => { this.setListEls(); }, 100);
+      if (this.listTimeout) { clearTimeout(this.listTimeout); }
+      this.listTimeout = setTimeout(() => { this.setListEls(); }, 200);
     }
   }
 

--- a/src/app/ui/ui-select/ui-select.component.ts
+++ b/src/app/ui/ui-select/ui-select.component.ts
@@ -126,8 +126,13 @@ export class UiSelectComponent implements OnInit {
     if (this.dropdown.isOpen) { this.dropdown.hide(); }
   }
 
+  /**
+   * Close the dropdown when the button loses focus
+   * WARNING: Do not remove or decrease the timeout or else chrome will hide the
+   *  dropdown menu before the click event fires on the selection.
+   */
   onButtonBlur(e) {
-    if (this.dropdown.isOpen) { this.dropdown.hide(); }
+    setTimeout(() => { if (this.dropdown.isOpen) { this.dropdown.hide(); } }, 500);
   }
 
   /** Do not propagate any menu wheel events to parent elements */

--- a/src/app/ui/ui-select/ui-select.component.ts
+++ b/src/app/ui/ui-select/ui-select.component.ts
@@ -78,7 +78,6 @@ export class UiSelectComponent implements OnInit {
     if (this.dropdownList) {
       this.listEls = this.dropdownList.nativeElement.getElementsByClassName('dropdown-item');
       this.listEls[this.focusIndex].focus();
-      console.log('list els', this.listEls);
     } else {
       setTimeout(() => { this.setListEls(); }, 100);
     }
@@ -91,22 +90,25 @@ export class UiSelectComponent implements OnInit {
         // go to next item
         this.switchFocus(e.keyCode === keys['UP']);
         e.preventDefault();
+        e.stopPropagation();
       }
       if (e.keyCode === keys['SPACE'] || e.keyCode === keys['ENTER']) {
         // select item and close
         this.selectedValue = this.values[this.focusIndex];
         this.dropdown.hide();
         e.preventDefault();
+        e.stopPropagation();
       }
       if (e.keyCode === keys['ESC'] || e.keyCode === keys['TAB']) {
         // close without selecting item
         this.dropdown.hide();
       }
     } else {
-      if (e.keyCode === keys['SPACE'] || e.keyCode === keys['UP'] || e.keyCode === keys['DOWN']) {
+      if (e.keyCode === keys['UP'] || e.keyCode === keys['DOWN']) {
         // open the menu
         this.dropdown.show();
         e.preventDefault();
+        e.stopPropagation();
       }
     }
   }
@@ -127,15 +129,6 @@ export class UiSelectComponent implements OnInit {
   @HostListener('document:scroll', ['$event'])
   onDocumentScroll(e) {
     if (this.dropdown.isOpen) { this.dropdown.hide(); }
-  }
-
-  /**
-   * Close the dropdown when the button loses focus
-   * WARNING: Do not remove or decrease the timeout or else chrome will hide the
-   *  dropdown menu before the click event fires on the selection.
-   */
-  onButtonBlur(e) {
-    // setTimeout(() => { if (this.dropdown.isOpen) { this.dropdown.hide(); } }, 500);
   }
 
   /** Do not propagate any menu wheel events to parent elements */


### PR DESCRIPTION
Did some testing with VoiceOver on OSX to make sure all page elements are readable with a screen reader, and made the following adjustments:

- Set page title for context
- Adjust keyboard navigation on `ui-select` so that menu items receive focus and are read by the screen reader (also fixes #460)
- hide search icon from screen reader

This should finish up #127, with a few exceptions that I've created separate issues for.