### PR TITLE
Fix tooltip, comparison style

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -437,6 +437,9 @@
   &:nth-child(3):before {
     background:$color3;
   }
+  &:nth-child(4):before {
+    background:$color4;
+  }
   .line-tooltip-year {
     display:block;
     font-weight: 400;

--- a/src/app/ui/location-cards/location-cards.component.html
+++ b/src/app/ui/location-cards/location-cards.component.html
@@ -16,7 +16,7 @@
   <div class="card-content">
     <ul class="card-stats">
       <li *ngFor="let propName of cardPropertyKeys; let i = index;" [class]="propName">
-        <span *ngIf="i === 1 && usAverage && f.properties[propName + '-' + abbrYear] > 0" class="card-stat-comparison">{{ f.properties[propName + '-' + abbrYear] > usAverage[propName + '-' + abbrYear] ? '+' : '' }}{{ f.properties[propName + '-' + abbrYear] - usAverage[propName + '-' + abbrYear] | number : '1.1-2' }} {{ 'DATA.US_AVERAGE' | translate }}</span>
+        <span *ngIf="i === 1 && usAverage && f.properties[propName + '-' + abbrYear] > 0" class="card-stat-comparison">{{ f.properties[propName + '-' + abbrYear] > usAverage[propName + '-' + abbrYear] ? '+' : '' }}{{ f.properties[propName + '-' + abbrYear] - usAverage[propName + '-' + abbrYear] | number : '1.1-1' }} {{ 'DATA.US_AVERAGE' | translate }}</span>
         <span class="card-stat-label">{{ cardProperties[propName] | translate }}</span>
         <span *ngIf="propName !== 'divider'" class="card-stat-value" [class.unavailable]="!(f.properties[propName + '-' + abbrYear] >= 0)">
           <span *ngIf="f.properties[propName + '-' + abbrYear] >= 0">{{ prefix(propName) }}{{ (f.properties[propName + '-' + abbrYear] | number) }}{{ suffix(propName) }}</span>

--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -311,6 +311,7 @@
           }
         }
         .card-stat-comparison {
+          font-size: 13px;
           display: block;
           position: absolute;
           bottom: grid(1.5);


### PR DESCRIPTION
Closes #524 and #525.

Tooltip styles:
<img width="1169" alt="screen shot 2018-01-25 at 9 02 33 am" src="https://user-images.githubusercontent.com/8291663/35394942-a634135a-01ae-11e8-8fef-b2d4930e35c0.png">

Updated US comparison:
<img width="277" alt="screen shot 2018-01-25 at 9 00 55 am" src="https://user-images.githubusercontent.com/8291663/35394955-ae133498-01ae-11e8-9137-1f4092456559.png">

