### PR TITLE
Update feature on zoomend, null check, fix names

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -235,9 +235,12 @@ export class MapService {
         f.geometry['coordinates'] = this.bboxPolygon(f.bbox);
         feat = f;
       }
-      feat['properties']['color'] = this.colors[i];
+      // Null check (later filtered out) null feature from getUnionFeature
+      if (feat !== null) {
+        feat['properties']['color'] = this.colors[i];
+      }
       return feat;
-    });
+    }).filter(f => f !== null);
     this.setSourceData('highlight', highlightFeatures);
   }
 

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -53,7 +53,7 @@
     [selectedLayer]="selectedLayer"
     [featureCount]="activeFeatures.length"
     (ready)="onMapReady($event)"
-    (zoom)="onMapZoom($event)"
+    (zoomEnd)="onMapZoomEnd($event)"
     (featureClick)="onFeatureClick($event)"
     (moveEnd)="onMapMoveEnd($event)"
   ></app-mapbox>

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -329,7 +329,7 @@ export class MapComponent implements OnInit, OnChanges {
    * Set the zoom value for the app, auto adjust layers if enabled
    * @param zoom the current zoom level of the map
    */
-  onMapZoom(zoom) {
+  onMapZoomEnd(zoom) {
     this.zoom = zoom;
     if (this.selectedLayer && this.selectedLayer.minzoom > zoom) {
       this.autoSwitch = true;
@@ -342,6 +342,7 @@ export class MapComponent implements OnInit, OnChanges {
         }
       }
     }
+    this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
   }
 
   enableZoom() { return this.map.enableZoom(); }

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -21,7 +21,7 @@ export class MapboxComponent implements AfterViewInit {
   @Input() selectedLayer: MapLayerGroup;
   @Input() featureCount = 0;
   @Output() ready: EventEmitter<any> = new EventEmitter();
-  @Output() zoom: EventEmitter<number> = new EventEmitter();
+  @Output() zoomEnd: EventEmitter<number> = new EventEmitter();
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   featureMouseMove: EventEmitter<any> = new EventEmitter();
@@ -117,10 +117,9 @@ export class MapboxComponent implements AfterViewInit {
    * Bind to map events for zoom and any specified event layers
    */
   private setupEmitters() {
-    // Emit all zoom end events from map
     this.map.on('moveend', (e) => this.moveEnd.emit(e));
     // Emit feature on zoom end to account for geography details changing across zooms
-    this.map.on('zoomend', () => this.zoom.emit(this.map.getZoom()));
+    this.map.on('zoomend', () => this.zoomEnd.emit(this.map.getZoom()));
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {


### PR DESCRIPTION
Closes #504 to the extent that it's the cause. Calling `updateHighlightFeatures` on `zoomend`, and also updated the events relating to `zoomend` to reflect that, rather than just saying `zoom`.

After looking it over, I don't actually think the topology exceptions are getting generated here though. `getUnionFeature` returning `null` wasn't initially handled entirely, but now there's an additional check so this should be covered