### PR TITLE
Scaffolding for analytics

### DIFF
--- a/src/app/analytics.service.spec.ts
+++ b/src/app/analytics.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AnalyticsService]
+    });
+  });
+
+  it('should be created', inject([AnalyticsService], (service: AnalyticsService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/analytics.service.spec.ts
+++ b/src/app/analytics.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { AnalyticsService } from './analytics.service';
+import { PlatformService } from './platform.service';
 
 describe('AnalyticsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [AnalyticsService]
+      providers: [AnalyticsService, PlatformService ]
     });
   });
 

--- a/src/app/analytics.service.ts
+++ b/src/app/analytics.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { PlatformService } from './platform.service';
+
+
+@Injectable()
+export class AnalyticsService {
+  dataLayer;
+
+  constructor(
+    private platform: PlatformService
+  ) {
+    // grab global dataLayer from window
+    this.dataLayer = platform.nativeWindow.dataLayer;
+  }
+
+  /**
+   * Pushes the event to the global dataLayer array that
+   * Google Tag Manager is watching.
+   * @param id string of the event name
+   * @param data object of event data
+   */
+  trackEvent(id: string, data: any) {
+    if (!this.dataLayer) { throw Error('dataLayer does not exist'); }
+    const event = { event: id, ...data };
+    this.dataLayer.push(event);
+  }
+
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -15,6 +15,7 @@ import { DataService } from './data/data.service';
 import { ToastModule } from 'ng2-toastr';
 import { LoadingService } from './loading.service';
 import { MenuComponent } from './menu/menu.component';
+import { AnalyticsService } from './analytics.service';
 
 export class TranslateServiceStub {
   public get(key: any): any {
@@ -39,6 +40,7 @@ describe('AppComponent', () => {
       providers: [
         PlatformService,
         LoadingService,
+        AnalyticsService,
         { provide: TranslateService, useClass: TranslateServiceStub },
         { provide: DataService, useValue: { languageOptions: [] } },
         { provide: Title, useValue: { setTitle: (...args) => {} } }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,6 +17,7 @@ import { DataService } from './data/data.service';
 import { MapFeature } from './map-tool/map/map-feature';
 import { ToastsManager } from 'ng2-toastr';
 import { LoadingService } from './loading.service';
+import { AnalyticsService } from './analytics.service';
 
 @Component({
   selector: 'app-root',
@@ -45,7 +46,9 @@ export class AppComponent implements OnInit {
     private toastr: ToastsManager,
     private vRef: ViewContainerRef,
     private titleService: Title,
-    private el: ElementRef
+    private el: ElementRef,
+    private analytics: AnalyticsService,
+    @Inject(DOCUMENT) private document: any
   ) {
       this.toastr.setRootViewContainerRef(vRef);
   }
@@ -81,6 +84,14 @@ export class AppComponent implements OnInit {
     } else if (component.constructor.name === 'RankingToolComponent') {
       this.titleService.setTitle('Eviction Lab - Eviction Rankings'); // TODO: translate
     }
+    // TODO: get actual data
+    // const loadedData = {
+    //   'siteVersion': '<site version>',
+    //   'timeStamp': '<timestamp>',
+    //   'pageCategory': '<page category>',
+    //   'Language': '<language>',
+    // };
+    // this.analytics.trackEvent('dataLayer-loaded', loadedData);
   }
 
   onMenuSelect(itemId: string) {
@@ -140,7 +151,7 @@ export class AppComponent implements OnInit {
       rankings: '/evictions/United%20States/0/evictionRate',
       evictors: '/evictors'
     };
-    const defaultRoute = window.location.pathname.includes('rankings') ?
+    const defaultRoute = this.platform.nativeWindow.location.pathname.includes('rankings') ?
       defaultViews.rankings : defaultViews.map;
     const appRoutes: Routes = [
       {
@@ -187,7 +198,7 @@ export class AppComponent implements OnInit {
    * Based on https://github.com/ngx-translate/core/issues/565
    */
   private updateHtmlLanguage() {
-    const lang = document.createAttribute('lang');
+    const lang = this.document.createAttribute('lang');
     lang.value = this.translate.currentLang;
     this.el.nativeElement.parentElement.parentElement.attributes.setNamedItem(lang);
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { FooterComponent } from './footer/footer.component';
 import { LoadingService } from './loading.service';
 import { MenuComponent } from './menu/menu.component';
 import { ToggleScrollService } from './toggle-scroll.service';
+import { AnalyticsService } from './analytics.service';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -62,6 +63,7 @@ export class CustomOption extends ToastOptions {
     PlatformService,
     DataService,
     LoadingService,
+    AnalyticsService,
     {provide: ToastOptions, useClass: CustomOption},
     Title
   ],

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -155,7 +155,7 @@ export class DataPanelComponent implements OnInit {
    * Adding method because calling window directly in the template doesn't work
    */
   getCurrentUrl() {
-    return window.location.href;
+    return this.platform.nativeWindow.location.href;
   }
 
   /**
@@ -170,7 +170,7 @@ export class DataPanelComponent implements OnInit {
     // https://www.uncinc.nl/articles/dealing-with-mailto-links-if-no-mail-client-is-available
     let timeout;
 
-    window.addEventListener('blur', () => clearTimeout(timeout));
+    this.platform.nativeWindow.addEventListener('blur', () => clearTimeout(timeout));
     timeout = setTimeout(() => {
       this.dialogService.showDialog({
         title: 'Email Link Error',

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -30,6 +30,7 @@ export class DataServiceStub {
   activeBubbleHighlight = DataAttributes[0];
   mapView;
   mapConfig;
+  getQueryParameters() { return []; }
   getRouteArray() { return []; }
   loadUSAverage() {}
 }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -259,9 +259,9 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   }
 
   private getVerticalOffset() {
-    return window.pageYOffset ||
-      document.documentElement.scrollTop ||
-      document.body.scrollTop || 0;
+    return this.platform.nativeWindow.pageYOffset ||
+      this.document.documentElement.scrollTop ||
+      this.document.body.scrollTop || 0;
   }
 
   /**
@@ -286,7 +286,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
       // only fire when wheel event hasn't been triggered yet
       .filter(() => !this.wheelEvent)
       .subscribe(e => this.wheelEvent = true);
-    Observable.fromEvent(window, 'scroll')
+    Observable.fromEvent(this.platform.nativeWindow, 'scroll')
       // trailing scroll event is needed so verticalOffset = 0 event is fired
       .throttleTime(10, undefined, { trailing: true, leading: true })
       .subscribe(e => this.onScroll());

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -519,19 +519,4 @@ export class MapComponent implements OnInit, OnChanges {
     this.map.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
   }
 
-  /** Animate the map based on scroll position */
-  private parallaxMap() {
-    if (window.scrollY < window.innerHeight) {
-      window.requestAnimationFrame(() => {
-        if (window.scrollY > 0) {
-          this.mapEl.nativeElement.style.transform =
-            'translate3d(0,' + (-(window.scrollY) / 2).toFixed(2) + 'px,0)';
-        } else {
-          this.mapEl.nativeElement.style.transform = 'translate3d(0,0,0)';
-        }
-      });
-    }
-  }
-
-
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,16 @@
   <title>Eviction Maps</title>
   <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Google Tag Manager -->
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M955JVB');</script>
+
+  <!-- Favicons / mobile icons -->
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
@@ -12,7 +22,9 @@
   <link rel="manifest" href="/assets/manifest.json">
   <meta name="theme-color" content="#ffffff">
 
+  <!-- Custom Fonts -->
   <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6135894/6199192/css/fonts.css" />
+  
   <!-- General metadata -->
   <meta name="description" content="We're building the nation's first dataset of evictions, and making everything public and accessible." />
   <meta name='author' content='Eviction Lab' />
@@ -35,6 +47,8 @@
   <meta name="twitter:image" content="https://qgc0xnya6w-flywheel.netdna-ssl.com/wp-content/uploads/2017/09/eviction-michael-kienitz-edit.jpg" />
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M955JVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <app-root></app-root>
 </body>
 </html>


### PR DESCRIPTION
Wanted to get this in before refactoring.  Adds Google Tag Manager to `index.html` and provides base service for tracking events.  Also cleaning up some direct references to `window` with the wrapper from `PlatformService`.