### PR TITLE
Fix mobile vh scroll jump with delayed transition 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eviction-maps",
-  "version": "0.0.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,7 +36,6 @@ export class AppComponent implements OnInit {
   @HostBinding('class.gt-large-desktop') largerThanLargeDesktop: boolean;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
-  @HostBinding('class.ready') ready = false;
   currentMenuItem: string;
   menuActive = false;
   private activeMenuItem;
@@ -75,8 +74,6 @@ export class AppComponent implements OnInit {
     this.iosSafari = ((userAgent.includes('iphone') || userAgent.includes('ipad')) &&
       (!userAgent.includes('crios') && !userAgent.includes('fxios')));
     this.android = userAgent.includes('android') && !userAgent.includes('firefox');
-    // Triggers vh transition delay after init
-    setTimeout(() => this.ready = true, 250);
   }
 
   closeMenu() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ export class AppComponent implements OnInit {
   @HostBinding('class.gt-large-desktop') largerThanLargeDesktop: boolean;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
+  @HostBinding('class.ready') ready = false;
   currentMenuItem: string;
   menuActive = false;
   private activeMenuItem;
@@ -74,6 +75,8 @@ export class AppComponent implements OnInit {
     this.iosSafari = ((userAgent.includes('iphone') || userAgent.includes('ipad')) &&
       (!userAgent.includes('crios') && !userAgent.includes('fxios')));
     this.android = userAgent.includes('android') && !userAgent.includes('firefox');
+    // Triggers vh transition delay after init
+    setTimeout(() => this.ready = true, 250);
   }
 
   closeMenu() {

--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -1,8 +1,4 @@
 <div class="data-wrapper">
-  <div class="mobile-scroll-indicator">
-    <p *ngIf="displayLocations.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
-    <p *ngIf="displayLocations.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
-  </div>
   <div class="panel-cards" [style.display]="displayLocations.length > 0 ? '' : 'none'">
     <div class="data-header">
       <p [innerHTML]="'DATA.CARD_HEADING' | translate:{'year':year}"></p>

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -10,8 +10,7 @@
 }
 
 .data-wrapper {
-  border-top: 1px solid #eee;
-
+  border-top: 1px solid $white;
 }
 
 // Data panel header text

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -14,18 +14,6 @@
 
 }
 
-.mobile-scroll-indicator p {
-  @include dataPanelHeader(14px);
-  text-align: center;
-  margin: grid(1) grid(4);
-  opacity: 1;
-  transition: opacity 0.6s;
-}
-
-:host-context(.map-inactive) {
-  .mobile-scroll-indicator p { opacity: 0; }
-}
-
 // Data panel header text
 // ----
 .data-header {
@@ -42,7 +30,6 @@
 // increase spacing for devices larger than tablet
 :host-context(.gt-tablet) {
   .data-header { margin: grid(8) 0 grid(4); }
-  .mobile-scroll-indicator { display: none; }
 }
 
 .data-content {

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,5 +1,6 @@
 <div id="top" role="main" class="app-wrapper">
   <app-map
+    [class.map-inactive]="!enableZoom"
     [mapConfig]="mapToolService.mapConfig"
     [dataAttributes]="mapToolService.dataAttributes"
     [layerOptions]="mapToolService.dataLevels"
@@ -52,7 +53,6 @@
       [locations]="mapToolService.activeFeatures" 
       (locationRemoved)="mapToolService.removeLocation($event); updateRoute()"
       (locationAdded)="onSearchSelect($event, false)"
-      [class.map-inactive]="!enableZoom"
   >
     <button (click)="goToTop()" class="btn btn-large btn-primary btn-map">
       <svg class="up-arrow" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -14,7 +14,6 @@
     margin-top: $headerHeightSm;
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
-    transition: $mobileVhTransition;
   }
   app-data-panel {
     display:block;
@@ -28,11 +27,8 @@
 // Additional spacing for iOS Safari
 :host-context(.ios-safari), :host-context(.gt-mobile.ios-safari) {
   .app-wrapper {
-    app-map.legend-active, app-map.slider-active {
+    app-map.legend-active, app-map.slider-active, app-map.cards-active {
       height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight});
-    }
-    app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight} - #{$legendHeight});
     }
   }
 }
