### PR TITLE
Focus States

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,6 +8,6 @@
   (selectLocation)="onSearchSelect($event)"
   (selectLanguage)="onLanguageSelect($event)"
 ></app-header-bar>
-<app-menu [expanded]="menuActive" (onClose)="closeMenu()"></app-menu>
+<app-menu tabindex="-1" [expanded]="menuActive" (onClose)="closeMenu()"></app-menu>
 <router-outlet (activate)="onActivate($event)"></router-outlet>
 <app-footer role="contentinfo"></app-footer>

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -1,5 +1,35 @@
 <div class="navigation-wrapper">
-  <button class="btn btn-icon menu-close" (click)="onClose.emit()">
+  <nav class="site-navigation">
+    <ul>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Home</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Map &amp; Data</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Eviction Rankings</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">About Us</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Learn More</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Methods</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Help &amp; FAQ</a></li>
+      <li><a [attr.tabindex]="expanded ? null : -1" href="#">Updates</a></li>
+    </ul>
+  </nav>
+  <ul class="social-media-links">
+    <li>
+      <a [attr.tabindex]="expanded ? null : -1" class="btn btn-border" href="#" target="_blank">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+          <path d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" />
+        </svg>
+      </a>
+    </li>
+    <li>
+      <a [attr.tabindex]="expanded ? null : -1" class="btn btn-border" href="#" target="_blank">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+          <path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"
+          />
+        </svg>
+      </a>
+    </li>
+  </ul>
+  <span class="menu-copyright">&copy; 2018 Eviction Lab</span>
+  <button [attr.tabindex]="expanded ? null : -1" class="btn btn-icon menu-close" (click)="onClose.emit()">
     <svg viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g transform="translate(-377.000000, -14.000000)">
         <g transform="translate(369.000000, 13.000000)">
@@ -12,34 +42,4 @@
     </svg>
     <span>Close</span>
   </button>
-  <nav class="site-navigation">
-    <ul>
-      <li><a href="#">Home</a></li>
-      <li><a href="#">Map &amp; Data</a></li>
-      <li><a href="#">Eviction Rankings</a></li>
-      <li><a href="#">About Us</a></li>
-      <li><a href="#">Learn More</a></li>
-      <li><a href="#">Methods</a></li>
-      <li><a href="#">Help &amp; FAQ</a></li>
-      <li><a href="#">Updates</a></li>
-    </ul>
-  </nav>
-  <ul class="social-media-links">
-    <li>
-      <a class="btn btn-border" href="#" target="_blank">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
-          <path d="M17,2V2H17V6H15C14.31,6 14,6.81 14,7.5V10H14L17,10V14H14V22H10V14H7V10H10V6A4,4 0 0,1 14,2H17Z" />
-        </svg>
-      </a>
-    </li>
-    <li>
-      <a class="btn btn-border" href="#" target="_blank">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
-          <path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"
-          />
-        </svg>
-      </a>
-    </li>
-  </ul>
-  <span class="menu-copyright">&copy; 2018 Eviction Lab</span>
 </div>

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -27,8 +27,8 @@
   // TEMPORARY - should have a focus style for accessibility
   &:focus {
     box-shadow:none;
-    .el-slider .scrubber-label {
-      opacity:1;
+    .el-slider .scrubber-marker {
+      box-shadow: 0 0 4px 2px $color1, 0 2px 5px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
     }
   }
 }
@@ -146,11 +146,11 @@
   }
   .slider-label:first-child {
     margin-left: 0;
-    margin-right: grid(4);
+    margin-right: grid(5);
   }
   .slider-label:last-child {
     margin-right: 0;
-    margin-left: grid(4);
+    margin-left: grid(5);
   }
   .el-slider {
     .scrubber-label {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -94,9 +94,9 @@ $focusBgColor: #FFE8DE;
 
 // Shadows
 // ----
-$z1shadow: 0 1px 4px 0 rgba(0,0,0,0.30);
-$z2shadow: 0 2px 5px rgba(0,0,0,0.5);
-$z3shadow: 0 2px 5px rgba(0,0,0,0.5), 0 2px 10px rgba(0,0,0,0.5);
+$z1shadow: 0 1px 3px 0 rgba(0,0,0,0.30);
+$z2shadow: 0 2px 4px rgba(0,0,0,0.5);
+$z3shadow: 0 2px 5px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
 
 @mixin focusState() {
   outline: 0;

--- a/src/theme/base/buttons.scss
+++ b/src/theme/base/buttons.scss
@@ -14,6 +14,7 @@ body {
     }
     &:active, &:focus, &:active:focus {
       background: darken($buttonHoverColor, 5%);
+      outline: 0;
     }
     // icon above button label
     svg{ display:block; margin: 0 auto 6px;}


### PR DESCRIPTION
A pass through the focus states in the app to make sure everything that is focused has a visible state.  The only case where there is an exception is when the map canvas has focus, not sure how to handle that yet.  Currently displays an orange outline of Firefox, but doesn't render on Chrome. Closes #414, will make any further revisions on a component-by-component basis if they are suggested by Noele.

In this PR:
  - Remove blue glow when button has both `:focus` and `:active` so only the orange glow shows. 
  - Change slider focus from having the tooltip visible to having an orange glow
  - Move close button in the DOM tree so it receives focus after the user has tabbed through links
  - Skip tabbing through menu links if the menu is closed (closes #517)