### PR TITLE
Fix copy link popup placement

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -144,3 +144,18 @@ body {
   transform: rotate(180deg);
   polyline { stroke-width: 3px; stroke: #fff; fill: none;}
 }
+
+
+// copy link tooltip override
+@media(max-width: $gtMobile) {
+  .popover.in.bs-popover-top {
+    left:0!important;
+    right:0!important;
+    margin:auto;
+    width: grid(35);
+    .popover-arrow.arrow {
+      left:auto!important;
+      right: grid(3);
+    }
+  }
+}


### PR DESCRIPTION
Overrides the mobile styles of the copy link popup so it is centered.

![image](https://user-images.githubusercontent.com/21034/35540344-aaed3c34-0512-11e8-9c9f-df5f5491acb5.png)
