### PR TITLE
Fix card preview wrapping

### DIFF
--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -160,10 +160,11 @@
 }
 
 // display all three data attributes in card when space permits
-@media(min-width: 380px) {
+@media(min-width: 540px) {
   :host-context(.map-ui-wrapper) {
     .location-card {
       .card-content { 
+        li { max-width: 40%; }
         li:nth-child(2) { display: block; }
         li:nth-child(2):last-child, li:nth-child(3) { float: left; }
       }
@@ -176,11 +177,7 @@
     width: 100%; 
     min-width: grid(35); 
     .card-content li { 
-      max-width: none;
-      span {
-        overflow:auto;
-        white-space: normal;
-      }
+      max-width: 30%;
     }
   }
 }
@@ -207,7 +204,16 @@
     .card-content {
       position: static;
       padding: $defaultPadding;
-      li { float: none; margin-right: 0; }
+      li {
+        max-width: none;
+        float: none;
+        margin-right: 0;
+
+        span {
+          overflow: auto;
+          white-space: normal;
+        }
+      }
       .card-stat-label {
         font-size: $cardLabelTextSize;
       }


### PR DESCRIPTION
Fixes #469. Doesn't show all three stats until a higher breakpoint, and continues to wrap the labels into tablet resolutions. It leaves a little extra space when the stat names are short, but I tried it with the longest combination and it holds up there

Long stat names:
![card-resize](https://user-images.githubusercontent.com/8291663/35105345-061c153e-fc31-11e7-8fe7-2ae919bac15b.gif)

Short stat names:
![card-resize-2](https://user-images.githubusercontent.com/8291663/35105355-0d1a9540-fc31-11e7-9a8f-f64a084f430f.gif)

