### PR TITLE
Update query params on rankings

### DIFF
--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -25,7 +25,7 @@ export class EmbedComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.routing.getMapRouteData().take(1)
+    this.routing.getCombinedRouteData().take(1)
       .subscribe((data) => this.mapToolService.setCurrentData(data));
     this.cdRef.detectChanges();
   }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -74,7 +74,7 @@ export class MapToolComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.setupPageScroll();
     // Set data from the route on init
-    this.routing.getMapRouteData().take(1)
+    this.routing.getCombinedRouteData().take(1)
       .subscribe((data) => this.mapToolService.setCurrentData(data));
     // Subscribe to language changes and store translated help content
     this.translate.onLangChange.subscribe(() => {

--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -106,8 +106,8 @@ export class RoutingService {
     const appRoutes: Routes = [
       { path: 'embed/:year/:geography/:bounds', component: components.embed },
       { path: ':year/:geography/:bounds', component: components.map },
-      // { path: 'evictors', component: components.rankings },
-      { path: ':tab', redirectTo: this.defaultViews.rankings },
+      { path: 'evictions', redirectTo: this.defaultViews.rankings, pathMatch: 'full' },
+      { path: ':tab', component: components.rankings },
       { path: ':tab/:region/:areaType/:sortProp', component: components.rankings },
       { path: '', redirectTo: defaultRoute, pathMatch: 'full' } // default route based on URL path
     ];


### PR DESCRIPTION
Closes #610. Sets `index` and `lang` as query params, and uses the `RoutingService` rather than calling routes directly