### PR TITLE
Fix page scroll service multiple instance error

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,8 @@ import { environment } from '../environments/environment';
 import { Observable } from 'rxjs/Observable';
 import { TranslateService, TranslatePipe, TranslateDirective } from '@ngx-translate/core';
 import { Routes, Router } from '@angular/router';
+import { PageScrollService } from 'ng2-page-scroll';
+
 import { MapToolComponent } from './map-tool/map-tool.component';
 import { RankingToolComponent } from './ranking/ranking-tool/ranking-tool.component';
 import { EmbedComponent } from './map-tool/embed/embed.component';
@@ -19,6 +21,7 @@ import { PlatformService } from './services/platform.service';
 import { LoadingService } from './services/loading.service';
 import { AnalyticsService } from './services/analytics.service';
 import { RoutingService } from './services/routing.service';
+import { ScrollService } from './services/scroll.service';
 
 @Component({
   selector: 'app-root',
@@ -51,6 +54,8 @@ export class AppComponent implements OnInit {
     private titleService: Title,
     private el: ElementRef,
     private analytics: AnalyticsService,
+    private pageScroll: PageScrollService,
+    private scroll: ScrollService,
     @Inject(DOCUMENT) private document: any
   ) {
       this.toastr.setRootViewContainerRef(vRef);
@@ -64,6 +69,7 @@ export class AppComponent implements OnInit {
       embed: EmbedComponent
     };
     this.routing.setupRoutes(components);
+    this.scroll.setupScroll(this.pageScroll);
     this.translate.setDefaultLang('en');
     this.translate.use('en');
     this.translate.onLangChange.subscribe((e) => this.updateHtmlLanguage());

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,7 +54,8 @@ export class CustomOption extends ToastOptions {
     ServicesModule.forRoot(),
     RouterModule.forRoot([], { useHash: true }),
     TooltipModule.forRoot(),
-    ToastModule.forRoot()
+    ToastModule.forRoot(),
+    Ng2PageScrollModule.forRoot()
   ],
   providers: [
     {provide: ToastOptions, useClass: CustomOption},

--- a/src/app/map-tool/embed/embed.component.spec.ts
+++ b/src/app/map-tool/embed/embed.component.spec.ts
@@ -1,7 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { PageScrollService } from 'ng2-page-scroll';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
+
 
 import { EmbedComponent } from './embed.component';
 import { MapModule } from '../map/map.module';
@@ -21,11 +22,9 @@ describe('EmbedComponent', () => {
         MapModule,
         RouterTestingModule,
         ServicesModule.forRoot(),
-        TranslateModule.forRoot(),
+        TranslateModule.forRoot()
       ],
       providers: [
-        PageScrollService,
-        ScrollService,
         MapToolService
       ]
     })

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { PageScrollService } from 'ng2-page-scroll';
 import { MapToolComponent } from './map-tool.component';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
@@ -57,9 +56,7 @@ describe('MapToolComponent', () => {
       set: {
         providers: [
           {provide: MapToolService, useClass: MapToolServiceStub },
-          TranslateService,
-          PageScrollService,
-          ScrollService
+          TranslateService
         ]
       }
     })

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -278,7 +278,6 @@ export class MapToolComponent implements OnInit, AfterViewInit {
    * to enable / disable map zoom
    */
   private setupPageScroll() {
-    this.scroll.setupScroll();
 
     // Setup scroll events to handle enable / disable map zoom
     Observable.fromEvent(this.document, 'wheel')

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, fakeAsync, tick, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { PageScrollService } from 'ng2-page-scroll';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 import { MapComponent } from './map.component';
 import { MapboxComponent } from '../mapbox/mapbox.component';
@@ -12,6 +12,7 @@ import { PlatformService } from '../../../services/platform.service';
 import { ScrollService } from '../../../services/scroll.service';
 import { UiMapLegendComponent } from '../map-legend/ui-map-legend.component';
 import { LocationCardsModule } from '../../location-cards/location-cards.module';
+import { ServicesModule } from '../../../services/services.module';
 
 class MapServiceStub {
   updateCensusSource() {}
@@ -37,16 +38,18 @@ describe('MapComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ MapComponent, MapboxComponent, UiMapLegendComponent ],
-      imports: [ UiModule, TranslateModule.forRoot(), TooltipModule.forRoot(), LocationCardsModule ]
+      imports: [
+        UiModule,
+        TranslateModule.forRoot(),
+        TooltipModule.forRoot(),
+        LocationCardsModule,
+        ServicesModule.forRoot()
+      ]
     });
     TestBed.overrideComponent(MapComponent, {
       set: {
         providers: [
-          PlatformService,
           { provide: MapService, useValue: new MapServiceStub() },
-          LoadingService,
-          PageScrollService,
-          ScrollService
         ],
       }
     })

--- a/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.spec.ts
@@ -1,11 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { PageScrollService } from 'ng2-page-scroll';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { MapboxComponent } from './mapbox.component';
 import { MapService } from '../map.service';
 import { PlatformService } from '../../../services/platform.service';
 import { ScrollService } from '../../../services/scroll.service';
+import { ServicesModule } from '../../../services/services.module';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 describe('MapboxComponent', () => {
   let component: MapboxComponent;
@@ -21,13 +22,14 @@ describe('MapboxComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ TranslateModule.forRoot() ],
+      imports: [
+        TranslateModule.forRoot(),
+        ServicesModule.forRoot()
+      ],
       declarations: [
         MapboxComponent
       ],
-      providers: [
-        MapService, PlatformService, PageScrollService, ScrollService
-      ]
+      providers: [ MapService ]
     }).compileComponents();
   }));
 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { PageScrollService } from 'ng2-page-scroll';
 
 import { UiModule } from '../../ui/ui.module';
 import { ServicesModule } from '../../services/services.module';
@@ -11,6 +10,7 @@ import { RankingToolComponent } from './ranking-tool.component';
 import { RankingUiComponent } from '../ranking-ui/ranking-ui.component';
 import { RankingListComponent } from '../ranking-list/ranking-list.component';
 import { RankingPanelComponent } from '../ranking-panel/ranking-panel.component';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 describe('RankingToolComponent', () => {
   let component: RankingToolComponent;
@@ -36,9 +36,7 @@ describe('RankingToolComponent', () => {
               loadCsvData: () => { },
               isReady: { subscribe: () => { } }
             }
-          },
-          PageScrollService,
-          ScrollService
+          }
         ]
       }
     })

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -261,7 +261,6 @@ export class RankingToolComponent implements OnInit {
 
   private setupPageScroll() {
     this.scroll.defaultScrollOffset = 175;
-    this.scroll.setupScroll();
 
     const listYOffset = this.document.querySelector('app-ranking-list').getBoundingClientRect().top;
     this.scroll.verticalOffset$.debounceTime(100)

--- a/src/app/services/scroll.service.spec.ts
+++ b/src/app/services/scroll.service.spec.ts
@@ -1,13 +1,14 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { PageScrollService } from 'ng2-page-scroll';
 
 import { ScrollService } from './scroll.service';
 import { PlatformService } from './platform.service';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 describe('ScrollService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ScrollService, PlatformService, PageScrollService]
+      imports: [ Ng2PageScrollModule ],
+      providers: [ ScrollService, PlatformService ]
     });
   });
 

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -15,6 +15,7 @@ export class ScrollService {
   defaultEasingLogic = {
     ease: (t, b, c, d) => -c * (t /= d) * (t - 2) + b
   };
+  pageScroll: PageScrollService;
   /**
    * Setting position fixed on body will prevent scroll, and setting overflow
    * to scroll ensures the scrollbar is always visible.
@@ -29,8 +30,7 @@ export class ScrollService {
 
   constructor(
     @Inject(DOCUMENT) private document: any,
-    private platform: PlatformService,
-    private pageScroll: PageScrollService
+    private platform: PlatformService
   ) {
     // provide observable with top / bottom vertical offset
     this.verticalOffset$ = Observable
@@ -41,7 +41,8 @@ export class ScrollService {
   /**
    * Sets up PageScrollConfig with defaults
    */
-  setupScroll() {
+  setupScroll(serviceInstance: PageScrollService) {
+    this.pageScroll = serviceInstance;
     PageScrollConfig.defaultScrollOffset = this.defaultScrollOffset;
     PageScrollConfig.defaultDuration = this.defaultDuration;
     PageScrollConfig.defaultEasingLogic = this.defaultEasingLogic;

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -8,6 +8,7 @@ import { LoadingService } from './loading.service';
 import { ScrollService } from './scroll.service';
 import { AnalyticsService } from './analytics.service';
 import { RoutingService } from './routing.service';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
This clears the error on tests and makes sure we aren't instantiating multiple instances of PageScrollService by injecting the service into the root `app.component`, then passing the service to `scroll.service` in the `setupScroll()` call.

Closes #642 