### PR TITLE
Keep US average grey on transitions

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -31,7 +31,7 @@
         [selectedValue]="graphType"
         (selectedValueChanged)="graphType = $event"
       ></app-ui-toggle>
-      <app-graph *ngIf="graphData" [class.average-shown]="showAverage" [data]="graphData" [settings]="graphSettings" [hoverAll]="true" (activeValuesChanged)="graphHover.emit($event)">
+      <app-graph *ngIf="graphData" [class.average-shown]="averageActive" [data]="graphData" [settings]="graphSettings" [hoverAll]="true" (activeValuesChanged)="graphHover.emit($event)">
         <div class="line-tooltips" *ngIf="graphType === 'line'">
           <div class="year-marker" *ngIf="tooltips.length" [style.transform]="'translateX('+ tooltips[0].xPos +'px)'"><span>{{tooltips[0].x}}</span></div>
           <div class="line-tooltip" 

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -152,10 +152,10 @@
         fill: $graphAxisLabels;
       }
     }
-    &.average-shown ::ng-deep .app-graph g.line:last-child path.line {
+    &.average-shown ::ng-deep .app-graph g.line:last-of-type path.line {
       stroke: $graphColor4;
     }
-    &.average-shown ::ng-deep .app-graph rect.bar:last-child {
+    &.average-shown ::ng-deep .app-graph rect.bar:last-of-type {
       fill: url(#g3);
     }
   }
@@ -412,6 +412,6 @@
     font-weight: 600;
   }
 }
-.average-shown .line-tooltip:last-child:before {
+.average-shown .line-tooltip:last-of-type:before {
   background:$color4;
 }

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -100,13 +100,7 @@ export class EvictionGraphsComponent implements OnInit {
       this._showAverage = value;
       this.showAverageChange.emit(value);
       this.setGraphData();
-      // toggle `averageActive` after a timeout if false so line/bar doesn't
-      // immediately change color
-      if (this.showAverage) {
-        this.averageActive = true;
-      } else {
-        setTimeout(() => { this.averageActive = false; }, 1000);
-      }
+      this.toggleAverageClass();
     }
   }
   get showAverage() { return this._showAverage; }
@@ -125,6 +119,7 @@ export class EvictionGraphsComponent implements OnInit {
   barYearSelect: Array<number>; // array of years for bar graph select
   graphHover = new EventEmitter(); // event emitter for when user hovers the graph
   private graphTimeout; // tracks if a timeout is set to update graph settings
+  private averageTimeout; // tracks timeout when setting average so it can be cancelled
 
   constructor(
     private translatePipe: TranslatePipe,
@@ -301,6 +296,22 @@ export class EvictionGraphsComponent implements OnInit {
     return null;
   }
 
+  /**
+   * toggle `averageActive` after a timeout if false so line/bar doesn't
+   * immediately change color
+   */
+  private toggleAverageClass() {
+
+    if (this.showAverage) {
+      if (this.averageTimeout) { clearTimeout(this.averageTimeout); }
+      this.averageActive = true;
+    } else {
+      this.averageTimeout = setTimeout(() => {
+        this.averageActive = false;
+        this.averageTimeout = null;
+      }, 1000);
+    }
+  }
 
   /**
    * Genrates line graph data from the features in `locations`

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -100,11 +100,19 @@ export class EvictionGraphsComponent implements OnInit {
       this._showAverage = value;
       this.showAverageChange.emit(value);
       this.setGraphData();
+      // toggle `averageActive` after a timeout if false so line/bar doesn't
+      // immediately change color
+      if (this.showAverage) {
+        this.averageActive = true;
+      } else {
+        setTimeout(() => { this.averageActive = false; }, 1000);
+      }
     }
   }
   get showAverage() { return this._showAverage; }
   @Output() showAverageChange = new EventEmitter();
 
+  averageActive = true; // tracks if the average is active on the graph
   tooltips = []; // attribute for holding tooltip data
   graphTypeOptions = this.createGraphTypeOptions(); // attribute w/ object of graph options
   graphAttribute: MapDataAttribute; // current graph property (sync with map?)


### PR DESCRIPTION
Fixes #555, also fixes the color change that was happening when transitioning graph types.

![us-graph-color](https://user-images.githubusercontent.com/21034/35637788-836fde62-0672-11e8-9a9c-ffa7c69e9600.gif)
