### PR TITLE
Check scrollTop in toggle scroll

### DIFF
--- a/src/app/toggle-scroll.service.ts
+++ b/src/app/toggle-scroll.service.ts
@@ -9,8 +9,9 @@ export class ToggleScrollService {
    * IE 11 requires an empty string rather than null to unset styles.
    */
   set allowScroll(val: boolean) {
-    this.document.body.style.position = val ? '' : 'fixed';
-    this.document.body.style.overflowY = val ? '' : 'scroll';
+    const changeScroll = !val && this.document.documentElement.scrollTop === 0;
+    this.document.body.style.position = changeScroll ? 'fixed' : '';
+    this.document.body.style.overflowY = changeScroll ? 'scroll' : '';
   }
 
   constructor(@Inject(DOCUMENT) private document: any) { }


### PR DESCRIPTION
Fixes #553. Checking the `scrollTop` position of the document, and also flipping the order of the conditional to make it a bit easier to read