### PR TITLE
Disable scroll during zoom

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { HeaderBarComponent } from './header-bar/header-bar.component';
 import { FooterComponent } from './footer/footer.component';
 import { LoadingService } from './loading.service';
 import { MenuComponent } from './menu/menu.component';
+import { ToggleScrollService } from './toggle-scroll.service';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -57,6 +58,7 @@ export class CustomOption extends ToastOptions {
     ToastModule.forRoot()
   ],
   providers: [
+    ToggleScrollService,
     PlatformService,
     DataService,
     LoadingService,

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -10,6 +10,7 @@ import { DataAttributes, BubbleAttributes } from '../data/data-attributes';
 import { DataLevels } from '../data/data-levels';
 import { ToastModule } from 'ng2-toastr';
 import { LoadingService } from '../loading.service';
+import { ToggleScrollService } from '../toggle-scroll.service';
 
 export class TranslateServiceStub {
   public get(key: any): any {
@@ -51,7 +52,8 @@ describe('MapToolComponent', () => {
         providers: [
           {provide: DataService, useClass: DataServiceStub },
           TranslateService,
-          LoadingService
+          LoadingService,
+          ToggleScrollService
         ]
       }
     })

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -8,6 +8,7 @@ import { UiModule } from '../../../ui/ui.module';
 import { MapService } from '../map.service';
 import { LoadingService } from '../../../loading.service';
 import { PlatformService } from '../../../platform.service';
+import { ToggleScrollService } from '../../../toggle-scroll.service';
 
 class MapServiceStub {
   updateCensusSource() {}
@@ -40,7 +41,8 @@ describe('MapComponent', () => {
         providers: [
           PlatformService,
           { provide: MapService, useValue: new MapServiceStub() },
-          LoadingService
+          LoadingService,
+          ToggleScrollService
         ],
       }
     })

--- a/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MapboxComponent } from './mapbox.component';
 import { MapService } from '../map.service';
 import { PlatformService } from '../../../platform.service';
+import { ToggleScrollService } from '../../../toggle-scroll.service';
 
 describe('MapboxComponent', () => {
   let component: MapboxComponent;
@@ -23,7 +24,7 @@ describe('MapboxComponent', () => {
         MapboxComponent
       ],
       providers: [
-        MapService, PlatformService
+        MapService, PlatformService, ToggleScrollService
       ]
     }).compileComponents();
   }));

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -5,6 +5,7 @@ import {
 import { Observable } from 'rxjs/Observable';
 import { MapService } from '../map.service';
 import { PlatformService } from '../../../platform.service';
+import { ToggleScrollService } from '../../../toggle-scroll.service';
 import { MapLayerGroup } from '../../map/map-layer-group';
 import { MapFeature } from '../../map/map-feature';
 import 'rxjs/add/observable/fromEvent';
@@ -38,7 +39,8 @@ export class MapboxComponent implements AfterViewInit {
   constructor(
     private mapService: MapService,
     private platform: PlatformService,
-    private zone: NgZone
+    private zone: NgZone,
+    private scroll: ToggleScrollService
   ) { }
 
   /**
@@ -151,8 +153,12 @@ export class MapboxComponent implements AfterViewInit {
    */
   private setupEmitters() {
     this.map.on('moveend', (e) => this.moveEnd.emit(e));
+    this.map.on('zoomstart', (e) => this.scroll.allowScroll = false);
     // Emit feature on zoom end to account for geography details changing across zooms
-    this.map.on('zoomend', () => this.zoomEnd.emit(this.map.getZoom()));
+    this.map.on('zoomend', () => {
+      this.scroll.allowScroll = true;
+      this.zoomEnd.emit(this.map.getZoom());
+    });
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -15,8 +15,7 @@ import 'rxjs/add/operator/distinctUntilChanged';
 @Component({
   selector: 'app-mapbox',
   templateUrl: './mapbox.component.html',
-  styleUrls: ['./mapbox.component.scss'],
-  providers: [ ToggleScrollService ]
+  styleUrls: ['./mapbox.component.scss']
 })
 export class MapboxComponent implements AfterViewInit {
   private map: mapboxgl.Map;

--- a/src/app/toggle-scroll.service.spec.ts
+++ b/src/app/toggle-scroll.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ToggleScrollService } from './toggle-scroll.service';
+
+describe('ToggleScrollService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ToggleScrollService]
+    });
+  });
+
+  it('should be created', inject([ToggleScrollService], (service: ToggleScrollService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/toggle-scroll.service.ts
+++ b/src/app/toggle-scroll.service.ts
@@ -1,0 +1,12 @@
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
+
+@Injectable()
+export class ToggleScrollService {
+  set allowScroll(val: boolean) {
+    this.document.body.style.overflowY = val ? null : 'hidden';
+  }
+
+  constructor(@Inject(DOCUMENT) private document: any) { }
+
+}

--- a/src/app/toggle-scroll.service.ts
+++ b/src/app/toggle-scroll.service.ts
@@ -3,8 +3,13 @@ import { DOCUMENT } from '@angular/platform-browser';
 
 @Injectable()
 export class ToggleScrollService {
+  /**
+   * Setting position fixed on body will prevent scroll, and setting overflow
+   * to scroll ensures the scrollbar is always visible.
+   */
   set allowScroll(val: boolean) {
-    this.document.body.style.overflowY = val ? null : 'hidden';
+    this.document.body.style.position = val ? null : 'fixed';
+    this.document.body.style.overflowY = val ? null : 'scroll';
   }
 
   constructor(@Inject(DOCUMENT) private document: any) { }


### PR DESCRIPTION
Should close #189 by disabling all scrolling on the `body` element while a map zoom is active. Originally I had just been bubbling the map `zoomstart` and `zoomend` events, but that seemed like a lot of filler. Since this is functionality we may want to use in other parts of the tool for #544, moving it into a separate service seemed to make sense