### PR TITLE
Update mapbox-gl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6584,26 +6584,6 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
-    "lodash._baseisequal": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-      "requires": {
-        "lodash.isarray": "3.0.4",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -6627,35 +6607,10 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.istypedarray": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -6825,9 +6780,9 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.43.0.tgz",
-      "integrity": "sha512-mSyGdXEy+JXXZS5/U4IL13JnOeHx8IoyrNPalxQnagFf3X8olaqKBy49YyEIBeAxTBR4QDeS50fwDLJK1C2Hgg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.44.0.tgz",
+      "integrity": "sha512-vMeZaLXjG1B1BKOD9HB11sb9UIUvbzXWJu0NR38j9Uyp1h5xUXqh1Rqe+EhxQp3jzlHIv/LVhFKCJjQQKA2LoA==",
       "requires": {
         "@mapbox/gl-matrix": "0.0.1",
         "@mapbox/mapbox-gl-supported": "1.3.0",
@@ -6846,7 +6801,6 @@
         "gray-matter": "3.1.1",
         "grid-index": "1.0.0",
         "jsonlint-lines-primitives": "1.6.0",
-        "lodash.isequal": "3.0.4",
         "minimist": "0.0.8",
         "package-json-versionify": "1.0.4",
         "pbf": "3.1.0",
@@ -6863,15 +6817,6 @@
         "webworkify": "1.5.0"
       },
       "dependencies": {
-        "lodash.isequal": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
-          "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
-          "requires": {
-            "lodash._baseisequal": "3.0.7",
-            "lodash._bindcallback": "3.0.1"
-          }
-        },
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "intl": "^1.2.5",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
-    "mapbox-gl": "^0.43.0",
+    "mapbox-gl": "^0.44.0",
     "ng2-page-scroll": "^4.0.0-beta.11",
     "ng2-toastr": "^4.1.2",
     "ngx-bootstrap": "^2.0.0-beta.9",


### PR DESCRIPTION
General update to `mapbox-gl` 0.44.0. This seems to bring some substantial performance improvements from playing around with it locally. In particular, zoom seems a bit smoother, and hover interactions on location cards seem much smoother (I'm guessing that's since the map is performing better so the site is faster generally)

Seems to mitigate #189, but I don't think that's fully fixable