### PR TITLE
responsive styles for data panel

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -1,40 +1,31 @@
 <div *ngIf="location" class="content-inner">
   <div class="close-button" (click)="close.emit(true)">
-    <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
-        <g transform="translate(-11.000000, -10.000000)" stroke="#E24000" stroke-width="4.2">
-          <g>
-            <g transform="translate(21.064250, 20.256128) rotate(45.000000) translate(-21.064250, -20.256128) translate(10.564250, 9.756128)">
-              <path d="M10.2734591,0.36432179 L10.2734591,20.3643218"></path>
-              <path d="M20.2734591,10.3643218 L0.27345908,10.3643218"></path>
-            </g>
-          </g>
-        </g>
-      </g>
+    <svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <path d="M10,0 L10,20" transform="translate(10, 10) rotate(45) translate(-10, -10) "></path>
+      <path d="M20,10 L0,10" transform="translate(10, 10) rotate(45) translate(-10, -10) "></path>
     </svg>
   </div>
-  <div class="panel-prev" (click)="goToPrevious.emit(true)">
-      <svg viewBox="0 0 24 24">
-          <path d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z" />
-      </svg>
-  </div>
-  <div class="panel-rank">
-    <span class="rank-number">{{ rank }}</span>
-    <span class="rank-label">{{ 'RANKINGS.HIGHEST' | translate }} {{dataProperty.name}}</span>
-  </div>
+  <button class="panel-arrow panel-prev" (click)="goToPrevious.emit(true)">
+    <svg viewBox="0 0 8 12">
+      <polygon transform="translate(4.295000, 6.000000) scale(-1, 1) translate(-4.295000, -6.000000) " points="0.59 10.58 5.17 6 0.59 1.41 2 0 8 6 2 12"></polygon>
+    </svg>
+  </button>
   <div class="panel-summary">
-    <div class="panel-summary-heading">
-      <h2>{{ location.name }}</h2>
-      <span>{{dataProperty.name}} </span>
-      <span>{{location[dataProperty.value]}}</span>
+    <div class="panel-top">
+      <span class="rank-number">{{ rank }}</span>
+      <div class="panel-summary-heading">
+        <h2 class="rank-location">{{ location.name }}</h2>
+        <span class="rank-value">{{dataProperty.name}} {{location[dataProperty.value]}}</span>
+        <a href="" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
+      </div>
     </div>
