### PR TITLE
Fix page scroll when using slider

### DIFF
--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -82,6 +82,8 @@ export class UiSliderComponent implements AfterViewInit {
     if (this.pressed) {
       this.setScrubberPosition(e);
     }
+    e.stopPropagation();
+    e.preventDefault();
   }
 
   /**
@@ -107,6 +109,8 @@ export class UiSliderComponent implements AfterViewInit {
     if (this.pressed && e.touches && e.touches.length === 1) {
       this.setScrubberPosition(e.touches[0]);
     }
+    e.stopPropagation();
+    e.preventDefault();
   }
 
   @HostListener('touchend', ['$event']) onTouchEnd(e) {


### PR DESCRIPTION
Stops propagation on the touchmove / mousemove events so the page doesn't scroll when interacting with the slider.  Fixes #544 

![slider-scroll](https://user-images.githubusercontent.com/21034/35639089-417f41d8-0676-11e8-9df8-ca7245ed00d3.gif)
