### PR TITLE
Another null check on highlight features

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -223,7 +223,11 @@ export class MapService {
         const geoidFeatures = highlightSource.filter(
           sf => sf['properties']['GEOID'] === f['properties']['GEOID']
         );
-        if (geoidFeatures.length > 0 && !this.shouldUpdateFeature(geoidFeatures[0], feat)) {
+        if (
+          geoidFeatures.length > 0 &&
+          feat !== null &&
+          !this.shouldUpdateFeature(geoidFeatures[0], feat)
+        ) {
           feat = geoidFeatures[0];
         }
       } else if (geoids.indexOf(f['properties']['GEOID']) !== -1) {


### PR DESCRIPTION
I missed one null check in #510 when `feat`, which might be `null`, is passed to `shouldUpdateFeature`. This adds a null check in the conditional to prevent that