### PR TITLE
Fix slider jump when released

### DIFF
--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -32,8 +32,13 @@
     }
   }
   // show toolip when dragging
-  &.active .el-slider .scrubber-label {
-    opacity:1;
+  &.active { 
+    .el-slider .scrubber-label {
+      opacity:1;
+    }
+    .el-slider .scrubber {
+      transition: none;
+    }
   }
 }
 .slider-label {
@@ -84,6 +89,7 @@
     margin: auto;
     margin-left: -1 * grid(8) / 2;
     cursor: move;
+    transition: transform 0.4s ease;
   }  
   .scrubber-label {
     opacity:0;


### PR DESCRIPTION
This adds a transition to the slider so it should animate into place when released.  Also has the added benefit of transitioning the scrubber when using it with the keyboard.

Should fix #518 on iOS Chrome, but I don't have iOS available to me to check right now.