### PR TITLE
Split out some configuration between environments

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -29,6 +29,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
+        "staging": "environments/environment.staging.ts",
         "prod": "environments/environment.prod.ts"
       }
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_script:
 script:
 - ng test --watch=false --sourcemaps=false
 - ng lint
-- ng build --prod
+- if [ "$TRAVIS_BRANCH" = "development" ]; then ng build --prod --env=staging; fi
+- if [ "$TRAVIS_BRANCH" = "master" ]; then ng build --prod --env=prod; fi
 after_script:
 - npm run e2e
 before_deploy:

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import {
 import { Title } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
+import { environment } from '../environments/environment';
 import { Observable } from 'rxjs/Observable';
 import { PlatformService } from './platform.service';
 import { TranslateService, TranslatePipe, TranslateDirective } from '@ngx-translate/core';
@@ -112,10 +113,10 @@ export class AppComponent implements OnInit {
         minZoom: 2,
         maxZoom: 14
       },
-      year: 2016
+      year: environment.maxYear
     };
     const defaultViews = {
-      map: '/2016/auto/-136.80,20.68,-57.60,52.06',
+      map: `/${environment.maxYear}/auto/-136.80,20.68,-57.60,52.06`,
       rankings: '/evictions/United%20States/0/evictionRate',
       evictors: '/evictors'
     };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { TranslateModule, TranslateLoader, TranslatePipe } from '@ngx-translate/
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ToastModule, ToastOptions } from 'ng2-toastr';
+import { environment } from '../environments/environment';
 
 // local imports
 import { AppComponent } from './app.component';
