### PR TITLE
Add translation to rankings

### DIFF
--- a/src/app/ranking/ranking-list/ranking-list.component.html
+++ b/src/app/ranking/ranking-list/ranking-list.component.html
@@ -1,4 +1,4 @@
-<p>View 2016 eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).</p>
+<p>{{ 'RANKINGS.LIST_INTRO' | translate:{'year': year} }}</p>
 <ul *ngIf="dataProperty && list && maxValue" class="ranking-list">
   <li 
     *ngFor="let location of list; let i = index" 

--- a/src/app/ranking/ranking-list/ranking-list.component.spec.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TranslateModule } from '@ngx-translate/core';
 import { RankingListComponent } from './ranking-list.component';
 
 describe('RankingListComponent', () => {
@@ -8,6 +8,7 @@ describe('RankingListComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [ TranslateModule.forRoot() ],
       declarations: [ RankingListComponent ]
     })
     .compileComponents();

--- a/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -7,7 +7,7 @@ import { RankingLocation } from '../ranking-location';
   styleUrls: ['./ranking-list.component.scss']
 })
 export class RankingListComponent implements OnInit {
-
+  @Input() year: number;
   @Input() list: Array<RankingLocation>;
   @Input() dataProperty: string;
   @Input() maxValue: number;

--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -20,7 +20,7 @@
   </div>
   <div class="panel-rank">
     <span class="rank-number">{{ rank }}</span>
-    <span class="rank-label">Highest {{dataProperty.name}}</span>
+    <span class="rank-label">{{ 'RANKINGS.HIGHEST' | translate }} {{dataProperty.name}}</span>
   </div>
   <div class="panel-summary">
     <div class="panel-summary-heading">
@@ -29,7 +29,7 @@
       <span>{{location[dataProperty.value]}}</span>
     </div>
     <p class="panel-summary-content">
-      There were {{location.evictions}} in the {{location.name}} area last year.  That amounts to {{ (location.evictions/365) | number: '1.2-2'}} people evicted every day.  {{ location.evictionRate }} in 100 renter homes are evicted each year.
+      {{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}
     </p>
   </div>
   <div class="panel-next" (click)="goToNext.emit(true)">

--- a/src/app/ranking/ranking-panel/ranking-panel.component.spec.ts
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TranslateModule } from '@ngx-translate/core';
 import { RankingPanelComponent } from './ranking-panel.component';
 
 describe('RankingPanelComponent', () => {
@@ -8,6 +8,7 @@ describe('RankingPanelComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [ TranslateModule.forRoot() ],
       declarations: [ RankingPanelComponent ]
     })
     .compileComponents();

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -1,15 +1,15 @@
 <div class="ranking-page" role="main">
   <div class="hero">
-    <h1>Eviction Rankings</h1>
+    <h1>{{ 'RANKINGS.EVICTION_RANKINGS' | translate }}</h1>
   </div>
   <div class="nav-bar nav-rankings">
     <div class="content-inner">
       <ul class="tabs">
         <li [class.active]="activeTab === 'evictions'">
-          <a routerLink="/evictions">Top Evicting Areas</a>
+          <a routerLink="/evictions">{{ 'RANKINGS.TOP_EVICTING_AREAS' | translate }}</a>
         </li>
         <li [class.active]="activeTab === 'evictors'">
-          <a>Top Evictors</a>
+          <a>{{ 'RANKINGS.TOP_EVICTORS' | translate }}</a>
         </li>
       </ul>
     </div>
@@ -31,6 +31,7 @@
           (selectedDataPropertyChange)="onDataPropertyChange($event)"
       ></app-ranking-ui>
         <app-ranking-list *ngIf="areaType && dataProperty"
+          [year]="rankings.year"
           [class]="'area-'+areaType.value"
           [list]="truncatedList"
           [dataProperty]="dataProperty.value"

--- a/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { UiModule } from '../../ui/ui.module';
 import { ServicesModule } from '../../services/services.module';
@@ -22,7 +23,7 @@ describe('RankingToolComponent', () => {
         RankingPanelComponent
       ],
       imports: [
-        UiModule, RouterTestingModule, ServicesModule.forRoot()
+        UiModule, RouterTestingModule, ServicesModule.forRoot(), TranslateModule.forRoot()
       ]
     });
     TestBed.overrideComponent(RankingToolComponent, {

--- a/src/app/ranking/ranking-ui/ranking-ui.component.html
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.html
@@ -1,30 +1,30 @@
 <div class="ranking-ui-container">
   <div class="ranking-ui-search">
-    <h2>Search</h2>
+    <h2>{{ 'RANKINGS.SEARCH' | translate }}</h2>
     <app-predictive-search
-      placeholder="Search for places"
+      placeholder="{{ 'RANKINGS.SEARCH_HINT' | translate }}"
       [options]="locationList"
       optionField="displayName"
       (selectionChange)="selectedLocationChange.emit($event)"
     ></app-predictive-search>
   </div>
   <div class="ranking-ui-filter">
-    <h2>Filter</h2> 
+    <h2>{{ 'RANKINGS.FILTER' | translate }}</h2> 
     <app-ui-select class="region-select z0"
-      label="Region"
+      label="{{ 'RANKINGS.REGION' | translate }}"
       [values]="regions"
       [selectedValue]="selectedRegion"
       (change)="selectedRegionChange.emit($event)"
     ></app-ui-select>
     <app-ui-select class="area-select z0"
-      label="Area"
+      label="{{ 'RANKINGS.AREA' | translate }}"
       labelProperty="name"
       [values]="areaTypes"
       [selectedValue]="selectedAreaType"
       (change)="selectedAreaTypeChange.emit($event)"
     ></app-ui-select>
     <app-ui-select class="prop-select z0"
-      label="Ranking By"
+      label="{{ 'RANKINGS.RANKING_BY' | translate }}"
       labelProperty="name"
       [values]="dataProperties"
       [selectedValue]="selectedDataProperty"

--- a/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TranslateModule } from '@ngx-translate/core';
 import { UiModule } from '../../ui/ui.module';
 import { RankingUiComponent } from './ranking-ui.component';
 
@@ -10,7 +10,7 @@ describe('RankingUiComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RankingUiComponent],
-      imports: [ UiModule ]
+      imports: [ UiModule, TranslateModule.forRoot() ]
     })
     .compileComponents();
   }));