-    <p class="panel-summary-content">
-      {{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}
-    </p>
+    <div class="panel-summary-content">
+      <p>{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
+    </div>
   </div>
-  <div class="panel-next" (click)="goToNext.emit(true)">
-      <svg viewBox="0 0 24 24">
-          <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z" />
-      </svg>
-  </div>
+  <button class="panel-arrow panel-next" (click)="goToNext.emit(true)">
+    <svg viewBox="0 0 8 12">
+      <polygon points="0.59 10.58 5.17 6 0.59 1.41 2 0 8 6 2 12"></polygon>
+    </svg>
+  </button>
 </div>

--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -1,85 +1,269 @@
 @import '../../../theme';
 
+:host {
+  padding: $pageMargin;
+}
+// increase page margins
+@media(min-width: $gtMobile) {
+  :host { padding: $pageMarginLg; }
+}
+
 .content-inner {
   position:relative;
   display:flex;
   align-items: center;
   justify-content:flex-start;
 }
-.panel-controls {
-  list-style:none;
-  margin:0;
-  padding:0;
-  li {
-    position:absolute;
-  }
-}
 
-.panel-rank {
-  min-width: grid(14);
-  height: grid(14);
-  padding: 0 grid(2);
-  margin:0 grid(5) 0 grid(3);
-  text-align:center;
-  flex:0;
-  background: $gradient4;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  .rank-number {
-    @include numberFont(24px);
-  }
-  .rank-label {
-    display:block;
-    @include smallCapsText(14px);
-  }
-}
-
-.panel-summary-heading {
-  display:flex;
-  align-items: flex-end;
-  justify-content: flex-start;
-  margin-bottom: grid(1);
-  h2 {
-    @include altFont(24px);
-    text-transform: uppercase;
-    line-height:1;
-    margin:0;
-    letter-spacing: 0.05em;
-    color: $color1;
-    margin-right: grid(1);
-  }
-  span {
-    @include smallCapsText(14px);
-    margin-right: grid(0.5);
-    display:block;
-    margin-bottom:-2px;
+@media(min-width: $gtMobile) {
+  .content-inner {
+    position:relative;
+    display:flex;
+    align-items: center;
+    justify-content:flex-start;
   }
 }
 
 .panel-summary {
-  flex:1;
+  width: 100%;
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .panel-summary {
+    max-width: grid(120);
+    margin: auto;
+  }
+}
+
+.panel-summary-heading {
+  text-align:center;
+}
+
+@media(min-width: $gtMobile) {
+  .panel-summary-heading {
+    text-align: left;
+  }
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .panel-summary-heading {
+    margin-top: grid(1);
+  }
+}
+
+@media(min-width: $gtMobile) {
+  .panel-top {
+    margin: auto;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+  }
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .panel-top {
+    display:inline;
+  }
+}
+
+
+.rank-number {
+  display:block;
+  margin:0 auto grid(1.5);
+  width: grid(3);
+  height: grid(3);
+  background: $gradient1;
+  @include numberFont(12px);
+  color: $white;
+  text-align:center;
+  line-height: grid(3);
+}
+
+@media(min-width: $gtMobile) {
+  .rank-number {
+    width: grid(6);
+    height: grid(6);
+    margin: 0 grid(4) 0 0;
+    @include numberFont(28px);
+    line-height: grid(6);
+  }
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .rank-number {
+    float:left;
+    width: grid(15);
+    height: grid(15);
+    line-height: grid(15);
+    @include numberFont(48px);
+  }
+}
+
+.rank-location {
+  display: block;
+  margin: 0 0 grid(0.5) 0;
+  @include altSmallCapsText(14px);
+  text-align: center;
+  color: $color1;
+  line-height:1;
+}
+
+@media(min-width: $gtMobile) {
+  .rank-location {
+    @include altSmallCapsText(26px);
+    text-align: left;
+  }
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .rank-location {
+    display: inline-block;
+    @include altSmallCapsText(30px);
+    margin-right: grid(3);
+  }
+}
+
+.rank-value {
+  margin-right: grid(1);
+  @include smallCapsText(10px);
+  line-height:1;
+}
+
+@media(min-width: $gtMobile) {
+  .rank-value {
+    margin-right: grid(3);
+    @include smallCapsText(14px);
+  }  
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .rank-value {
+    @include smallCapsText(15px);
+  }
+}
+
+.rank-link {
+  @include smallCapsText(10px);
+  color: $color1;
+  line-height:1;
+}
+
+@media(min-width: $gtMobile) {
+  .rank-link {
+    @include smallCapsText(14px);
+  }  
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .rank-link {
+    @include smallCapsText(15px);
+  }
 }
 
 .panel-summary-content {
-  @include defaultFont(16px);
+  width: 100%;
+  padding: $pageMargin;
+  margin: grid(1) -1*$pageMargin -1*$pageMargin;
+  background: $grey5;
+  @include defaultFont(12px);
+  text-align: center;
+  box-sizing: content-box;
+  p {
+    margin: 0 auto;
+    max-width: grid(50);
+  }
 }
 
-.panel-next, .panel-prev {
-  width: 48px;
-  height: 48px;
-  flex:0;
+@media(min-width: $gtMobile) {
+  .panel-summary-content {
+    @include defaultFont(18px);
+    padding: $pageMarginLg;
+    margin: grid(2) -1*$pageMarginLg -1*$pageMarginLg;
+    p { max-width: grid(90); }
+  }
+}
+
+@media(min-width: $gtSmallDesktop) {
+  .panel-summary-content {
+    display:inline;
+    @include defaultFont(20px);
+    padding: 0;
+    margin: grid(2) 0;
+    background: none;
+    p {
+      max-width: none;
+      text-align: left;
+      margin-top: grid(1);
+    }
+  }
+}
+
+.panel-arrow {
+  appearance: none; // remove button defaults
+  border: none;
+  position: absolute;
+  top: grid(2);
+  width: grid(5);
+  height: grid(5);
+  display:flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   &:hover {
     background: $shadingColor;
-  }  
+  }
+  &.panel-next { right: 0; }
+  &.panel-prev { left: 0; }
+  svg {
+    width: grid(3);
+    height: grid(3);
+    polygon { fill: $color1; }
+  }
 }
-svg {
-  width: 48px;
-  height: 48px;
-  path { fill: $grey3; }
+// boost prev / next icon size on tablet
+@media(min-width: $gtMobile) {
+  .panel-arrow {
+    top: 0;
+    width: grid(6);
+    height: grid(6);
+    svg {
+      width: grid(5);
+      height: grid(5);
+    }
+  }
 }
+
+@media(min-width: $gtSmallDesktop) {
+  .panel-arrow {
+    top: grid(5);
+  }
+}
+
+
+// .panel-summary-heading {
+//   margin-bottom: grid(1);
+//   h2 {
+//     @include altFont(24px);
+//     text-transform: uppercase;
+//     line-height:1;
+//     margin:0;
+//     letter-spacing: 0.05em;
+//     color: $color1;
+//     margin-right: grid(1);
+//   }
+//   .rank-property {
+//     @include smallCapsText(14px);
+//     margin-right: grid(0.5);
+//     display:block;
+//     margin-bottom:-2px;
+//   }
+// }
+
+// .panel-summary {
+//   flex:1;
+// }
+
+
 
 .close-button {
   cursor: pointer;
@@ -96,8 +280,10 @@ svg {
   svg {
     height: grid(2.5);
     width: grid(2.5);
-
-    path { stroke: $color1; }
+    path { 
+      stroke: $color1;
+      stroke-width: 4;
+    }
   }
 
   &:hover, &:active {

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -227,7 +227,6 @@ app-ranking-ui {
   left:0;
   right:0;
   background: $white;
-  padding: $pageMarginLg;
   z-index:21;
   box-shadow: $z1shadow;
   app-ranking-panel {
@@ -237,7 +236,6 @@ app-ranking-ui {
 
 .scroll-to-top-button {
   position: fixed;
-  position: -webkit-sticky;
   position: sticky;
   cursor: pointer;
   text-align: center;
@@ -250,12 +248,9 @@ app-ranking-ui {
   bottom: grid(3);
   margin-left: auto;
   z-index: 2;
-
   polyline { stroke: $color1; }
-
   &:hover, &:active {
     background-color: $color1;
-
     polyline { stroke: $white; }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -117,7 +117,8 @@
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",
-    "SEARCH_FILTER": "Search & Filter"
+    "SEARCH_FILTER": "Search & Filter",
+    "TOP_EVICTORS_LINK": "View Top Evictors"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -116,7 +116,8 @@
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",
-    "SEARCH_FILTER": "Search & Filter"
+    "SEARCH_FILTER": "Search & Filter",
+    "TOP_EVICTORS_LINK": "View Top Evictors"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",


### PR DESCRIPTION
Progress on #607, adds mobile, tablet, and new desktop styles for ranking tool panel based on mockups from Noele.

Mobile:
![image](https://user-images.githubusercontent.com/21034/36171830-51117a94-10c1-11e8-845d-3ac9a99a265d.png)

Tablet:
![image](https://user-images.githubusercontent.com/21034/36171842-59148b32-10c1-11e8-86b6-c2e8d68d2d51.png)

Desktop:
![image](https://user-images.githubusercontent.com/21034/36171868-69d8dcc0-10c1-11e8-818d-18ac955b5fd9.png)
