### PR TITLE
Set bar graph x tick format

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -25,7 +25,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
   get barGraphSettings() {
     return {
       axis: {
-        x: { label: null, tickFormat: null },
+        x: { label: null, tickFormat: '.0f' },
         y: {
           label: this.translatePipe.transform(this.cardProps[this.graphProp]),
           tickSize: '-100%',


### PR DESCRIPTION
Fixes #475. It looks like the transition is using the first axis' `tickFormat`, but since we're not using X axis labels on the bar graph anyway it doesn't seem to hurt to update the format to prevent the weird transition behavior.

![year-format-fix](https://user-images.githubusercontent.com/8291663/35103337-23a3938a-fc2b-11e7-960d-6a82def2d125.gif)
