### PR TITLE
Fix tooltip cursor scroll

### DIFF
--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -12,6 +12,10 @@
     outline: 4px solid transparentize($color1, 0.5);
     outline-offset: -4px;
   }
+  .mapboxgl-popup, .mapboxgl-popup-content {
+    cursor: pointer;
+    pointer-events: none;
+  }
   .mapboxgl-popup-content {
     background-color: $tooltipBackground;
     color: $tooltipFontColor;


### PR DESCRIPTION
Closes #491. Also adds `cursor: pointer` which gets removed sometimes if someone hovers on a tooltip and isn't immediately re-added now that we debounce the hover events