--- a/src/app/ranking/ranking.module.ts
+++ b/src/app/ranking/ranking.module.ts
@@ -1,6 +1,7 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { RankingToolComponent } from './ranking-tool/ranking-tool.component';
 import { RankingUiComponent } from './ranking-ui/ranking-ui.component';
 import { RankingListComponent } from './ranking-list/ranking-list.component';
@@ -16,7 +17,8 @@ export class RankingConfig {
   imports: [
     CommonModule,
     RouterModule,
-    UiModule
+    UiModule,
+    TranslateModule
   ],
   declarations: [
     RankingToolComponent,

--- a/src/app/ranking/ranking.service.spec.ts
+++ b/src/app/ranking/ranking.service.spec.ts
@@ -1,17 +1,19 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { RankingService } from './ranking.service';
 import { RankingModule } from './ranking.module';
 
 describe('RankingService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [RankingService],
+      providers: [RankingService, TranslateService],
       imports: [
         RankingModule.forRoot({ dataUrl: 'https://fakeurl.com/' }),
         HttpClientModule,
-        HttpClientTestingModule
+        HttpClientTestingModule,
+        TranslateModule.forRoot()
       ]
     });
   });

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -101,6 +101,23 @@
     "PCT_MULTIPLE": "% Multiple Races",
     "PCT_OTHER": "% Other Race"
   },
+  "RANKINGS": {
+    "CITIES": "Cities",
+    "MID_SIZED_AREAS": "Mid-sized Areas",
+    "RURAL_AREAS": "Rural Areas",
+    "SEARCH": "Search",
+    "SEARCH_HINT": "Search for places",
+    "FILTER": "Filter",
+    "REGION": "Region",
+    "AREA": "Area",
+    "RANKING_BY": "Ranking By",
+    "EVICTION_RANKINGS": "Eviction Rankings",
+    "TOP_EVICTING_AREAS": "Top Evicting Areas",
+    "TOP_EVICTORS": "Top Evictors",
+    "HIGHEST": "Highest",
+    "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
+    "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number)."
+  },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",
     "SHARE_FACEBOOK": "Share on Facebook",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -101,6 +101,22 @@
     "PCT_MULTIPLE": "% Dos o Más Razas ",
     "PCT_OTHER": "% Otra Raza"
   },
+  "RANKINGS": {
+    "CITIES": "Cities",
+    "MID_SIZED_AREAS": "Mid-sized Areas",
+    "RURAL_AREAS": "Rural Areas",
+    "SEARCH": "Buscar",
+    "SEARCH_HINT": "Buscar lugares",
+    "FILTER": "Filter",
+    "REGION": "Region",
+    "AREA": "Area",
+    "RANKING_BY": "Ranking By",
+    "TOP_EVICTING_AREAS": "Top Evicting Areas",
+    "TOP_EVICTORS": "Top Evictors",
+    "HIGHEST": "Highest",
+    "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
+    "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number)."
+  },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",
     "SHARE_FACEBOOK": "Share on Facebook",


### PR DESCRIPTION
Closes #591. Also adds `year` as a property on the ranking service and input on the rankings list so that it isn't managed in the template