### PR TITLE
Add attribute hint functionality

### DIFF
--- a/src/app/data/data-attributes.ts
+++ b/src/app/data/data-attributes.ts
@@ -335,6 +335,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'id': 'er',
     'type': 'bubble',
     'langKey': 'STATS.JUDGMENT_RATE',
+    'hintKey': 'HINTS.EVICTION_RATE',
     'format': 'percent',
     'order': 1,
     'default': 0,

--- a/src/app/map-tool/map/map-data-attribute.ts
+++ b/src/app/map-tool/map/map-data-attribute.ts
@@ -1,18 +1,19 @@
 import { MapDataObject } from './map-data-object';
 
 export interface MapDataAttribute extends MapDataObject {
-    id: string;
-    type?: string;
-    langKey: string;
-    yearAttr?: string;
-    order?: number;
-    name?: string;
-    format?: string;
-    default?: string | number;
-    stops?: {
-        [id: string]: Array<Array<any>>
-    };
-    expressions?: {
-        [id: string]: Array<any>
-    };
+  id: string;
+  type?: string;
+  langKey: string;
+  yearAttr?: string;
+  hintKey?: string;
+  order?: number;
+  name?: string;
+  format?: string;
+  default?: string | number;
+  stops?: {
+      [id: string]: Array<Array<any>>
+  };
+  expressions?: {
+      [id: string]: Array<any>
+  };
 }

--- a/src/app/ui/location-cards/location-cards.component.html
+++ b/src/app/ui/location-cards/location-cards.component.html
@@ -15,14 +15,17 @@
   </div>
   <div class="card-content">
     <ul class="card-stats">
-      <li *ngFor="let prop of cardProperties; let i = index;" [class]="prop.id">
+      <li *ngFor="let prop of cardProperties; let i = index;" [class]="prop.id" [class.has-hint]="prop.hintKey">
         <span *ngIf="i === 1 && usAverage && f.properties[prop.yearAttr] > 0" class="card-stat-comparison">
           {{ f.properties[prop.yearAttr] > usAverage[prop.yearAttr] ? '+' : '' }}{{
           (f.properties[prop.yearAttr] - usAverage[prop.yearAttr]).toFixed(1) !== '0.0' ?
             (f.properties[prop.yearAttr] - usAverage[prop.yearAttr] | number : '1.1-1') : '='
           }} {{ 'DATA.US_AVERAGE' | translate }}
         </span>
-        <span *ngIf="prop.id !== 'divider'" class="card-stat-label">{{ prop.name }}</span>
+        <span *ngIf="prop.id !== 'divider'" class="card-stat-label">
+          {{ prop.name }}
+          <app-ui-hint *ngIf="prop.hintKey" class="attribute-hint" [hint]="prop.hintKey | translate" placement="right" triggers="hover touchend"></app-ui-hint>
+        </span>
         <span *ngIf="prop.id !== 'divider'" class="card-stat-value" [class.unavailable]="!(f.properties[prop.yearAttr] >= 0)">
           <span *ngIf="f.properties[prop.yearAttr] >= 0">{{ prefix(prop.id) }}{{ (f.properties[prop.yearAttr] | number) }}{{ suffix(prop.id) }}</span>
           <span *ngIf="!(f.properties[prop.yearAttr] >= 0)">{{ 'DATA.UNAVAILABLE' | translate }}</span>

--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -235,7 +235,7 @@
         margin-right: 0;
 
         span {
-          overflow: auto;
+          overflow: visible;
           white-space: normal;
         }
       }

--- a/src/app/ui/location-cards/location-cards.component.scss
+++ b/src/app/ui/location-cards/location-cards.component.scss
@@ -102,12 +102,37 @@
     }
     .card-stats li { margin-bottom: grid(1); }
     .card-stats li:last-child { margin-bottom: 0;}
-
+    // attribute labels
     .card-stat-label {
       display:block;       
       color: $cardLabelText;
       font-size: 12px;
+      position:relative;
+      .attribute-hint {
+        display:block;
+        position:absolute;
+        width:100%;
+        height:100%;
+        left:0;top:0;
+        ::ng-deep {
+          .hint-button {
+            width:100%;
+            text-align:right;
+            min-width: grid(2);
+            min-height:grid(2);
+            svg {
+              width:grid(2);
+              height:grid(2);
+              display:inline-block;
+              circle { fill: $grey2; }
+            }
+          }
+        }
+      }
     }
+    // add space for hint icon on labels with hints
+    .card-stats li.has-hint .card-stat-label { padding-right: grid(3);}
+    // attribute values
     .card-stat-value {
       @include numberFont(14px);
       color: $cardValueText;
@@ -216,12 +241,21 @@
       }
       .card-stat-label {
         font-size: $cardLabelTextSize;
+        // align hint button with text
+        .attribute-hint ::ng-deep .hint-button svg {
+          margin-top:2px;
+        }
       }
       .card-stat-value {
         @include numberFont($cardValueTextSize);
         &.unavailable {
           @include defaultFont($cardValueTextSize);
         }
+      }
+      // override for eviction rate to place the hint button after text
+      li.er .card-stat-label .attribute-hint {
+        width: auto;
+        right: grid(4);
       }
     }
   }
@@ -286,7 +320,7 @@
         }
       }
       .card-stat-label { color: $panelCardLabelText; }
-      // first two stats
+      // first two stats have a more prominent layout
       &:nth-child(1), &:nth-child(2) {
         position:absolute;
         width:50%;
@@ -303,6 +337,11 @@
           @include defaultFontBold($panelCardLabelTextLg);
           text-transform: uppercase;
           letter-spacing:0.5px;
+        }
+        // drop the hint icon to save space, but still show a hint if they hover
+        &.has-hint .card-stat-label { 
+          padding-right: 0;
+          .attribute-hint ::ng-deep .hint-button svg { display: none; }
         }
         .card-stat-value {
           @include numberFont($panelCardLabelValueLg);
@@ -351,7 +390,7 @@
         @include smallCapsText(12px);
         .card-stat-label { 
           width:100%; 
-          color: #A3A7A8; 
+          color: $grey2; 
           text-align:center; 
         }
       }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -51,6 +51,9 @@
     "SEARCH_HINT": "Search for places",
     "MAP_HINT": "Start Here"
   },
+  "HINTS": {
+    "EVICTION_RATE": "Represents the number of evictions per 100 renter homes."
+  },
   "HELP": "Lorem Ipsum",
   "LAYERS": {
     "STATES": "States",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -52,6 +52,9 @@
     "MAP_HINT": "Empiece aquí"
   },
   "HELP": "Lorem Ipsum",
+  "HINTS": {
+    "EVICTION_RATE": "Represents the number of evictions per 100 renter homes."
+  },
   "LAYERS": {
     "STATES": "Estados",
     "COUNTIES": "Condados",


### PR DESCRIPTION
Allows us to set a `hintKey` on data attributes so that they show a tooltip hint in the location cards.  Wording will likely need to change, but provides functionality for #482.

![attribute-hint](https://user-images.githubusercontent.com/21034/35644813-45c33b8a-0687-11e8-973c-9b3365d056f0.gif)
