### PR TITLE
Refactor search service, location search

### DIFF
--- a/src/app/services/search-sources.ts
+++ b/src/app/services/search-sources.ts
@@ -1,5 +1,5 @@
-import { environment } from '../../../../environments/environment';
-import { MapFeature } from '../../../map-tool/map/map-feature';
+import { environment } from '../../environments/environment';
+import { MapFeature } from '../map-tool/map/map-feature';
 
 export interface SearchSource {
     key: string;

--- a/src/app/services/search.service.spec.ts
+++ b/src/app/services/search.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientModule, HttpRequest, HttpParams } from '@angular/common/http'
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { SearchService } from './search.service';
-import { ServicesModule } from '../../../services/services.module';
+import { ServicesModule } from './services.module';
 
 describe('SearchService', () => {
   beforeEach(() => {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -5,14 +5,12 @@ import { csvParse } from 'd3-dsv';
 import 'rxjs/add/operator/do';
 
 import { SearchSource, MapboxSource } from './search-sources';
-import { MapFeature } from '../../../map-tool/map/map-feature';
-import { AnalyticsService } from '../../../services/analytics.service';
+import { MapFeature } from '../map-tool/map/map-feature';
+import { AnalyticsService } from './analytics.service';
 
 @Injectable()
 export class SearchService {
   source: SearchSource = MapboxSource;
-  query: string;
-  results: Observable<Object[]>;
 
   constructor(private http: HttpClient, private analytics: AnalyticsService) {
     if (this.source.hasOwnProperty('csvUrl')) {
@@ -20,12 +18,6 @@ export class SearchService {
         .map(csvStr => this.parseCsv(csvStr))
         .subscribe(features => { this.source.featureList = features; });
     }
-    this.results = Observable.create((observer: any) => {
-      this.queryGeocoder(this.query)
-        .subscribe((results: Object[]) => {
-          observer.next(results);
-        });
-    });
   }
 
   /**

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -9,6 +9,7 @@ import { ScrollService } from './scroll.service';
 import { AnalyticsService } from './analytics.service';
 import { RoutingService } from './routing.service';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
+import { SearchService } from './search.service';
 
 @NgModule({
   imports: [
@@ -24,7 +25,8 @@ export class ServicesModule {
         PlatformService,
         LoadingService,
         AnalyticsService,
-        RoutingService
+        RoutingService,
+        SearchService
       ]
     };
   }

--- a/src/app/ui/location-search/location-search.component.html
+++ b/src/app/ui/location-search/location-search.component.html
@@ -1,6 +1,6 @@
 <app-predictive-search
-  [(selected)]="search.query"
-  [options]="search.results"
+  [(selected)]="query"
+  [options]="results"
   [placeholder]="placeholder"
   optionField="properties.label"
   (selectionChange)="onSearchSelect($event)">

--- a/src/app/ui/location-search/location-search.component.spec.ts
+++ b/src/app/ui/location-search/location-search.component.spec.ts
@@ -4,7 +4,7 @@ import { LocationSearchComponent } from './location-search.component';
 import { PredictiveSearchComponent } from '../predictive-search/predictive-search.component';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 
-import { SearchService } from './search/search.service';
+import { SearchService } from '../../services/search.service';
 
 describe('LocationSearchComponent', () => {
   let component: LocationSearchComponent;

--- a/src/app/ui/location-search/location-search.component.ts
+++ b/src/app/ui/location-search/location-search.component.ts
@@ -1,19 +1,28 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { SearchService } from './search/search.service';
+import { Observable } from 'rxjs/Observable';
+import { SearchService } from '../../services/search.service';
 import { PredictiveSearchComponent } from '../predictive-search/predictive-search.component';
 
 @Component({
   selector: 'app-location-search',
   templateUrl: './location-search.component.html',
-  styleUrls: ['./location-search.component.scss'],
-  providers: [ SearchService ]
+  styleUrls: ['./location-search.component.scss']
 })
 export class LocationSearchComponent {
+  query: string;
+  results: Observable<Object[]>;
   @Input() placeholder;
   /** Emits a location whenever one is selected in the search */
   @Output() locationSelected = new EventEmitter();
 
-  constructor(public search: SearchService) { }
+  constructor(public search: SearchService) {
+    this.results = Observable.create((observer: any) => {
+      this.search.queryGeocoder(this.query)
+        .subscribe((results: Object[]) => {
+          observer.next(results);
+        });
+    });
+  }
 
   /**
    * Adds the corresponding layerId to the feature


### PR DESCRIPTION
Closes #632. Moves `SearchService` into the general services module so that it's only loaded once, and also moves its `query` and `results` properties to the location search component, since they're really being used on a component basis anyway