### PR TITLE
Fix Travis build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,12 +25,32 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
-      "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.28.tgz",
+      "integrity": "sha512-rfGRVdpx080zZq9NGZ3RNG+cmoq/ZPaCzpM4dAbosEM46ficUkwr/JKjhjZUUoSyb9ItrT1lp9C33GfE/YpSVQ==",
       "dev": true,
       "requires": {
+        "ajv": "5.5.2",
+        "chokidar": "1.7.0",
+        "rxjs": "5.5.6",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.6",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+          "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/schematics": {
@@ -44,6 +64,17 @@
         "@schematics/schematics": "0.0.11",
         "minimist": "1.2.0",
         "rxjs": "5.5.2"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "0.0.22",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
+          "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        }
       }
     },
     "@angular/animations": {
@@ -375,6 +406,17 @@
       "dev": true,
       "requires": {
         "@angular-devkit/core": "0.0.22"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "0.0.22",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
+          "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        }
       }
     },
     "@schematics/schematics": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
+    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.5.0",
     "@angular/compiler-cli": "^5.0.3",
     "@angular/language-service": "^4.2.4",


### PR DESCRIPTION
It sounds like all the Travis build errors we've been getting are related to installing the newest version of `@angular/devkit-core`, and [this Stack Overflow post](https://stackoverflow.com/questions/48331098/ng-command-throws-error-angular-devkit-core-seems-to-be-missing) suggested to add it to `devDependencies` which fixes the issue