### PR TITLE
Fix city labels, feature bug

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -259,14 +259,11 @@ export class MapService {
    */
   updateCensusSource(layerGroups: MapLayerGroup[], sourceSuffix: string) {
     const mapStyle: mapboxgl.Style = this.map.getStyle();
-    const layerObj = {};
-    layerGroups.forEach(l => {
-      layerObj[l.id] = l.layerIds;
-    });
+    const layerPrefixes = layerGroups.map(l => l.id);
 
     mapStyle.layers.map(l => {
       const layerPrefix = l.id.split('_')[0];
-      if (layerObj.hasOwnProperty(layerPrefix)) {
+      if (layerPrefixes.indexOf(layerPrefix) > -1) {
         l.source = `us-${layerPrefix}-${sourceSuffix}`;
       }
       return l;
@@ -404,6 +401,11 @@ export class MapService {
    * @param newFeat
    */
   private shouldUpdateFeature(currentFeat, newFeat): boolean {
+    // Check if the current feature has geometry
+    if (!currentFeat.geometry && newFeat.geometry) { return true; }
+    // Return false and exit early if the new feature has no geometry
+    if (!newFeat.geometry) { return false; }
+
     const bboxPoly = {
       type: 'Polygon',
       coordinates: currentFeat.hasOwnProperty('bbox') ?

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -978,7 +978,7 @@
       }
     },
     {
-      "id": "cities_extra_small_labels",
+      "id": "city_extra_small_labels",
       "type": "symbol",
       "source": "us-cities-10",
       "source-layer": "cities-centers",
@@ -1033,7 +1033,7 @@
       }
     },
     {
-      "id": "cities_small_labels",
+      "id": "city_small_labels",
       "type": "symbol",
       "source": "us-cities-10",
       "source-layer": "cities-centers",
@@ -1087,7 +1087,7 @@
       }
     },
     {
-      "id": "cities_mid_labels",
+      "id": "city_mid_labels",
       "type": "symbol",
       "source": "us-cities-10",
       "source-layer": "cities-centers",
@@ -1145,7 +1145,7 @@
       }
     },
     {
-      "id": "cities_large_labels",
+      "id": "city_large_labels",
       "type": "symbol",
       "source": "us-cities-10",
       "source-layer": "cities-centers",


### PR DESCRIPTION
Closes #533 by changing the city label layer names.

In the process, I noticed that the `updateCensusSource` had a lot of unnecessary processing, so I simplified it to be more clear.

Also, I think I may have fixed #505. Sometimes the features end up in `shouldUpdateFeature` without `geometry` (seems more common on multi-polygons), so I'm checking for that now as well. Before it was throwing an error in the later functions because that property is required