### PR TITLE
Unset IE scroll styles

### DIFF
--- a/src/app/toggle-scroll.service.ts
+++ b/src/app/toggle-scroll.service.ts
@@ -6,10 +6,11 @@ export class ToggleScrollService {
   /**
    * Setting position fixed on body will prevent scroll, and setting overflow
    * to scroll ensures the scrollbar is always visible.
+   * IE 11 requires an empty string rather than null to unset styles.
    */
   set allowScroll(val: boolean) {
-    this.document.body.style.position = val ? null : 'fixed';
-    this.document.body.style.overflowY = val ? null : 'scroll';
+    this.document.body.style.position = val ? '' : 'fixed';
+    this.document.body.style.overflowY = val ? '' : 'scroll';
   }
 
   constructor(@Inject(DOCUMENT) private document: any) { }


### PR DESCRIPTION
Fixes #551. Not sure why, but IE 11 requires an empty string to unset styles (I checked it out in Browserstack). This works across Firefox and Chrome as well, so looks like it's safe generally