@@ -42,7 +43,7 @@ export class CustomOption extends ToastOptions {
     BrowserAnimationsModule,
     HttpClientModule,
     RankingModule.forRoot({
-      dataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/city-rankings.csv'
+      dataUrl: environment.cityRankingDataUrl
     }),
     TranslateModule.forRoot({
       loader: {

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
+import { environment } from '../../environments/environment';
 import * as SphericalMercator from '@mapbox/sphericalmercator';
 import * as vt from '@mapbox/vector-tile';
 import * as Protobuf from 'pbf';
@@ -44,7 +45,7 @@ export class DataService {
   locations$ = this._locations.asObservable();
 
   private mercator = new SphericalMercator({ size: 256 });
-  private tileBase = 'https://tiles.evictionlab.org/';
+  private tileBase = environment.tileBaseUrl;
   private tilePrefix = 'evictions-';
   private tilesetYears = ['00', '10'];
   private queryZoom = 10;

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, OnInit, Input, Output, EventEmitter, SimpleChanges, OnChanges, ChangeDetectorRef
 } from '@angular/core';
+import { environment } from '../../../environments/environment';
 import { DownloadFormComponent } from './download-form/download-form.component';
 import { UiDialogService } from '../../ui/ui-dialog/ui-dialog.service';
 import { MapFeature } from '../map/map-feature';
@@ -94,9 +95,9 @@ export class DataPanelComponent implements OnInit, OnChanges {
 
   endSelect: Array<number>;
   barYearSelect: Array<number>;
-  minYear = 2000;
+  minYear = environment.minYear;
   lineStartYear: number = this.minYear;
-  maxYear = 2016;
+  maxYear = environment.maxYear;
   lineEndYear: number = this.maxYear;
   dollarProps = DollarProps;
   percentProps = PercentProps;

--- a/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, inject, async } from '@angular/core/testing';
 import { HttpClientModule, HttpRequest, HttpParams } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { environment } from '../../../../environments/environment';
 import { FileExportService } from './file-export.service';
 
 describe('FileExportService', () => {
@@ -65,7 +66,7 @@ describe('FileExportService', () => {
         service.sendFileRequest(['xlsx']).subscribe();
         backend.expectOne((req: HttpRequest<any>) => {
           const body = JSON.parse(req.body);
-          return req.url === 'https://exports.evictionlab.org/format/xlsx'
+          return req.url === `${environment.downloadBaseUrl}/format/xlsx`
             && req.method === 'POST'
             && req.headers.get('Content-Type') === 'application/json'
             && body.lang === 'en'

--- a/src/app/map-tool/data-panel/download-form/file-export.service.ts
+++ b/src/app/map-tool/data-panel/download-form/file-export.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
 import { MapFeature } from '../../map/map-feature';
 import * as bbox from '@turf/bbox';
 
@@ -23,7 +24,7 @@ export interface ExportType {
 
 @Injectable()
 export class FileExportService {
-  downloadBase = 'https://exports.evictionlab.org';
+  downloadBase = environment.downloadBaseUrl;
   lang: string;
   features: MapFeature[];
   year: number;

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -64,8 +64,8 @@
     class="year-slider"
     [label]="year"
     [(value)]="year" 
-    [min]="2000" 
-    [max]="2016" 
+    [min]="minYear" 
+    [max]="maxYear" 
   ></app-ui-slider>
 </div>
 <ng-content></ng-content>

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -2,6 +2,7 @@ import {
   Component, OnInit, OnChanges, HostBinding, Input, Output, EventEmitter, SimpleChanges, ViewChild,
   HostListener, ElementRef
 } from '@angular/core';
+import { environment } from '../../../../environments/environment';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/distinctUntilChanged';
@@ -25,6 +26,8 @@ import { PlatformService } from '../../../platform.service';
 })
 export class MapComponent implements OnInit, OnChanges {
   censusYear = 2010;
+  minYear = environment.minYear;
+  maxYear = environment.maxYear;
   mapEventLayers: Array<string>;
   cardProps;
   dollarProps = DollarProps;

--- a/src/app/ui/location-search/search/search-sources.ts
+++ b/src/app/ui/location-search/search/search-sources.ts
@@ -1,3 +1,4 @@
+import { environment } from '../../../../environments/environment';
 import { MapFeature } from '../../../map-tool/map/map-feature';
 
 export interface SearchSource {
@@ -38,11 +39,9 @@ export const MapzenSource: SearchSource = {
 };
 
 export const MapboxSource: SearchSource = {
-    key: 'pk.' +
-        'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
-        '4et5d5nstXWM5P0JG67XEQ',
+    key: environment.mapboxApiKey,
     baseUrl: 'https://api.mapbox.com/geocoding/v5/mapbox.places/',
-    csvUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+    csvUrl: environment.mapboxCountyUrl,
     featureList: [],
     query: function (text: string) {
         const queryParams = [

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,13 @@
 export const environment = {
-  production: true
+  production: true,
+  tileBaseUrl: 'https://tiles.evictionlab.org/',
+  cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/city-rankings.csv',
+  usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+  mapboxKey: 'pk.' +
+    'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqY20zamVpcTBwb3gzM28yb292YzM3dXoifQ.' +
+    'uKgAjsMd4qkJNqEtr3XyPQ',
+  mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+  downloadBaseUrl: 'https://exports.evictionlab.org',
+  minYear: 2000,
+  maxYear: 2016
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,0 +1,15 @@
+// Staging should use prod mode, but different specifics
+
+export const environment = {
+    production: true,
+    tileBaseUrl: 'https://tiles.evictionlab.org/',
+    cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/city-rankings.csv',
+    usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+    mapboxApiKey: 'pk.' +
+        'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
+        '4et5d5nstXWM5P0JG67XEQ',
+    mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+    downloadBaseUrl: 'https://exports-dev.evictionlab.org',
+    minYear: 2000,
+    maxYear: 2016
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,5 +4,15 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  tileBaseUrl: 'https://tiles.evictionlab.org/',
+  cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/city-rankings.csv',
+  usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+  mapboxApiKey: 'pk.' +
+    'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
+    '4et5d5nstXWM5P0JG67XEQ',
+  mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+  downloadBaseUrl: 'https://exports-dev.evictionlab.org',
+  minYear: 2000,
+  maxYear: 2016
 };


### PR DESCRIPTION
Closes #486. Trying to move a lot of the external service configuration to environment variables, especially for the exports link (which we have a dev URL for) and the Mapbox API key. Also updates the build step in Travis with this. A lot of it is redundant, but I figure we can add onto this as we go along, and it could make these changes easier in the future