### PR TITLE
Update embed styles

### DIFF
--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -4,8 +4,7 @@
     app-map .year-slider-container {
         display: none !important;
     }
-    app-map .map-ui-wrapper app-ui-map-legend {
-        bottom: 24px !important;
-    }
+    app-map .map-ui-wrapper { height: 100vh !important; }
     .mapboxgl-ctrl-bottom-left { bottom: 0 !important; }
+    .mapboxgl-popup-content { line-height: 16px !important; }
 }

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -348,6 +348,28 @@ app-ui-map-legend {
 .gt-tablet :host-context(.cards-active) .mobile-scroll-indicator {
   display: none;
 }
+
+// Embed view overrides
+//    Ignores time slider, cards
+:host-context(.embed) app-ui-map-legend {
+  bottom: 0;
+}
+.embed.gt-mobile :host-context(.cards-active) .mobile-scroll-indicator,
+.embed.gt-mobile :host-context(.slider-active) .mobile-scroll-indicator,
+.embed.gt-mobile :host-context(.cards-active.slider-active) .mobile-scroll-indicator,
+.embed.gt-tablet :host-context(.cards-active) .mobile-scroll-indicator,
+.embed.gt-tablet :host-context(.slider-active) .mobile-scroll-indicator,
+.embed.gt-tablet :host-context(.cards-active.slider-active) .mobile-scroll-indicator {
+  display: none;
+}
+.embed.gt-mobile :host-context(.slider-active) app-ui-map-legend,
+.embed.gt-mobile :host-context(.cards-active.slider-active) app-ui-map-legend {
+  bottom: $pageMarginLg;
+}
+.embed.gt-tablet :host-context(.cards-active.slider-active) app-ui-map-legend {
+  bottom: $pageMarginLg;
+}
+
 // - End Map Legend
 
 
@@ -404,13 +426,13 @@ app-ui-map-legend {
 // Device-specific adjustments
 
 // Additional spacing for iOS Safari
-.ios-safari:not(.gt-tablet) :host-context(.slider-active) {
+.ios-safari:not(.gt-tablet):not(.embed) :host-context(.slider-active) {
   .year-slider-container { height: $timeSliderHeight + $iosSafariPadding; }
 }
-.ios-safari:not(.gt-tablet) :host-context(.legend-active) {
+.ios-safari:not(.gt-tablet):not(.embed) :host-context(.legend-active) {
   app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
 }
-.ios-safari:not(.gt-tablet) :host-context(.cards-active) {
+.ios-safari:not(.gt-tablet):not(.embed) :host-context(.cards-active) {
   .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
   app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
   .year-slider-container {
@@ -421,13 +443,13 @@ app-ui-map-legend {
 }
 
 // Additional spacing for Android
-.android:not(.gt-tablet) :host-context(.slider-active) {
+.android:not(.gt-tablet):not(.embed) :host-context(.slider-active) {
   .year-slider-container { height: $timeSliderHeight + $androidPadding; }
 }
-.android:not(.gt-tablet) :host-context(.legend-active) {
+.android:not(.gt-tablet):not(.embed) :host-context(.legend-active) {
   app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
 }
-.android:not(.gt-tablet) :host-context(.cards-active) {
+.android:not(.gt-tablet):not(.embed) :host-context(.cards-active) {
   .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
   app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
   .year-slider-container {

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -21,6 +21,9 @@
     color: $tooltipFontColor;
     font-family: $fontStack;
   }
+  .mapboxgl-popup-content p {
+    margin: 0;
+  }
   .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
   .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip,
   .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip, {


### PR DESCRIPTION
Progress on #509. Setup embed for a variety of screen sizes, ignoring mobile scroll and year slider styling. Also sets up hover interactions if embed is active, regardless of window size. Cleans up the tooltip as well.

![embed-mobile](https://user-images.githubusercontent.com/8291663/36321530-bea27a72-130f-11e8-9860-5c701d9a0077.gif)


