### PR TITLE
Bump OpenMapTiles max zoom to 13

### DIFF
--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -6,7 +6,7 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
-      "maxzoom": 12,
+      "maxzoom": 13,
       "tiles": [
         "https://openmaptiles.evictionlab.org/{z}/{x}/{y}.pbf"
       ],


### PR DESCRIPTION
Not sure why this was originally on 12, but the tiles are created through zoom 13