### PR TITLE
Fix rankings tabs to top

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -23,7 +23,7 @@
 
 app-ranking-ui {
   position:sticky;
-  top:112px;
+  top: grid(21);
   z-index:10;
   display:block;
   margin-right: grid(3);
@@ -36,11 +36,18 @@ app-ranking-list {
   height: grid(8);
   box-shadow: $z1shadow;
   padding: 0 $pageMargin;
+  position: -webkit-sticky;
+  position: sticky;
+  top: grid(11);
+  background-color: $rankingsBg1;
+  z-index: 11;
+
   .content-inner {
     height: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-direction: column;
   }
   ul {
     list-style: none;
@@ -51,21 +58,30 @@ app-ranking-list {
     
     li {
       display:inline-block;
-      @include defaultFontBold(16px);
+      @include altFont(16px);
       height:100%;
-      &.active {
-        border-bottom: grid(0.5) solid $color1;
-      }
+      margin: 0 grid(1);
       a {
-        color: $black;
+        color: $grey1a;
         display:block;
         height:100%;
         line-height: grid(4);
         padding: grid(2);
+        padding-left: 0;
         &:hover {
+          color: $color1;
           text-decoration: none;
-          background: $grey4;
         }
+      }
+      &.active {
+        &::after {
+          content: '';
+          width: grid(6);
+          position: absolute;
+          bottom: 0;
+          border-bottom: grid(0.5) solid $color1;
+        }
+        a { color: $color1; }
       }
     }
   }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -87,6 +87,7 @@ $color2: #434878;
 $color3: #2c897f;
 $color4: #94AABD;
 $color5: #b5c2b7;
+$color6: #EEF2F5;
 $gradient1: linear-gradient(180deg, #F27636, #E04119);
 $gradient2: linear-gradient(180deg, #787EB0, #434878);
 $gradient3: linear-gradient(180deg, #57BEB6, #2C897F);
@@ -254,6 +255,9 @@ $footerGradientFrom: #393939;
 $footerGradientTo: #2F2D2B;
 $footerIconBorder: #333;
 $footerHoverIconBorder: $white;
+
+// Rankings
+$rankingsBg1: $color6;
 
 // TODO: 
 // - type definitions / sizes


### PR DESCRIPTION
Closes #587, progress on #590. Doesn't address mobile styles yet, but uses `position: sticky` for the navigation and updates some of the styling to match the mockups

![fixed-tabs](https://user-images.githubusercontent.com/8291663/36101896-4182441a-0fd0-11e8-8824-9288bc95744a.gif)