@@ -40,13 +36,14 @@
 // Additional spacing for Android 
 :host-context(.android), :host-context(.gt-mobile.android) {
   .app-wrapper {
-    app-map.legend-active, app-map.slider-active {
+    app-map.legend-active, app-map.slider-active, app-map.cards-active {
       height: calc(100vh - #{$headerHeightSm} - #{$androidPadding} - #{$timeSliderHeight});
     }
-    app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$androidPadding} - #{$timeSliderHeight} - #{$legendHeight});
-    }
   }
+}
+
+:host-context(.ready) {
+  .app-wrapper app-map { transition: $mobileVhTransition; }
 }
 
 // Larger than mobile:

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -6,6 +6,7 @@
   &.map-active {
     height: 100vh;
     overflow: hidden;
+    // transition: $mobileVhTransition;
   }
   app-map {
     position:relative;
@@ -14,10 +15,11 @@
     margin-top: $headerHeightSm;
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
+    transition: $mobileVhTransition;
   }
-  app-map.cards-active {
-    height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
-  }
+  // app-map.cards-active {
+  //   height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
+  // }
   app-data-panel {
     display:block;
     position:relative;
@@ -60,11 +62,11 @@
       height: calc(100vh - #{$headerHeightLg});
     }
   }
-  .app-wrapper {
-    app-map.cards-active {
-      height: calc(100vh - #{$headerHeightLg} - #{grid(5)});
-    }
-  }
+  // .app-wrapper {
+  //   app-map.cards-active {
+  //     height: calc(100vh - #{$headerHeightLg} - #{grid(5)});
+  //   }
+  // }
 }
 
 // Larger than tablet:
@@ -73,10 +75,13 @@
 :host-context(.gt-tablet.ios-safari),
 :host-context(.gt-tablet.andrdoid) {
   .app-wrapper {
+    &.map-active { transition: none; }
+
     app-map, app-map.legend-active, app-map.slider-active,
     app-map.legend-active.slider-active, app-map.cards-active {
       margin-top: $headerHeightLg;
       height: calc(100vh - #{$headerHeightLg});
+      transition: none;
     }
   }
 }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -14,6 +14,7 @@
     margin-top: $headerHeightSm;
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
+    transition: $mobileVhTransition;
   }
   app-data-panel {
     display:block;
@@ -22,28 +23,6 @@
     background:#fff;
     z-index:200;
   }
