### PR TITLE
Fix desktop card overflow

### DIFF
--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -381,7 +381,7 @@
   padding: 0 grid(4) grid(6);
   .location-card {
     margin-right: grid(4);
-    min-width: grid(45);
+    min-width: grid(39);
     flex:1;
     &:last-child { margin-right: 0; }
     .card-header svg {


### PR DESCRIPTION
Fixes #397. The card get less pushed together now that the animation is different, so we didn't need the `min-width` to be quite as large. This doesn't trigger `overflow-x` on any desktop screen sizes and also doesn't re-introduce the scroll jump bug

![desktop-card-overflow](https://user-images.githubusercontent.com/8291663/35106218-4a1db4c0-fc33-11e7-8653-caf275e539c1.gif)


