### PR TITLE
Fix Facebook social share

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -48,7 +48,7 @@
               class="btn btn-border icon btn-facebook"
               (click)="trackShare('facebook')" 
               appSocialSharePopup 
-              [href]="'https://www.facebook.com/sharer.php?u=' + getCurrentUrl()"  
+              [href]="'https://www.facebook.com/sharer/sharer.php?u=' + getEncodedUrl()"  
               [attr.aria-label]="'FOOTER.SHARE_FACEBOOK' | translate"
             >
               <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -163,6 +163,13 @@ export class DataPanelComponent implements OnInit {
   }
 
   /**
+   * Encoding URL for Facebook share
+   */
+  getEncodedUrl() {
+    return this.platform.nativeWindow.encodeURIComponent(this.getCurrentUrl());
+  }
+
+  /**
    * Adding method because calling window directly in the template doesn't work
    */
   getCurrentUrl() {

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Eviction Lab: Map and Data" />
   <meta property="og:description" content="We’ve built the first nationwide database of evictions. Use our tools to find and compare eviction rates in your neighborhood, city, or state." />
-  <meta property="og:url" content="https://preview.evictionlab.org/" />
+  <meta property="og:url" content="https://d24ep4gf2mq4il.cloudfront.net/" />
   <meta property="og:site_name" content="Eviction Lab" />
   <meta property="og:image" content="https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg" />
   <meta property="og:image:secure_url" content="https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg" />


### PR DESCRIPTION
Facebook social share is currently broken, but this should fix it for now. One thing to note (that probably doesn't need to be fixed in development) is that the `og:url` property redirects, so currently it's just pulling all metadata from the preview site. I changed it to the staging site URL on CloudFront