### PR TITLE
responsive styles for ranking tool header

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,8 @@ import { RoutingService } from './services/routing.service';
 })
 export class AppComponent implements OnInit {
   mapComponent: MapToolComponent;
+  @HostBinding('class.ranking-tool') isRankingTool: boolean;
+  @HostBinding('class.map-tool') isMapTool: boolean;
   @HostBinding('class.embed') embed: boolean;
   @HostBinding('class.gt-mobile') largerThanMobile: boolean;
   @HostBinding('class.gt-tablet') largerThanTablet: boolean;
@@ -86,9 +88,8 @@ export class AppComponent implements OnInit {
       this.titleService.setTitle('Eviction Lab - Map & Data'); // TODO: translate
     } else if (component.id === 'ranking-tool') {
       this.titleService.setTitle('Eviction Lab - Eviction Rankings'); // TODO: translate
-    } else if (component.id === 'embed-map') {
-      this.embed = true;
     }
+    this.updateClassAttributes(component.id);
     const loadedData = {
       'siteVersion': this.platform.deviceType,
       'appVersion': environment.appVersion,
@@ -97,6 +98,13 @@ export class AppComponent implements OnInit {
       'language': this.translate.currentLang,
     };
     this.analytics.trackEvent('dataLayer-loaded', loadedData);
+  }
+
+  /** Sets the attribute properties that determine the root class for the active component */
+  updateClassAttributes(id: string) {
+    this.isRankingTool = (id === 'ranking-tool');
+    this.isMapTool = (id === 'map-tool');
+    this.embed = (id === 'embed-map');
   }
 
   onMenuSelect(itemId: string) {

--- a/src/app/header-bar/header-bar.component.scss
+++ b/src/app/header-bar/header-bar.component.scss
@@ -21,6 +21,10 @@
     padding:0;
     margin:0 auto;
     box-sizing:border-box;
+    display:flex;
+    justify-content: flex-end;
+    align-content: center;
+    align-items: center;
   }
   // toolbar icon row
   .header-icons {
@@ -64,6 +68,7 @@
   // no logo on mobile
   .header-logo { 
     display: none;
+    img { width: 152px; }
   }
   // place search below toolbar
   .header-search {
@@ -81,10 +86,27 @@
   }
   .language-select {
     display: none;
+    
     ::ng-deep .btn.dropdown-toggle {
       @include defaultFont(13px);
       text-transform: none;
     }
+
+  }
+}
+// Override language select font/icon on mobile only
+@media(max-width: $gtMobile) {
+  .header-wrapper .language-select {
+    margin-right: grid(1);
+    width: grid(9);
+    ::ng-deep .el-select {
+      .btn { 
+        padding: 8px; 
+        height: 40px; 
+      }
+      .btn .el-select-value { font-size:10px; }
+      .btn .svg-down-arrow { width: 8px; right: 8px; }
+    } 
   }
 }
 
@@ -94,12 +116,6 @@
   .header-wrapper {
     height: $headerHeightLg;
     padding: 0 $pageMarginLg;    
-    .header-content {
-      display:flex;
-      justify-content: flex-end;
-      align-content: center;
-      align-items: center;
-    }
     .header-icons {
       flex:none;
       width:grid(5);
@@ -161,6 +177,26 @@
       display:block;
       margin: 0 grid(3) 0 grid(2);
       order: 3;
+      // Vertical treatment with arrow on bottom
+      ::ng-deep {
+        .el-select .dropdown-toggle.btn {
+          height:grid(7);
+          padding: 6px 12px;
+          text-align: center;
+          padding-right: grid(1.5)!important; // never want to add padding for down arrow
+          span {
+            position: relative;
+            top: -7px;
+          }
+          .svg-down-arrow {
+            top:auto;
+            left: 0;
+            bottom: 11px;
+            right: 0!important; // need to force override for vertical select
+            margin: 0 auto;
+          }
+        }
+      }
     }
   }
 }
@@ -185,4 +221,26 @@
       margin-right: grid(1);
     }
   }
+}
+
+// Ranking tool overrides
+:host-context(.ranking-tool) {
+  .btn.btn-icon {
+    display: none;
+  }
+  .btn.btn-icon.el-button-menu {
+    display: block;
+  }
+  .header-wrapper .header-logo {
+    display: block;
+    flex:1;
+  }
+  .header-wrapper .header-icons {
+    width: grid(5);
+    margin-right: -6px; // nudge a bit so menu icon aligns properly
+  }
+  .header-wrapper .language-select {
+    display: block;
+  }
+  .header-wrapper .header-search { display: none; }
 }

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -40,36 +40,6 @@
 
 // OVERRIDES
 
-// Vertical treatment with arrow on bottom
-:host-context(.vertical-select) {
-  .el-select .dropdown-toggle.btn {
-    height:grid(7);
-    padding: 6px 12px;
-    text-align: center;
-    span {
-      position: relative;
-      top: -7px;
-    }
-    .svg-down-arrow {
-      top:auto;
-      left: 0;
-      bottom: 11px;
-      right: 0;
-      margin: 0 auto;
-    }
-  }
-}
-
-// 1px border and no drop shadow when in header
-:host-context(.header-content) {
-  .el-select .dropdown-toggle.btn {
-    padding-right: grid(1.5)!important; // never want to add padding for down arrow
-    .svg-down-arrow {
-      right: 0!important; // never want to reposition down arrow
-    }
-  }
-}
-
 :host-context(.z0) {
   border: 1px solid $shadingColor;
   box-shadow: none;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -161,3 +161,6 @@ body {
     }
   }
 }
+
+// force hide tooltip in header on ranking tool
+.ranking-tool .header-icons .tooltip { display: none; }


### PR DESCRIPTION
Progress on #607, adds style overrides to display the header as provided in mockups on mobile / tablet / desktop.

Mobile:
![image](https://user-images.githubusercontent.com/21034/36130058-b90bb366-1027-11e8-87ec-013853c1109b.png)

Tablet+
![image](https://user-images.githubusercontent.com/21034/36130072-cd86432e-1027-11e8-82c8-d746060a9c98.png)

