### PR TITLE
Update US comparison values

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -18,8 +18,8 @@
       <li *ngFor="let prop of cardProperties; let i = index;" [class]="prop.id" [class.has-hint]="prop.hintKey">
         <span *ngIf="i === 1 && usAverage && f.properties[prop.yearAttr] > 0" class="card-stat-comparison">
           {{ f.properties[prop.yearAttr] > usAverage[prop.yearAttr] ? '+' : '' }}{{
-          (f.properties[prop.yearAttr] - usAverage[prop.yearAttr]).toFixed(1) !== '0.0' ?
-            (f.properties[prop.yearAttr] - usAverage[prop.yearAttr] | number : '1.1-1') : '='
+          f.properties[prop.yearAttr] - usAverage[prop.yearAttr] !== 0 ?
+            (f.properties[prop.yearAttr] - usAverage[prop.yearAttr] | number : '1.1-2') : '='
           }} {{ 'DATA.US_AVERAGE' | translate }}
         </span>
         <span *ngIf="prop.id !== 'divider'" class="card-stat-label">


### PR DESCRIPTION
Fixes #578 

<img width="390" alt="screen shot 2018-02-07 at 2 08 12 pm" src="https://user-images.githubusercontent.com/8291663/35939099-c0101dd4-0c10-11e8-83f7-4c6005af909c.png">

Larger numbers still don't overflow

<img width="274" alt="screen shot 2018-02-07 at 2 09 09 pm" src="https://user-images.githubusercontent.com/8291663/35939102-c36a9dc4-0c10-11e8-81e7-8d8ef879c21a.png">
