### PR TITLE
Add scroll to top button on mobile rankings

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -88,7 +88,7 @@ svg {
   width: grid(5);
   height: grid(5);
   box-shadow: $z1shadow;
-  background-color: #EEF2F5;
+  background-color: $rankingsBg1;
   position: absolute;
   right: 0;
   top: grid(-10);

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -40,17 +40,24 @@
       ></app-ranking-list>
     </div>
   </div>
-  <div class="page-fixed-bottom" *ngIf="canRetrieveData && (selectedIndex || selectedIndex === 0)">
-    <app-ranking-panel
-      [rank]="selectedIndex+1"
-      [location]="listData[selectedIndex]"
-      [dataProperty]="dataProperty"
-      (goToPrevious)="onGoToPrevious()"
-      (goToNext)="onGoToNext()"
-      (close)="onClose()"
-    ></app-ranking-panel>
+  <div *ngIf="showScrollButton" class="scroll-to-top-button" (click)="scrollToTop()">
+    <svg width="17px" height="11px" viewBox="0 0 17 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-12, -15)" stroke="#E24000" stroke-width="3">
+          <polyline transform="translate(20.482980, 20.5) scale(1, -1) translate(-20.482980, -20.5) " points="13 17 20.2488435 24 22.1593956 22.2671098 27.9659591 17.0004975"></polyline>
+        </g>
+      </g>
+    </svg>
   </div>
-
 </div>
-
+<div class="page-fixed-bottom" *ngIf="canRetrieveData && (selectedIndex || selectedIndex === 0)">
+  <app-ranking-panel
+    [rank]="selectedIndex+1"
+    [location]="listData[selectedIndex]"
+    [dataProperty]="dataProperty"
+    (goToPrevious)="onGoToPrevious()"
+    (goToNext)="onGoToNext()"
+    (close)="onClose()"
+  ></app-ranking-panel>
+</div>
 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -2,6 +2,7 @@
 
 .ranking-page {
   margin-top: $headerHeightSm;
+  margin-bottom: grid(2);
 }
 
 .page-content {
@@ -109,6 +110,33 @@ app-ranking-list {
   }
 }
 
-:host-context(.gt-mobile) {
+.scroll-to-top-button {
+  position: fixed;
+  position: -webkit-sticky;
+  position: sticky;
+  cursor: pointer;
+  text-align: center;
+  padding: grid(1.25);
+  width: grid(5);
+  height: grid(5);
+  box-shadow: $z1shadow;
+  background-color: $rankingsBg1;
+  right: grid(3);
+  bottom: grid(3);
+  margin-left: auto;
+  z-index: 2;
 
+  polyline { stroke: $color1; }
+
+  &:hover, &:active {
+    background-color: $color1;
+
+    polyline { stroke: $white; }
+  }
+}
+
+:host-context(.gt-mobile) {
+  .scroll-to-top-button {
+    display: none;
+  }
 }

--- a/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PageScrollService } from 'ng2-page-scroll';
 
 import { UiModule } from '../../ui/ui.module';
 import { ServicesModule } from '../../services/services.module';
@@ -33,7 +34,8 @@ describe('RankingToolComponent', () => {
               loadCsvData: () => { },
               isReady: { subscribe: () => { } }
             }
-          }
+          },
+          PageScrollService
         ]
       }
     })

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, ViewChild, Inject } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+import { PageScrollConfig, PageScrollService, PageScrollInstance } from 'ng2-page-scroll';
 
 import { RankingLocation } from '../ranking-location';
 import { RankingService } from '../ranking.service';
@@ -34,6 +36,8 @@ export class RankingToolComponent implements OnInit {
   fullData: Array<RankingLocation>;
   /** list of data for the current UI selections */
   listData: Array<RankingLocation>; // Array of locations to show the rank list for
+  /** Boolean of whether to show scroll to top button */
+  showScrollButton = false;
   /** number of items to show in the list */
   private topCount = 100;
   /** returns if all of the required params are set to be able to fetch data */
@@ -50,7 +54,9 @@ export class RankingToolComponent implements OnInit {
     public rankings: RankingService,
     private route: ActivatedRoute,
     private router: Router,
-    private scroll: ScrollService
+    private pageScrollService: PageScrollService,
+    private scroll: ScrollService,
+    @Inject(DOCUMENT) private document: any
   ) { }
 
   /** Listen for when the data is ready and for route changes */
@@ -142,6 +148,11 @@ export class RankingToolComponent implements OnInit {
     this.selectedIndex = undefined;
   }
 
+  scrollToTop() {
+    const pageScrollInstance = PageScrollInstance.simpleInstance(this.document, 'app-ranking-list');
+    this.pageScrollService.start(pageScrollInstance);
+  }
+
   /**
    * Update the list data based on the selected UI properties
    */
@@ -159,9 +170,26 @@ export class RankingToolComponent implements OnInit {
         })
       );
       console.log('got list data:', this.listData, this.truncatedList, this.dataMax);
+      this.setupPageScroll();
     } else {
       console.warn('data is not ready yet');
     }
+  }
+
+  private setupPageScroll() {
+    PageScrollConfig.defaultScrollOffset = 120;
+    PageScrollConfig.defaultDuration = 1000;
+    // easing function pulled from:
+    // https://joshondesign.com/2013/03/01/improvedEasingEquations
+    PageScrollConfig.defaultEasingLogic = {
+      ease: (t, b, c, d) => -c * (t /= d) * (t - 2) + b
+    };
+
+    const listYOffset = this.document.querySelector('app-ranking-list').getBoundingClientRect().top;
+    this.scroll.verticalOffset$.debounceTime(100)
+      .subscribe(offset => {
+        this.showScrollButton = offset > listYOffset;
+      });
   }
 
 }


### PR DESCRIPTION
Closes #584. Moves the panel out of the main div to make alignment work and add some margin between the footer and close button when scrolled to the bottom. Duplicates some functionality from the map tool component that we'll probably want to move into the scroll service later

![scroll-top](https://user-images.githubusercontent.com/8291663/36114878-ed3aaa7e-0ff6-11e8-84e8-771550188b25.gif)
