### PR TITLE
Pull initial map bounds from route if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,14 @@
         "tslib": "1.8.0"
       }
     },
+    "@mapbox/geo-viewport": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geo-viewport/-/geo-viewport-0.2.2.tgz",
+      "integrity": "sha1-kyBsBEI4whpg/KfpBkyM5j6AJ7Q=",
+      "requires": {
+        "@mapbox/sphericalmercator": "1.0.5"
+      }
+    },
     "@mapbox/geojson-area": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "^5.0.3",
     "@angular/platform-server": "^5.0.3",
     "@angular/router": "^5.0.3",
+    "@mapbox/geo-viewport": "^0.2.2",
     "@mapbox/sphericalmercator": "^1.0.5",
     "@mapbox/vector-tile": "^1.3.0",
     "@ngx-translate/core": "^9.0.1",

--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -52,6 +52,7 @@ export class EmbedComponent implements OnInit {
         if (bubble) { this.mapConfig['popupProps'].push(bubble); }
         this.mapConfig['year'] = data['year'];
         this.mapToolService.setCurrentData(mapData);
+        this.mapConfig = { ...this.mapConfig, ...this.mapToolService.mapConfig };
       });
     this.cdRef.detectChanges();
     // Turn off auto-switching so locked into initial layer

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -11,8 +11,10 @@ import * as bbox from '@turf/bbox';
 import 'rxjs/add/observable/forkJoin';
 import * as _isEqual from 'lodash.isequal';
 import * as polylabel from 'polylabel';
+import * as geoViewport from '@mapbox/geo-viewport';
 
 import { environment } from '../../environments/environment';
+import { PlatformService } from '../services/platform.service';
 import { MapDataAttribute } from './data/map-data-attribute';
 import { MapLayerGroup } from './data/map-layer-group';
 import { MapFeature } from './map/map-feature';
@@ -57,7 +59,8 @@ export class MapToolService {
   constructor(
     private http: HttpClient,
     private translate: TranslateService,
-    private analytics: AnalyticsService
+    private analytics: AnalyticsService,
+    private platform: PlatformService
   ) {
     translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
@@ -133,8 +136,13 @@ export class MapToolService {
    * Sets the bounding box for the map to focus to
    * @param mapBounds an array with four coordinates representing west, south, east, north
    */
-  setMapBounds(mapBounds) {
-    this.activeMapView = mapBounds;
+  setMapBounds(mapBounds: Array<any>) {
+    this.activeMapView = mapBounds.map(b => +b);
+    this.mapConfig = {
+      ...this.mapConfig,
+      ...geoViewport.viewport(this.activeMapView,
+        [this.platform.viewportWidth, this.platform.viewportHeight])
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #637. Uses `PlatformService` and `geo-viewport` to set the initial map view from bounds if they're supplied in the route params. Sometimes it'll still adjust the exact location, but usually that's because of differences in the viewport size, and it's still loading significantly fewer tiles