### PR TITLE
Override some Bootstrap default styles

### DIFF
--- a/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.html
+++ b/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.html
@@ -2,7 +2,7 @@
 <div class="input-wrapper">
   <input #textInput [value]="copyText">
   <button #btn #pop="bs-tooltip" placement="bottom" [tooltip]="'DATA.COPY_SUCCESS' | translate" triggers="" class="btn">
-    <svg xmlns="http://www.w3.org/2000/svg" width="13" viewBox="0 0 896 1024">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 896 1024">
       <path d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z"/>
     </svg>
   </button>

--- a/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.scss
+++ b/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.scss
@@ -14,12 +14,14 @@ input {
   min-width: grid(30);
   height: grid(5);
   padding: 0 grid(1);
-
 }
 
 .btn {
   position:absolute;
   top:0;right:0;
+  border-radius: 0;
   width: grid(5);
   height: grid(5);
+
+  svg { margin: inherit; }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -67,6 +67,9 @@ body {
 
 // STYLE OVERRIDES
 
+// Bootstrap tooltips should use default font stack
+bs-tooltip-container.tooltip .tooltip-inner { font-family: $fontStack; }
+
 // no mobile "map button" hint on tablet+
 @media(min-width: $gtMobile) {
   .tooltip.map-hint-mobile { display:none!important;}

--- a/src/theme/base/dialogs.scss
+++ b/src/theme/base/dialogs.scss
@@ -62,6 +62,29 @@ body {
     margin-top: grid(3);
   }
 
+  // Eviction Lab popover styles
+  .popover {
+    border: none;
+    border-radius: 0;
+    box-shadow: $z3shadow;
+    background-clip: border-box;
+    padding: grid(2);
+
+    .popover-header {
+      padding: 0;
+      background-color: inherit;
+      border-bottom: none;
+      margin-bottom: grid(2);
+      @include altSmallCapsText(16px);
+      color: $grey1a;
+      line-height: 1;
+    }
+    .popover-content {
+      padding: 0;
+      @include defaultFont(14px);
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
Closes #600, progress on #592 (maybe closes?). Uses Akkurat for the Bootstrap tooltips instead of Helvetica Neue, and overrides the Bootstrap styling on the link sharing dialog

<img width="221" alt="screen shot 2018-02-16 at 8 36 49 am" src="https://user-images.githubusercontent.com/8291663/36312684-f34d7706-12f4-11e8-940b-f3b5c933c300.png">

<img width="327" alt="screen shot 2018-02-16 at 8 36 35 am" src="https://user-images.githubusercontent.com/8291663/36312681-f20c8de6-12f4-11e8-853b-332c4d36d1f5.png">
