### PR TITLE
Remove download delay after export fix

### DIFF
--- a/src/app/map-tool/data-panel/download-form/download-form.component.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.ts
@@ -60,12 +60,9 @@ export class DownloadFormComponent implements OnInit {
           console.log(`Error occured: ${res}`);
           this.loading = false;
         } else {
-          // Download after slight delay to make sure file is ready
-          setTimeout(() => {
-            window.location.href = res['path'];
-            this.dismiss({ accepted: true });
-            this.loading = false;
-          }, 500);
+          window.location.href = res['path'];
+          this.dismiss({ accepted: true });
+          this.loading = false;
         }
       });
   }


### PR DESCRIPTION
Related to fix for https://github.com/EvictionLab/eviction-lab-exports/issues/36

I'd added a timeout because sometimes the file on S3 wasn't ready when the response came, but that's because I wasn't calling `await` on the file upload function. Now that it's fixed this isn't needed