### PR TITLE
Alternate routing strategy on rankings

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -18,11 +18,29 @@ export class RankingToolComponent implements OnInit {
   /** tab ID for the active tab */
   activeTab = 'evictions';
   /** string representing the region */
-  region = 'United States';
+  set region(regionValue) {
+    if (regionValue !== this.store.region) {
+      this.store.region = regionValue;
+      this.updateEvictionList();
+    }
+  }
+  get region() { return this.store.region; }
   /** ID representing the selected area type */
-  areaType = null;
+  set areaType(newType) {
+    if (newType !== this.store.areaType) {
+      this.store.areaType = newType;
+      this.updateEvictionList();
+    }
+  }
+  get areaType() { return this.store.areaType; }
   /** object key representing the data property to sort by */
-  dataProperty = null;
+  set dataProperty(newProp) {
+    if (newProp !== this.store.dataProperty) {
+      this.store.dataProperty = newProp;
+      this.updateEvictionList();
+    }
+  }
+  get dataProperty() { return this.store.dataProperty; }
   /** the index of the selected location for the data panel */
   selectedIndex: number;
   /** tracks if the data has been loaded and parsed */
@@ -41,6 +59,11 @@ export class RankingToolComponent implements OnInit {
   showScrollButton = false;
   /** number of items to show in the list */
   private topCount = 100;
+  private store = {
+    region: 'United States',
+    areaType: null,
+    dataProperty: null
+  };
   /** returns if all of the required params are set to be able to fetch data */
   get canRetrieveData(): boolean {
     return this.canNavigate && this.isDataReady;
@@ -74,86 +97,116 @@ export class RankingToolComponent implements OnInit {
    */
   onRouteChange(url) {
     this.activeTab = url[0].path;
+    console.log('url changed', url);
     if (this.activeTab === 'evictions') {
       this.region = url[1].path;
       this.areaType = this.rankings.areaTypes.find(a => a.value === parseInt(url[2].path, 10));
       this.dataProperty = this.rankings.sortProps.find(p => p.value === url[3].path);
-      this.updateEvictionList();
+      this.selectedIndex = url[4] ? parseInt(url[4].path, 10) : null;
     }
   }
 
   /** Update the route when the region changes */
   onRegionChange(newRegion: string) {
     if (this.canNavigate) {
-      this.router.navigate(
-        ['/', this.activeTab, newRegion, this.areaType.value, this.dataProperty.value]
-      );
+      const newLocation = this.getCurrentNavArray();
+      newLocation[2] = newRegion;
+      this.router.navigate(newLocation);
     }
   }
 
   /** Update the route when the area type changes */
   onAreaTypeChange(areaType: { name: string, value: number }) {
     if (this.canNavigate) {
-      this.router.navigate(
-        ['/', this.activeTab, this.region, areaType.value, this.dataProperty.value]
-      );
+      const newLocation = this.getCurrentNavArray();
+      newLocation[3] = areaType.value;
+      this.router.navigate(newLocation);
     }
   }
 
   /** Update the sort property when the area type changes */
   onDataPropertyChange(dataProp: { name: string, value: string }) {
     if (this.canNavigate) {
-      this.router.navigate(
-        ['/', this.activeTab, this.region, this.areaType.value, dataProp.value]
-      );
+      const newLocation = this.getCurrentNavArray();
+      newLocation[4] = dataProp.value;
+      this.router.navigate(newLocation);
+    }
+  }
+
+  /** Update current location */
+  setCurrentLocation(locationIndex: number) {
+    if (this.canNavigate) {
+      const newLocation = this.getCurrentNavArray();
+      if (locationIndex || locationIndex === 0) {
+        newLocation[5] = locationIndex;
+      } else {
+        newLocation.splice(-1, 1);
+      }
+      this.router.navigate(newLocation);
     }
   }
 
   onSearchSelectLocation(location: RankingLocation | null) {
     if (location === null) {
-      this.selectedIndex = undefined;
+      this.setCurrentLocation(null);
       return;
     }
     this.showUiPanel = false;
     const listIndex = this.listData.map(d => d.geoId).indexOf(location.geoId);
+    let selectedIndex = -1;
     if (listIndex > -1) {
-      this.selectedIndex = listIndex;
+      selectedIndex = listIndex;
     } else {
       this.region = 'United States';
       this.areaType = this.rankings.areaTypes.filter(t => t.value === location.areaType)[0];
       this.updateEvictionList();
-      this.selectedIndex = this.listData.map(d => d.geoId).indexOf(location.geoId);
+      selectedIndex = this.listData.map(d => d.geoId).indexOf(location.geoId);
     }
-    if (this.selectedIndex < this.topCount) {
-      this.scroll.scrollTo(`.ranking-list > li:nth-child(${this.selectedIndex + 1})`);
+    if (selectedIndex < this.topCount) {
+      this.scroll.scrollTo(`.ranking-list > li:nth-child(${selectedIndex + 1})`);
     }
+    this.setCurrentLocation(selectedIndex);
   }
 
   onClickLocation(index: number) {
-    this.selectedIndex = index;
+    this.setCurrentLocation(index);
   }
 
   /** Switch the selected location to the next one in the list */
   onGoToNext() {
     if (this.selectedIndex < this.listData.length - 1) {
-      this.selectedIndex++;
+      this.setCurrentLocation(this.selectedIndex + 1);
     }
   }
 
   /** Switch the selected location to the previous one in the list */
   onGoToPrevious() {
     if (this.selectedIndex > 0) {
-      this.selectedIndex--;
+      this.setCurrentLocation(this.selectedIndex - 1);
     }
   }
 
   /** Removes currently selected index on closing the panel */
   onClose() {
-    this.selectedIndex = undefined;
+    this.setCurrentLocation(null);
   }
 
   scrollToTop() {
     this.scroll.scrollTo('app-ranking-list');
+  }
+
+  private getCurrentNavArray() {
+    const routeArray =  [
+      '/',
+      this.activeTab,
+      this.region,
+      this.areaType.value,
+      this.dataProperty.value
+    ];
+    if (this.selectedIndex || this.selectedIndex === 0) {
+      routeArray.push(this.selectedIndex);
+    }
+    return routeArray;
   }
 
   /**

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -2,8 +2,6 @@ import { Component, OnInit, ViewChild, Inject } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { DOCUMENT } from '@angular/common';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/combineLatest';
 
 import { RankingLocation } from '../ranking-location';
 import { RankingService } from '../ranking.service';
@@ -97,11 +95,8 @@ export class RankingToolComponent implements OnInit {
         this.router.navigate(this.getCurrentNavArray(), { queryParams: this.getQueryParams() });
       }
     });
-    Observable.combineLatest(
-      this.route.url,
-      this.route.queryParams,
-      (url, queryParams) => ({ ...url, queryParams: queryParams })
-    ).subscribe(this.onRouteChange.bind(this));
+    this.route.url.subscribe(this.onRouteChange.bind(this));
+    this.route.queryParams.subscribe(this.onQueryParamChange.bind(this));
   }
 
   /**
@@ -117,12 +112,20 @@ export class RankingToolComponent implements OnInit {
       this.dataProperty = this.rankings.sortProps.find(p => p.value === url[3].path);
       this.selectedIndex = url[4] ? parseInt(url[4].path, 10) : null;
     }
-    this.translate.use(url.queryParams['lang'] || 'en');
+  }
+
+  /**
+   * Update data from query params
+   * @param params
+   */
+  onQueryParamChange(params) {
+    this.translate.use(params['lang'] || 'en');
   }
 
   /** Update the route when the region changes */
   onRegionChange(newRegion: string) {
     if (this.canNavigate) {
+      if (newRegion !== this.region) { this.selectedIndex = null; }
       const newLocation = this.getCurrentNavArray();
       newLocation[2] = newRegion;
       this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
@@ -132,6 +135,9 @@ export class RankingToolComponent implements OnInit {
   /** Update the route when the area type changes */
   onAreaTypeChange(areaType: { name: string, value: number }) {
     if (this.canNavigate) {
+      if (this.areaType !== null && areaType.value !== this.areaType.value) {
+        this.selectedIndex = null;
+      }
       const newLocation = this.getCurrentNavArray();
       newLocation[3] = areaType.value;
       this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
@@ -141,6 +147,9 @@ export class RankingToolComponent implements OnInit {
   /** Update the sort property when the area type changes */
   onDataPropertyChange(dataProp: { name: string, value: string }) {
     if (this.canNavigate) {
+      if (this.dataProperty !== null && dataProp.value !== this.dataProperty.value) {
+        this.selectedIndex = null;
+      }
       const newLocation = this.getCurrentNavArray();
       newLocation[4] = dataProp.value;
       this.router.navigate(newLocation, { queryParams: this.getQueryParams() });


### PR DESCRIPTION
@pjsier Here's the location updates based on subscribing to the URL changes.  It makes sense to me to have our routing implementations consistent between map tool / ranking tool, but I kind of wish I had implemented routing in the map tool this way.   If I had, we wouldn't need `routing.service`, we wouldn't need to `updateRoute()` every time something changes, and we wouldn't need to `take(1)` on load.

You've obviously put in a lot of work restructuring the ranking tool routes, and really I'm fine with either approach.  What are your thoughts?