### PR TITLE
Refactor hover popup and outline

### DIFF
--- a/src/app/data/data-levels.ts
+++ b/src/app/data/data-levels.ts
@@ -9,7 +9,6 @@ export const DataLevels: Array<MapLayerGroup> = [
       'states',
       'states_stroke',
       'states_bubbles',
-      'states_text',
       'states_null'
     ],
     'minzoom': 0,

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -204,7 +204,7 @@ export class DataService {
       .find(f => f.properties.GEOID === feature.properties.GEOID);
     if (exists) { return null; }
     // Process feature if bbox and layerId not included based on current data level
-    if (!(feature.properties.bbox && feature.properties.bbox)) {
+    if (!(feature.bbox && feature.properties.layerId)) {
       feature = this.processMapFeature(feature);
     }
     const maxLocations = (this.activeFeatures.length >= 3);
@@ -221,7 +221,7 @@ export class DataService {
    */
   updateLocation(feature: MapFeature) {
     // Process feature if bbox and layerId not included based on current data level
-    if (!(feature.properties.bbox && feature.properties.layerId)) {
+    if (!(feature.bbox && feature.properties.layerId)) {
       feature = this.processMapFeature(feature);
     }
     const geoids = this.activeFeatures.map(f => f.properties.GEOID);

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/distinct';
@@ -15,13 +15,12 @@ import { MapFeature } from './map-feature';
 @Injectable()
 export class MapService {
   private map: mapboxgl.Map;
-  private popup: mapboxgl.Popup;
   private _isLoading = new BehaviorSubject<boolean>(true);
   isLoading$ = this._isLoading.asObservable();
   private colors = ['#e24000', '#434878', '#2c897f'];
   get mapCreated() { return this.map !== undefined; }
 
-  constructor(private zone: NgZone) { }
+  constructor() { }
 
   /** Expose any MapboxGL API functions that are needed  */
   // https://www.mapbox.com/mapbox-gl-js/api/#map#setpaintproperty
@@ -53,22 +52,6 @@ export class MapService {
    * @param map mapbox instance
    */
   setMapInstance(map) { this.map = map; }
-
-  /**
-   * Setup hover popup to display when labels are not visible
-   * @param layerIds layer IDs to query for tooltip label
-   */
-  setupHoverPopup(layerIds: string[]) {
-    this.popup = new mapboxgl.Popup({ closeButton: false });
-    this.zone.runOutsideAngular(() => {
-      Observable.fromEvent(this.map, 'mousemove')
-        .debounceTime(100)
-        .subscribe(e => this.updateHoverTooltip(e, layerIds));
-      Observable.fromEvent(this.map, 'mouseout')
-        .debounceTime(100)
-        .subscribe(e => this.popup.remove());
-    });
-  }
 
   /**
    * Set the visibility for a mapbox layer
@@ -155,13 +138,19 @@ export class MapService {
    * @param feature feature with attributes to query
    */
   getUnionFeature(layerId: string, feature: MapFeature): GeoJSON.Feature<GeoJSON.Polygon> | null {
+    // Check if feature already has needed data first
+    const geomBbox = bbox(feature);
+    const featBbox = this.featureBbox(feature);
+    const addReduce = (a, b) => a + b;
+    if (
+      this.bboxArea(geomBbox) >= (this.bboxArea(featBbox) * 0.98) &&
+      geomBbox.reduce(addReduce, 0) !== featBbox.reduce(addReduce, 0)
+    ) {
+      return feature as GeoJSON.Feature<GeoJSON.Polygon>;
+    }
     const queryFeatures = this.map.queryRenderedFeatures(undefined, {
       layers: [layerId],
-      filter: [
-        'all',
-        ['==', 'n', feature.properties.n],
-        ['==', 'pl', feature.properties.pl]
-      ]
+      filter: ['==', 'GEOID', feature.properties['GEOID']]
     });
     if (queryFeatures.length > 0) {
       return queryFeatures.reduce((currFeat, nextFeat) => {
@@ -326,49 +315,17 @@ export class MapService {
     ], { padding: 50 });
   }
 
-  /**
-   * Update hover tooltip content
-   */
-  private updateHoverTooltip(e: any, layerIds: string[]) {
-    const features = this.map.queryRenderedFeatures(e.point, { layers: layerIds });
-    if (features.length) {
-      const feat: MapFeature = features[0];
-      const labelLayerId = `${feat['layer']['id']}_text`;
-      let updateTooltip;
-      // Check if label layer exists, otherwise check features
-      if (this.map.getLayer(labelLayerId) === undefined) {
-        updateTooltip = true;
-      } else {
-        const labelFeatures = this.map.queryRenderedFeatures(undefined, {
-          layers: [`${feat['layer']['id']}_text`],
-          filter: [
-            'all',
-            ['==', 'n', feat.properties.n],
-          ]
-        });
-        // Check if labels are visible, don't display tooltip if so
-        const labelLayerOpacity = this.map.getPaintProperty(
-          `${feat['layer']['id']}_text`, 'text-opacity'
-        );
-        let labelsVisible;
-        if (labelLayerOpacity) {
-          labelsVisible = labelLayerOpacity['stops'][0][0] >= this.map.getZoom();
-        } else {
-          labelsVisible = false;
-        }
-        updateTooltip = !(labelFeatures.length && !labelsVisible && labelLayerOpacity !== 0);
-      }
+  private bboxArea(bbox: Array<number>): number {
+    return Math.abs(bbox[0] - bbox[2]) * Math.abs(bbox[1] - bbox[3]);
+  }
 
-      if (updateTooltip) {
-        this.popup.setLngLat(e.lngLat)
-          .setHTML(`${feat.properties.n}, ${feat.properties.pl}`)
-          .addTo(this.map);
-      } else {
-        this.popup.remove();
-      }
-    } else {
-      this.popup.remove();
-    }
+  private featureBbox(feature: MapFeature): Array<number> {
+    return [
+      +feature.properties['west'],
+      +feature.properties['south'],
+      +feature.properties['east'],
+      +feature.properties['north']
+    ];
   }
 
   /**

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -135,7 +135,6 @@ export class MapComponent implements OnInit, OnChanges {
   @Output() clickedCardHeader: EventEmitter<any> = new EventEmitter();
   @Output() dismissedCard: EventEmitter<any> = new EventEmitter();
   @Output() featureClick: EventEmitter<any> = new EventEmitter();
-  @Output() featureHover: EventEmitter<any> = new EventEmitter();
   @Output() boundingBoxChange: EventEmitter<Array<number>> = new EventEmitter();
   @Output() yearChange: EventEmitter<number> = new EventEmitter();
   @Output() selectedLayerChange: EventEmitter<MapLayerGroup> = new EventEmitter();
@@ -299,9 +298,6 @@ export class MapComponent implements OnInit, OnChanges {
   onMapReady(map) {
     this._mapInstance = map;
     this.map.setMapInstance(map);
-    if (this.gtMobile) {
-      this.map.setupHoverPopup(this.mapEventLayers);
-    }
     this.setGroupVisibility(this.selectedLayer);
     this.updateCensusYear();
     this.updateMapData();

--- a/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapboxComponent } from './mapbox.component';
 import { MapService } from '../map.service';
+import { PlatformService } from '../../../platform.service';
 
 describe('MapboxComponent', () => {
   let component: MapboxComponent;
@@ -22,7 +23,7 @@ describe('MapboxComponent', () => {
         MapboxComponent
       ],
       providers: [
-        MapService
+        MapService, PlatformService
       ]
     }).compileComponents();
   }));

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -4,8 +4,12 @@ import {
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { MapService } from '../map.service';
+import { PlatformService } from '../../../platform.service';
 import { MapLayerGroup } from '../../map/map-layer-group';
+import { MapFeature } from '../../map/map-feature';
 import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/throttleTime';
+import 'rxjs/add/operator/distinctUntilChanged';
 
 @Component({
   selector: 'app-mapbox',
@@ -14,6 +18,8 @@ import 'rxjs/add/observable/fromEvent';
 })
 export class MapboxComponent implements AfterViewInit {
   private map: mapboxgl.Map;
+  private popup: mapboxgl.Popup;
+  private mapStyle: Object;
   private activeFeature: any;
   @ViewChild('map') mapEl: ElementRef;
   @Input() mapConfig: Object;
@@ -25,12 +31,15 @@ export class MapboxComponent implements AfterViewInit {
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   featureMouseMove: EventEmitter<any> = new EventEmitter();
-  featureMouseLeave: EventEmitter<any> = new EventEmitter();
   hoverColors = [
     'rgba(226,64,0,0.8)', 'rgba(67,72,120,0.8)', 'rgba(44,137,127,0.8)', 'rgba(255,255,255,0.8)'
   ];
 
-  constructor(private mapService: MapService, private zone: NgZone) { }
+  constructor(
+    private mapService: MapService,
+    private platform: PlatformService,
+    private zone: NgZone
+  ) { }
 
   /**
    * Create map object from mapEl ViewChild
@@ -43,6 +52,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
     this.map.addControl(new mapboxgl.GeolocateControl({showUserLocation: false}), 'top-left');
     this.map.addControl(new mapboxgl.AttributionControl({ compact: true }), 'top-left');
+    this.popup = new mapboxgl.Popup({ closeButton: false });
     this.map.on('load', () => {
       this.onMapInstance(this.map);
     });
@@ -65,33 +75,39 @@ export class MapboxComponent implements AfterViewInit {
    */
   on(...args: any[]) { return this.map.on.apply(this.map, arguments); }
 
-  onMouseEnterFeature() { this.map.getCanvas().style.cursor = 'pointer'; }
+  onMouseEnterFeature(e) {
+    this.map.getCanvas().style.cursor = 'pointer';
+    this.updatePopupContent(e.features.length > 0 ? e.features[0] : null);
+    this.updatePopupLocation(e);
+  }
 
   onMouseLeaveFeature() {
     this.map.getCanvas().style.cursor = '';
     this.activeFeature = null;
     this.mapService.setSourceData('hover');
+    // Make sure debounced featureMouseMove doesn't re-add element
+    this.featureMouseMove.emit({features: []});
+    this.popup.remove();
   }
 
-  onMouseMoveFeature(e) {
-    if (e.features.length) {
-      const feature = e.features[0];
-      if (
-        !this.activeFeature ||
-        this.activeFeature.properties.n !== feature.properties.n ||
-        this.activeFeature.properties.pl !== feature.properties.pl
-      ) {
-        this.activeFeature = feature;
-        if (feature && feature.layer.id === this.selectedLayer.id) {
-          const union = this.mapService.getUnionFeature(this.selectedLayer.id, feature);
-          if (union !== null) {
-            union.properties['color'] = this.hoverColors[this.featureCount];
-            this.mapService.setSourceData('hover', [union]);
-          }
-        } else {
-          this.mapService.setSourceData('hover');
-        }
+  /**
+   * Updates the active feature outlined on the map
+   * @param feature Feature or null
+   */
+  updateActiveFeature(feature) {
+    if (feature === null) {
+      this.mapService.setSourceData('hover');
+      return;
+    }
+    this.activeFeature = feature;
+    if (feature.layer.id === this.selectedLayer.id) {
+      const union = this.mapService.getUnionFeature(this.selectedLayer.id, feature);
+      if (union !== null) {
+        union.properties['color'] = this.hoverColors[this.featureCount];
+        this.mapService.setSourceData('hover', [union]);
       }
+    } else {
+      this.mapService.setSourceData('hover');
     }
   }
 
@@ -101,14 +117,31 @@ export class MapboxComponent implements AfterViewInit {
    */
   onMapInstance(map) {
     this.map = map;
+    this.mapStyle = map.getStyle();
     this.setupEmitters();
     this.zone.runOutsideAngular(() => {
-      this.featureMouseMove
-        .debounceTime(100)
-        .subscribe(e => this.onMouseMoveFeature(e));
-      this.featureMouseLeave
-        .debounceTime(100)
-        .subscribe(e => this.onMouseLeaveFeature());
+      // Function to process observable
+      const distinctFeature = (obs) => {
+        return obs
+          .map(e => e.features.length > 0 ? e.features[0] : null)
+          .filter(e => e !== null)
+          .distinctUntilChanged((prev, next) => {
+            if (prev === next) { return false; }
+            if (prev === null || next === null) { return true; }
+            return prev['properties']['GEOID'] === next['properties']['GEOID'];
+          });
+      };
+
+      distinctFeature(this.featureMouseMove.debounceTime(150))
+        .subscribe(feat => this.updateActiveFeature(feat));
+
+      if (this.platform.isLargerThanMobile) {
+        this.featureMouseMove
+          .subscribe(e => this.updatePopupLocation(e));
+
+        distinctFeature(this.featureMouseMove.debounceTime(50))
+          .subscribe(feat => this.updatePopupContent(feat));
+      }
     });
     this.ready.emit(this.map);
   }
@@ -123,8 +156,8 @@ export class MapboxComponent implements AfterViewInit {
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {
-      this.map.on('mouseenter', layer, (ev) => this.onMouseEnterFeature());
-      this.map.on('mouseleave', layer, (ev) => this.featureMouseLeave.emit(ev));
+      this.map.on('mouseenter', layer, (ev) => this.onMouseEnterFeature(ev));
+      this.map.on('mouseleave', layer, (ev) => this.onMouseLeaveFeature());
       this.map.on('mousemove', layer, (ev) => this.featureMouseMove.emit(ev));
       this.map.on('click', layer, (e) => {
         if (e.features.length) {
@@ -132,5 +165,50 @@ export class MapboxComponent implements AfterViewInit {
         }
       });
     });
+  }
+
+  private updatePopupLocation(e: any) {
+    if (!e.hasOwnProperty('lngLat')) {
+      this.popup.remove();
+    } else if (this.popup.isOpen()) {
+      this.popup.setLngLat(e.lngLat);
+    }
+  }
+
+  /**
+   * Update hover tooltip content
+   */
+  private updatePopupContent(feature: MapFeature | null) {
+    // Since fires before updating outline, remove outline
+    this.mapService.setSourceData('hover');
+    if (!feature) {
+      this.popup.remove();
+      return;
+    }
+    const labelLayerId = `${feature['layer']['id']}_text`;
+    const mapLayers = this.mapStyle['layers'].map(l => l.id);
+
+    let updatePopup;
+    // Check if label layer exists, otherwise update
+    if (mapLayers.indexOf(labelLayerId) === -1) {
+      updatePopup = true;
+    } else {
+      // If label layer exists and has text-opacity with stops not visible, update popup
+      const labelLayer = this.mapStyle['layers'].filter(l => l.id === labelLayerId)[0];
+      updatePopup = (
+        labelLayer['paint'].hasOwnProperty('text-opacity') &&
+        labelLayer['paint']['text-opacity'].hasOwnProperty('stops') &&
+        labelLayer['paint']['text-opacity']['stops'][0][0] >= this.map.getZoom()
+      );
+    }
+
+    if (updatePopup) {
+      this.popup.setHTML(`${feature.properties.n}, ${feature.properties.pl}`);
+      if (!this.popup.isOpen()) {
+        this.popup.addTo(this.map);
+      }
+    } else {
+      this.popup.remove();
+    }
   }
 }

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -877,61 +877,6 @@
       }
     },
     {
-      "id": "states_text",
-      "type": "symbol",
-      "source": "us-states-10",
-      "source-layer": "states-centers",
-      "layout": {
-        "text-field": "{n}",
-        "text-size": {
-          "stops": [
-            [
-              4,
-              11
-            ],
-            [
-              4,
-              10
-            ],
-            [
-              5,
-              13
-            ]
-          ]
-        },
-        "visibility": "none",
-        "text-font": {
-          "stops": [
-            [
-              3,
-              [
-                "Metropolis+Medium"
-              ]
-            ],
-            [
-              7,
-              [
-                "Metropolis+Medium"
-              ]
-            ]
-          ]
-        },
-        "text-letter-spacing": 0.1,
-        "text-justify": "center",
-        "text-transform": "uppercase"
-      },
-      "paint": {
-        "icon-opacity": 1,
-        "icon-halo-color": "rgba(255, 255, 255, 1)",
-        "icon-halo-width": 0,
-        "icon-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255, 255, 255, 0.7)",
-        "text-color": "rgba(31, 31, 31, 1)",
-        "text-opacity": 0
-      }
-    },
-    {
       "id": "cities_bubbles",
       "type": "circle",
       "source": "us-cities-10",


### PR DESCRIPTION
Closes #537 and #500.

* Moves all hover interactions into the Mapbox component running outside of Angular (rather than splitting them in between the map service and component)
* Splits the popup (renamed from tooltip for consistency) updates into location and content. The location update doesn't result in any performance hit since it's a cheap calculation, and even if the text inside it doesn't update until a debounced feature change it looks a lot smoother
* Simplifies the conditional on whether a tooltip should show up. Before we were hitting the map multiple times, now since the way we show labels has changed it's a lot more straightforward
* Updates `getUnionFeature` to only do any calculations if the feature is missing area compared to its bounding box, or if it is using the bounding box geography in which case it should be updated. This is one of the worst functions for performance, but we don't have another way of pulling the full data with vector tiles, so minimizing how much it gets called helps
* Removes `states_text` since we're not using it
* Fixes references to `feature.properties.bbox` since the standard way of using it, included in the interface, is `feature.bbox`
* Adds tests for the updated geometry behavior

After this, I can hover around at this speed with counties on the default view and still average around 35fps on Firefox

![hover-pr](https://user-images.githubusercontent.com/8291663/35465267-67098206-02c0-11e8-8786-2e69833a6732.gif)