-}
-
-// Additional spacing for iOS Safari
-:host-context(.ios-safari), :host-context(.gt-mobile.ios-safari) {
-  .app-wrapper {
-    app-map.legend-active, app-map.slider-active, app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$iosSafariPadding} - #{$timeSliderHeight});
-    }
-  }
-}
-
-// Additional spacing for Android 
-:host-context(.android), :host-context(.gt-mobile.android) {
-  .app-wrapper {
-    app-map.legend-active, app-map.slider-active, app-map.cards-active {
-      height: calc(100vh - #{$headerHeightSm} - #{$androidPadding} - #{$timeSliderHeight});
-    }
-  }
-}
-
-:host-context(.ready) {
-  .app-wrapper app-map { transition: $mobileVhTransition; }
 }
 
 // Larger than mobile:
@@ -59,9 +38,7 @@
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-tablet),
-:host-context(.gt-tablet.ios-safari),
-:host-context(.gt-tablet.android) {
+:host-context(.gt-tablet) {
   .app-wrapper {
     &.map-active { transition: none; }
 

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -6,7 +6,6 @@
   &.map-active {
     height: 100vh;
     overflow: hidden;
-    // transition: $mobileVhTransition;
   }
   app-map {
     position:relative;
@@ -17,9 +16,6 @@
     z-index:10;
     transition: $mobileVhTransition;
   }
-  // app-map.cards-active {
-  //   height: calc(100vh - #{$headerHeightSm} - #{grid(5)});
-  // }
   app-data-panel {
     display:block;
     position:relative;
@@ -62,18 +58,13 @@
       height: calc(100vh - #{$headerHeightLg});
     }
   }
-  // .app-wrapper {
-  //   app-map.cards-active {
-  //     height: calc(100vh - #{$headerHeightLg} - #{grid(5)});
-  //   }
-  // }
 }
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
 :host-context(.gt-tablet),
 :host-context(.gt-tablet.ios-safari),
-:host-context(.gt-tablet.andrdoid) {
+:host-context(.gt-tablet.android) {
   .app-wrapper {
     &.map-active { transition: none; }
 

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -48,6 +48,10 @@
     (clickedHeader)="clickedCardHeader.emit($event)"
     (dismissedCard)="dismissedCard.emit($event)"
   ></app-location-cards>
+  <div class="mobile-scroll-indicator">
+    <p *ngIf="activeFeatures.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
+    <p *ngIf="activeFeatures.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
+  </div>
 </div>
 <div class="map-wrapper" #mapEl>
   <app-mapbox

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -53,7 +53,7 @@
   pointer-events: all;
   display: none;
   position: absolute;
-  height: grid(5);
+  height: $mobileScrollIndicatorHeight;
   bottom: 0;
   width: 100vw;
   z-index: 51;
@@ -88,7 +88,7 @@ app-mapbox ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
 // center controls vertically on the right side of the map
 app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
   top: 0;
-  bottom: calc(#{$timeSliderHeight} + #{grid(10)});
+  bottom: $timeSliderHeight + $mobileScrollIndicatorHeight + grid(5);
   margin:auto;
   height:grid(22);
   right:$pageMargin;
@@ -129,7 +129,7 @@ app-location-cards {
   background: $defaultBackground;
   pointer-events:all;
   position: absolute;
-  bottom: grid(5);
+  bottom: $mobileScrollIndicatorHeight;
   left:0;
   height: $cardHeaderHeight;
   z-index: 20;
@@ -310,7 +310,7 @@ app-ui-map-legend {
 // cards and slider activated on mobile:
 //    move legend above cards / time slider
 :host-context(.cards-active.slider-active) app-ui-map-legend {
-  bottom: $timeSliderHeight + $cardHeaderHeight + grid(5);
+  bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight;
 }
 // larger than tablet: 
 //    move legend to bottom right of the map
@@ -337,7 +337,7 @@ app-ui-map-legend {
   bottom: $timeSliderLg + $pageMarginLg;
 }
 .gt-mobile :host-context(.cards-active.slider-active) app-ui-map-legend {
-  bottom: $timeSliderLg + $cardHeaderHeight + $pageMarginLg;
+  bottom: $timeSliderLg + $cardHeaderHeight + $pageMarginLg + $mobileScrollIndicatorHeight;
 }
 
 // large than tablet:
@@ -381,7 +381,7 @@ app-ui-map-legend {
 }
 // increase offset from the bottom if cards are shown
 :host-context(.cards-active) {
-  .year-slider-container { bottom: $cardHeaderHeight + grid(5); }
+  .year-slider-container { bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight; }
 }
 .gt-mobile :host-context {
   .year-slider-container {
@@ -411,13 +411,13 @@ app-ui-map-legend {
   app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
 }
 .ios-safari:not(.gt-tablet) :host-context(.cards-active) {
-  .mobile-scroll-indicator { height: grid(5) + $iosSafariPadding; }
-  app-location-cards { bottom: grid(5) + $iosSafariPadding; }
+  .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
+  app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
   .year-slider-container {
     height: $timeSliderHeight;
-    bottom: $cardHeaderHeight + grid(5) + $iosSafariPadding;
+    bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
   }
-  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + grid(5) + $iosSafariPadding; }
+  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
 }
 
 // Additional spacing for Android
@@ -428,12 +428,12 @@ app-ui-map-legend {
   app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
 }
 .android:not(.gt-tablet) :host-context(.cards-active) {
-  .mobile-scroll-indicator { height: grid(5) + $androidPadding; }
-  app-location-cards { bottom: grid(5) + $androidPadding; }
+  .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
+  app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
   .year-slider-container {
     height: $timeSliderHeight;
-    bottom: $cardHeaderHeight + grid(5) + $androidPadding;
+    bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
   }
-  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + grid(5) + $androidPadding; }
+  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
 }
 // - End of device adjustments

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -400,3 +400,40 @@ app-ui-map-legend {
   }
 }
 // - End Year Slider
+
+// Device-specific adjustments
+
+// Additional spacing for iOS Safari
+.ios-safari:not(.gt-tablet) :host-context(.slider-active) {
+  .year-slider-container { height: $timeSliderHeight + $iosSafariPadding; }
+}
+.ios-safari:not(.gt-tablet) :host-context(.legend-active) {
+  app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
+}
+.ios-safari:not(.gt-tablet) :host-context(.cards-active) {
+  .mobile-scroll-indicator { height: grid(5) + $iosSafariPadding; }
+  app-location-cards { bottom: grid(5) + $iosSafariPadding; }
+  .year-slider-container {
+    height: $timeSliderHeight;
+    bottom: $cardHeaderHeight + grid(5) + $iosSafariPadding;
+  }
+  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + grid(5) + $iosSafariPadding; }
+}
+
+// Additional spacing for Android
+.android:not(.gt-tablet) :host-context(.slider-active) {
+  .year-slider-container { height: $timeSliderHeight + $androidPadding; }
+}
+.android:not(.gt-tablet) :host-context(.legend-active) {
+  app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
+}
+.android:not(.gt-tablet) :host-context(.cards-active) {
+  .mobile-scroll-indicator { height: grid(5) + $androidPadding; }
+  app-location-cards { bottom: grid(5) + $androidPadding; }
+  .year-slider-container {
+    height: $timeSliderHeight;
+    bottom: $cardHeaderHeight + grid(5) + $androidPadding;
+  }
+  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + grid(5) + $androidPadding; }
+}
+// - End of device adjustments

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -47,6 +47,29 @@
 }
 // - End Map UI Layout
 
+.mobile-scroll-indicator {
+  position: absolute;
+  height: grid(5);
+  bottom: 0;
+  width: 100vw;
+  z-index: 1;
+  background-color: $white;
+}
+
+.mobile-scroll-indicator p {
+  @include defaultFont(14px);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-align: center;
+  margin: grid(1) grid(4);
+  opacity: 1;
+  transition: opacity 0.6s;
+}
+
+:host-context(.map-inactive) {
+  .mobile-scroll-indicator p { opacity: 0; }
+}
+
 // Map Zoom Controls
 // ----
 // Hide rotate button because it's confusing
@@ -97,7 +120,8 @@ app-location-cards {
   background: $defaultBackground;
   pointer-events:all;
   position: absolute;
-  bottom:0;
+  // bottom:0;
+  bottom: grid(5);
   left:0;
   height: $cardHeaderHeight;
   z-index: 20;
@@ -115,6 +139,7 @@ app-location-cards {
 //    Adjust cards container to account for the larger header height
 //    center cards vertically over the map
 :host-context(.gt-tablet) {
+  .mobile-scroll-indicator { display: none; }
   app-location-cards {
     background: none;
     pointer-events: none;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -47,12 +47,16 @@
 }
 // - End Map UI Layout
 
+// Mobile scroll indicator
+// ---
 .mobile-scroll-indicator {
+  pointer-events: all;
+  display: none;
   position: absolute;
   height: grid(5);
   bottom: 0;
   width: 100vw;
-  z-index: 1;
+  z-index: 51;
   background-color: $white;
 }
 
@@ -66,9 +70,14 @@
   transition: opacity 0.6s;
 }
 
+:host-context(.cards-active) .mobile-scroll-indicator {
+  display: inherit;
+}
+
 :host-context(.map-inactive) {
   .mobile-scroll-indicator p { opacity: 0; }
 }
+// - End mobile scroll indicator
 
 // Map Zoom Controls
 // ----
@@ -79,7 +88,7 @@ app-mapbox ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
 // center controls vertically on the right side of the map
 app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
   top: 0;
-  bottom: calc(#{$timeSliderHeight} + #{grid(5)});
+  bottom: calc(#{$timeSliderHeight} + #{grid(10)});
   margin:auto;
   height:grid(22);
   right:$pageMargin;
@@ -120,7 +129,6 @@ app-location-cards {
   background: $defaultBackground;
   pointer-events:all;
   position: absolute;
-  // bottom:0;
   bottom: grid(5);
   left:0;
   height: $cardHeaderHeight;
@@ -139,7 +147,6 @@ app-location-cards {
 //    Adjust cards container to account for the larger header height
 //    center cards vertically over the map
 :host-context(.gt-tablet) {
-  .mobile-scroll-indicator { display: none; }
   app-location-cards {
     background: none;
     pointer-events: none;
@@ -303,7 +310,7 @@ app-ui-map-legend {
 // cards and slider activated on mobile:
 //    move legend above cards / time slider
 :host-context(.cards-active.slider-active) app-ui-map-legend {
-  bottom: $timeSliderHeight + $cardHeaderHeight;
+  bottom: $timeSliderHeight + $cardHeaderHeight + grid(5);
 }
 // larger than tablet: 
 //    move legend to bottom right of the map
@@ -338,6 +345,9 @@ app-ui-map-legend {
 .gt-tablet :host-context(.cards-active.slider-active) app-ui-map-legend {
   bottom: $timeSliderLg + $pageMarginLg;
 }
+.gt-tablet :host-context(.cards-active) .mobile-scroll-indicator {
+  display: none;
+}
 // - End Map Legend
 
 
@@ -371,7 +381,7 @@ app-ui-map-legend {
 }
 // increase offset from the bottom if cards are shown
 :host-context(.cards-active) {
-  .year-slider-container { bottom: $cardHeaderHeight; }
+  .year-slider-container { bottom: $cardHeaderHeight + grid(5); }
 }
 .gt-mobile :host-context {
   .year-slider-container {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -264,8 +264,7 @@ $rankingsBg1: $color6;
 // Utility
 // Delay vh height transition on mobile to prevent jump on scroll
 // Idea from: https://abdus.co/blog/preventing-vh-jump-on-mobile-browsers
-// $mobileVhTransition: height 3600s steps(1);
-$mobileVhTransition: height 3s steps(1);
+$mobileVhTransition: height 3600s steps(1);
 
 // TODO: 
 // - type definitions / sizes

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -250,8 +250,8 @@ $tooltipBackground: $black;;
 $tooltipFontColor: #fff;
 
 // Map tool component heights, software button
-$iosSafariPadding: grid(4);
-$androidPadding: grid(2);
+$iosSafariPadding: grid(9);
+$androidPadding: grid(7);
 
 
 // Footer

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -179,6 +179,9 @@ $selectCaret: $color1;
 // Progress Bars
 $progressBarColor: $color1;
 
+// Mobile Scroll Indicator
+$mobileScrollIndicatorHeight: grid(5);
+
 // Cards
 // ----
 // layout

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -261,5 +261,11 @@ $footerHoverIconBorder: $white;
 // Rankings
 $rankingsBg1: $color6;
 
+// Utility
+// Delay vh height transition on mobile to prevent jump on scroll
+// Idea from: https://abdus.co/blog/preventing-vh-jump-on-mobile-browsers
+// $mobileVhTransition: height 3600s steps(1);
+$mobileVhTransition: height 3s steps(1);
+
 // TODO: 
 // - type definitions / sizes


### PR DESCRIPTION
Potentially fixes #542. I was looking into this issue and found this article: https://abdus.co/blog/preventing-vh-jump-on-mobile-browsers

I'd seen a few JS fixes, but since we're using `vh` in a few different places along with `calc` it seemed like that could get complicated. Option 2 in that article seemed interesting because it's pure CSS, and it actually seems to work great. I have the delay set for an hour, since I don't imagine anyone would have the site open on their phone for that long.

Most of the changes came from having to move the scroll indicator into the map tool rather than the data panel, since we were changing the overall element height to get the scroll indicator to show up which would mean we couldn't delay the transition without breaking that.

I have a prototype here which seems to work well for me on iOS Chrome, Firefox, and Safari as well as Chrome on Android through BrowserStack: http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/vh-fix/