### PR TITLE
Add US average to graph, card data

### DIFF
--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -302,6 +302,16 @@ export class DataService {
       +feature.properties['east'],
       +feature.properties['north']
     ];
+    // Add evictions-per-day property
+    Object.keys(feature.properties)
+      .filter(p => p.startsWith('e-'))
+      .forEach(p => {
+        const evictions = +feature.properties[p];
+        const yearSuffix = p.split('-').slice(1)[0];
+        const daysInYear = +yearSuffix % 4 === 0 ? 366 : 365;
+        const evictionsPerDay = evictions > 0 ? +(evictions / daysInYear).toFixed(2) : -1;
+        feature.properties[`epd-${yearSuffix}`] = evictionsPerDay;
+      });
     return feature;
   }
 

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpResponse, HttpHeaders } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import { environment } from '../../environments/environment';
 import * as SphericalMercator from '@mapbox/sphericalmercator';
@@ -36,6 +36,7 @@ export class DataService {
   activeBubbleHighlight: MapDataAttribute = BubbleAttributes[0];
   mapView;
   mapConfig;
+  usAverage;
 
   get selectedLanguage() {
     return this.languageOptions.filter(l => l.id === this.translate.currentLang)[0];
@@ -213,7 +214,7 @@ export class DataService {
    */
   updateLocation(feature: MapFeature) {
     // Process feature if bbox and layerId not included based on current data level
-    if (!(feature.properties.bbox && feature.properties.bbox)) {
+    if (!(feature.properties.bbox && feature.properties.layerId)) {
       feature = this.processMapFeature(feature);
     }
     const geoids = this.activeFeatures.map(f => f.properties.GEOID);
@@ -302,6 +303,12 @@ export class DataService {
       +feature.properties['north']
     ];
     return feature;
+  }
+
+  loadUSAverage() {
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    this.http.get(environment.usAverageDataUrl, { headers: headers })
+      .subscribe(data => this.usAverage = data);
   }
 
   private stripYearFromAttr(attr: string) {

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -74,7 +74,7 @@
               <path d="M20,0 C29.8203125,0 40,6.75551115 40,19.0800608 C40,27.2964272 33.3333333,40.2697402 20,58 C6.66666667,40.3015304 3.48313052e-16,27.3282173 0,19.0800608 C0,6.70782593 10.1796875,0 20,0 Z M19.5,29.7038377 C24.4705627,29.7038377 28.5,25.6678161 28.5,20.6891311 C28.5,15.7104461 24.4705627,11.6744245 19.5,11.6744245 C14.5294373,11.6744245 10.5,15.7104461 10.5,20.6891311 C10.5,25.6678161 14.5294373,29.7038377 19.5,29.7038377 Z" id="Combined-Shape"></path>
             </svg>
             <span class="legend-label">{{ location.properties["n"] }}</span>
-            <button [attr.aria-label]="'DATA.REMOVE_LOCATION' | translate:{'name':location.properties.n}" class="btn btn-close" (click)="last ? toggleUS() : locationRemoved.emit(location)">
+            <button [attr.aria-label]="(!showUS && last ? 'DATA.ADD_LOCATION' : 'DATA.REMOVE_LOCATION') | translate:{'name':location.properties.n}" class="btn btn-close" (click)="last ? toggleUS() : locationRemoved.emit(location)">
               <span aria-hidden="true">&times;</span>
             </button>
             <p class="legend-data">

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -1,15 +1,15 @@
 <div class="data-wrapper">
   <div class="mobile-scroll-indicator">
-    <p *ngIf="locations.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
-    <p *ngIf="locations.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
+    <p *ngIf="displayLocations.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
+    <p *ngIf="displayLocations.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
   </div>
   <div class="data-header">
       <p [innerHTML]="'DATA.CARD_HEADING' | translate:{'year':year}"></p>
   </div>
   <app-location-cards
     class="card-table"
-    [allowAddLocation]="locations.length < 3"
-    [features]="locations"
+    [allowAddLocation]="displayLocations.length < 3"
+    [features]="displayLocations"
     [year]="year"
     [cardProperties]="cardProps"
     (dismissedCard)="locationRemoved.emit($event)"
@@ -68,12 +68,12 @@
       </div>
       <div class="graph-legend">
         <ul>
-          <li *ngFor="let location of locations; let i = index">
+          <li *ngFor="let location of allLocations; let i = index; let last = last" [class.us-average]="last" [class.active]="showUS && last">
             <svg class="legend-marker marker" viewBox="0 0 40 58" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <path d="M20,0 C29.8203125,0 40,6.75551115 40,19.0800608 C40,27.2964272 33.3333333,40.2697402 20,58 C6.66666667,40.3015304 3.48313052e-16,27.3282173 0,19.0800608 C0,6.70782593 10.1796875,0 20,0 Z M19.5,29.7038377 C24.4705627,29.7038377 28.5,25.6678161 28.5,20.6891311 C28.5,15.7104461 24.4705627,11.6744245 19.5,11.6744245 C14.5294373,11.6744245 10.5,15.7104461 10.5,20.6891311 C10.5,25.6678161 14.5294373,29.7038377 19.5,29.7038377 Z" id="Combined-Shape"></path>
             </svg>
             <span class="legend-label">{{ location.properties["n"] }}</span>
-            <button [attr.aria-label]="'DATA.REMOVE_LOCATION' | translate:{'name':location.properties.n}" class="btn btn-close" (click)="locationRemoved.emit(location)">
+            <button [attr.aria-label]="'DATA.REMOVE_LOCATION' | translate:{'name':location.properties.n}" class="btn btn-close" (click)="last ? toggleUS() : locationRemoved.emit(location)">
               <span aria-hidden="true">&times;</span>
             </button>
             <p class="legend-data">

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -10,6 +10,7 @@
     class="card-table"
     [allowAddLocation]="displayLocations.length < 3"
     [features]="displayLocations"
+    [usAverage]="dataService.usAverage"
     [year]="year"
     [cardProperties]="cardProps"
     (dismissedCard)="locationRemoved.emit($event)"

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -257,6 +257,22 @@
     &:nth-child(3) .legend-marker path { fill: $graphColor3; }
     &:nth-child(4) .legend-marker path { fill: $graphColor4; }
   }
+  li.us-average {
+    opacity: 0.5;
+
+    .btn.btn-close::after {
+      transform: rotate(45deg);
+      transition: all 0.2s ease;
+    }
+
+    &.active {
+      opacity: 1;
+
+      .btn.btn-close::after {
+        transform: rotate(0deg);
+      }
+    }
+  }
 }
 
 :host-context(.gt-mobile) {

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -100,6 +100,7 @@ export class DataPanelComponent implements OnInit, OnChanges {
   graphType = 'line';
   graphTypeOptions = this.createGraphTypeOptions();
   cardProps = {
+    'epd': 'STATS.JUDGMENTS_PER_DAY',
     'er': 'STATS.JUDGMENT_RATE',
     'e': 'STATS.JUDGMENTS',
     'efr': 'STATS.FILING_RATE',

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -30,6 +30,7 @@ export class DataServiceStub {
   mapView;
   mapConfig;
   getRouteArray() { return []; }
+  loadUSAverage() {}
 }
 
 describe('MapToolComponent', () => {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -209,9 +209,9 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   onSearchSelect(feature: MapFeature | null, updateMap = true) {
     if (feature) {
       this.loader.start('search');
-      const layerId = feature.properties['layerId'];
+      const layerId = feature.properties['layerId'] as string;
       this.dataService.getTileData(
-        layerId, feature.geometry['coordinates'], feature.properties['name'], true
+        layerId, feature.geometry['coordinates'], feature.properties['name'] as string, true
       ).subscribe(data => {
           if (!data.properties.n) {
             this.toast.error('Could not find data for location.');

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -71,6 +71,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
     // Add click to dimiss to all toast messages
     this.toast.onClickToast()
       .subscribe(t => this.toast.dismissToast(t));
+    this.dataService.loadUSAverage();
   }
 
   ngOnInit() {

--- a/src/app/map-tool/map/map-feature.ts
+++ b/src/app/map-tool/map/map-feature.ts
@@ -1,6 +1,6 @@
 export interface MapFeature extends GeoJSON.Feature<GeoJSON.GeometryObject> {
     bbox?: number[];
     properties: {
-        [n: string]: string;
+        [n: string]: string | number;
     };
 }

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -217,9 +217,9 @@ export class MapService {
       // Otherwise, check if currently added or use bounding box
       if (
         f.properties['layerId'] === layerId &&
-        this.hasRenderedFeatures(f.properties['layerId'], f)
+        this.hasRenderedFeatures(f.properties['layerId'] as string, f)
       ) {
-        feat = this.getUnionFeature(f.properties['layerId'], f);
+        feat = this.getUnionFeature(f.properties['layerId'] as string, f);
         const geoidFeatures = highlightSource.filter(
           sf => sf['properties']['GEOID'] === f['properties']['GEOID']
         );

--- a/src/app/ui/location-cards/location-cards.component.html
+++ b/src/app/ui/location-cards/location-cards.component.html
@@ -16,6 +16,7 @@
   <div class="card-content">
     <ul class="card-stats">
       <li *ngFor="let propName of cardPropertyKeys; let i = index;" [class]="propName">
+        <span *ngIf="i === 1 && usAverage && f.properties[propName + '-' + abbrYear] > 0" class="card-stat-comparison">{{ f.properties[propName + '-' + abbrYear] > usAverage[propName + '-' + abbrYear] ? '+' : '' }}{{ f.properties[propName + '-' + abbrYear] - usAverage[propName + '-' + abbrYear] | number : '1.1-2' }} {{ 'DATA.US_AVERAGE' | translate }}</span>
         <span class="card-stat-label">{{ cardProperties[propName] | translate }}</span>
         <span *ngIf="propName !== 'divider'" class="card-stat-value" [class.unavailable]="!(f.properties[propName + '-' + abbrYear] >= 0)">
           <span *ngIf="f.properties[propName + '-' + abbrYear] >= 0">{{ prefix(propName) }}{{ (f.properties[propName + '-' + abbrYear] | number) }}{{ suffix(propName) }}</span>

--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -245,6 +245,9 @@
     box-shadow:none;
     margin-right: grid(2);
     &:last-child { margin-right: 0; }
+    &:nth-child(1) .card-stat-comparison { color: $cardHeaderBg1 }
+    &:nth-child(2) .card-stat-comparison { color: $cardHeaderBg2 }
+    &:nth-child(3) .card-stat-comparison { color: $cardHeaderBg3 }
     // marker icon
     .card-header svg { 
         display:block; 
@@ -274,7 +277,7 @@
       top: auto;
       bottom: grid(5);
     }
-    .card-stats { padding-top: grid(12); }
+    .card-stats { padding-top: grid(14); }
     .card-stats li {
       .card-stat-value { 
         color: $panelCardValueText;
@@ -289,7 +292,7 @@
         width:50%;
         top:0;
         left:0;
-        height: grid(12);
+        height: grid(14);
         border-bottom:1px solid $panelCardBorder;
         text-align:center;
         display:flex;
@@ -306,6 +309,13 @@
           &.unavailable {
             @include defaultFont($panelCardLabelValueLg);
           }
+        }
+        .card-stat-comparison {
+          display: block;
+          position: absolute;
+          bottom: grid(1.5);
+          right: 0;
+          left: 0;
         }
       }
       &:nth-child(2) {
@@ -406,10 +416,10 @@
       bottom: grid(4.5);
     }
     .card-stats { 
-      padding-top: grid(13); 
+      padding-top: grid(15); 
       li:nth-child(1),
       li:nth-child(2) {
-        height: grid(13);
+        height: grid(15);
         .card-stat-label { font-size: $panelCardLabelTextLg_t; }
         .card-stat-value { font-size: $panelCardLabelValueLg_t; }
       }

--- a/src/app/ui/location-cards/location-cards.component.ts
+++ b/src/app/ui/location-cards/location-cards.component.ts
@@ -47,6 +47,7 @@ import { DecimalPipe } from '@angular/common';
 export class LocationCardsComponent implements OnInit {
   @Input() allowAddLocation = false;
   @Input() features: Array<any> = [];
+  @Input() usAverage: Object;
   @Input() year = 2010;
   @Input() percentProps: Array<string>;
   @Input() dollarProps: Array<string>;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -36,6 +36,7 @@
     "GRAPH_BAR_LABEL": "Bar",
     "GRAPH_LINE_LABEL": "Line",
     "UNAVAILABLE": "Unavailable",
+    "ADD_LOCATION": "Add {{name}}",
     "REMOVE_LOCATION": "Remove {{name}}",
     "US_AVERAGE": "U.S. average"
   },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -36,7 +36,8 @@
     "GRAPH_BAR_LABEL": "Bar",
     "GRAPH_LINE_LABEL": "Line",
     "UNAVAILABLE": "Unavailable",
-    "REMOVE_LOCATION": "Remove {{name}}"
+    "REMOVE_LOCATION": "Remove {{name}}",
+    "US_AVERAGE": "U.S. average"
   },
   "HEADER": {
     "HOME": "Home",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -36,6 +36,7 @@
     "GRAPH_BAR_LABEL": "Bar",
     "GRAPH_LINE_LABEL": "Line",
     "UNAVAILABLE": "Unavailable",
+    "ADD_LOCATION": "Add {{name}}",
     "REMOVE_LOCATION": "Eliminar {{name}}",
     "US_AVERAGE": "U.S. average"
   },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -36,7 +36,8 @@
     "GRAPH_BAR_LABEL": "Bar",
     "GRAPH_LINE_LABEL": "Line",
     "UNAVAILABLE": "Unavailable",
-    "REMOVE_LOCATION": "Eliminar {{name}}"
+    "REMOVE_LOCATION": "Eliminar {{name}}",
+    "US_AVERAGE": "U.S. average"
   },
   "HEADER": {
     "HOME": "Inicio",

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -77,7 +77,7 @@ $white: #fff;
 $color1: #e24000;
 $color2: #434878;
 $color3: #2c897f;
-$color4: #4a4238;
+$color4: #94AABD;
 $color5: #b5c2b7;
 $gradient1: linear-gradient(180deg, #F27636, #E04119);
 $gradient2: linear-gradient(180deg, #787EB0, #434878);


### PR DESCRIPTION
Closes #463. Splits `locations` on the data panel into `displayLocations` for anything that should have its own location card and `allLocations` for anything that should be displayed on the graph. Updates `$color4` in sass to be the color mentioned in the issue (it was a dark gray). Also fixes an unrelated typo in the data service (`bbox` was being checked twice when it should be checking for `bbox` and `layerId` according to a comment)


![us-avg](https://user-images.githubusercontent.com/8291663/35356180-47c270a8-0115-11e8-8f41-14dbcf383016.gif)
