### PR TITLE
Update year slider styles

### DIFF
--- a/src/app/ui/ui-slider/ui-slider.component.html
+++ b/src/app/ui/ui-slider/ui-slider.component.html
@@ -1,9 +1,10 @@
+<span class="slider-label" *ngIf="min">{{min}}</span>
 <div #container class="el-slider">
   <div class="track track-full"></div>
   <div class="track track-value" [style.width]="percent"></div>
   <div #scrubber class="scrubber" [style.transform]="'translateX('+pxValue+'px)'">
-    <span class="scrubber-marker"></span>
+    <span class="scrubber-marker">{{ getStepValue(value) }}</span>
     <span class="scrubber-label">{{ getStepValue(value) }}</span>
   </div>
 </div>
-<span class="slider-label" *ngIf="label">{{label}}</span>
+<span class="slider-label" *ngIf="max">{{max}}</span>

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -15,9 +15,6 @@
     .scrubber-label:after {
       border-top-color: $foregroundColor!important;
     }
-    .scrubber-marker {
-      background: $textColor;
-    }
   }
 }
 
@@ -36,12 +33,22 @@
   }
 }
 .slider-label {
-  margin-left: grid(2);
-  @include defaultFont(14px);
+  @include numberFont(11px);
   letter-spacing: 0.5px;
   text-transform: uppercase;
   color: $sliderLabel;
 }
+
+.slider-label:first-child {
+  margin-left: grid(-1);
+  margin-right: grid(3);
+}
+
+.slider-label:last-child {
+  margin-right: grid(-3);
+  margin-left: grid(3);
+}
+
 .el-slider {
   width: 100%;
   height: 100%;
@@ -114,22 +121,36 @@
 
   // circle marker for scrubber
   .scrubber-marker {
-    width: grid(3);
-    height: grid(3);
+    width: grid(5);
+    height: grid(4);
+    line-height: grid(4);
     border-radius: 15px;
-    border: 5px solid $color1;
+    @include numberFont(11px);
+    text-align: center;
+    font-weight: 600;
     margin: auto;
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
+    color: $white;
+    background: $gradient1;
+    border-radius: grid(0.5);
   }
 }
 
 :host-context(.gt-mobile) {
   .slider-label {
-    margin-left: grid(3);
+    @include numberFont(14px);
+  }
+  .slider-label:first-child {
+    margin-left: 0;
+    margin-right: grid(4);
+  }
+  .slider-label:last-child {
+    margin-right: 0;
+    margin-left: grid(4);
   }
   .el-slider {
     .scrubber-label {
@@ -145,9 +166,15 @@
       }  
     }
     .scrubber-marker {
-      width: grid(5);
-      height: grid(5);
-      border-radius: grid(2.5);
+      width: grid(7);
+      @include numberFont(14px);
     }
+  }
+}
+
+// Don't show scrubber hover label on desktop
+:host-context(.gt-tablet) {
+  .el-slider {
+    .scrubber-label { display: none }
   }
 }

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -137,6 +137,7 @@
     color: $white;
     background: $gradient1;
     border-radius: grid(0.5);
+    box-shadow: $z3shadow;
   }
 }
 
@@ -167,6 +168,8 @@
     }
     .scrubber-marker {
       width: grid(7);
+      height: grid(6);
+      line-height: grid(6);
       @include numberFont(14px);
     }
   }


### PR DESCRIPTION
Closes #412. I have the years on both sides of the slider because it seemed to fit, but it'll be easy to remove it. I'm also not displaying the hover tooltip on desktop

Mobile:
![mobile-slider](https://user-images.githubusercontent.com/8291663/35171176-69f14316-fd28-11e7-97bd-4d8d490be8bd.gif)

Desktop:
![desktop-slider](https://user-images.githubusercontent.com/8291663/35171185-6f4b2fac-fd28-11e7-83c7-82c73c6ccaf2.gif)
