### PR TITLE
Finish up iframe embed feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8834,6 +8834,11 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
+    "pym.js": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pym.js/-/pym.js-1.3.2.tgz",
+      "integrity": "sha512-/fFzHFB4BTsJQP5id0wzUdYsDT4VPkfAxk+uENBE9/aP6YbvhAEpcuJHdjxqisqfXOCrcz7duTK1fbtF2rz8RQ=="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ngx-bootstrap": "^2.0.0-beta.9",
     "pbf": "^3.1.0",
     "polylabel": "^1.0.2",
+    "pym.js": "^1.3.2",
     "rxjs": "^5.5.2",
     "web-animations-js": "^2.3.1",
     "zone.js": "^0.8.14"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -14,38 +14,3 @@ app-footer {
 #embed-branding {
   display: none;
 }
-
-// Hide most of UI when embedded
-:host-context(.embed) {
-  #embed-branding {
-    display: block;
-    position: fixed;
-    top: 24px;
-    left: 24px;
-    z-index: 11;
-
-    a {
-      padding: 16px;
-
-      img { height: 16px; }
-    }
-    a:hover { background-color: rgba(255,255,255,0.4); }
-  }
-  ::ng-deep {
-    app-header-bar, app-footer {
-      display: none !important;
-    }
-    app-map-tool {
-      app-map .map-ui-wrapper .map-ui,
-      app-map .map-ui-wrapper app-location-cards,
-      app-map .year-slider-container,
-      app-data-panel
-      {
-        display: none !important;
-      }
-      app-map .map-ui-wrapper app-ui-map-legend {
-        bottom: 24px !important;
-      }
-    }
-  }
-}

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -24,7 +24,11 @@ app-footer {
     left: 24px;
     z-index: 11;
 
-    a { padding: 16px; }
+    a {
+      padding: 16px;
+
+      img { height: 16px; }
+    }
     a:hover { background-color: rgba(255,255,255,0.4); }
   }
   ::ng-deep {

--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -4,7 +4,6 @@
     app-map .year-slider-container {
         display: none !important;
     }
-    app-map .map-ui-wrapper { height: 100vh !important; }
     .mapboxgl-ctrl-bottom-left { bottom: 0 !important; }
     .mapboxgl-popup-content { line-height: 16px !important; }
 }

--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -1,4 +1,23 @@
+
+
 ::ng-deep {
+    html.embedded {
+        body {
+            min-height: 500px;
+            position: relative;
+
+            app-root, app-embed, app-map {
+                display: block;
+                height: 100%;
+
+                .map-ui-wrapper, .map-wrapper {
+                    position: absolute;
+                    height: 100%;
+                }
+            }
+        }
+    }
+
     app-map .map-ui-wrapper .map-ui,
     app-map .map-ui-wrapper app-location-cards,
     app-map .year-slider-container {

--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -1,6 +1,37 @@
-
-
 ::ng-deep {
+    .embed {
+        app-header-bar, app-footer {
+            display: none !important;
+        }
+        app-map-tool {
+            app-map .map-ui-wrapper .map-ui,
+            app-map .map-ui-wrapper app-location-cards,
+            app-map .year-slider-container,
+            app-data-panel
+            {
+                display: none !important;
+            }
+            app-map .map-ui-wrapper app-ui-map-legend {
+                bottom: 24px !important;
+            }
+        }
+        #embed-branding {
+            display: block;
+            position: fixed;
+            top: 24px;
+            left: 24px;
+            z-index: 11;
+
+            a {
+                padding: 16px;
+
+                img { height: 16px; }
+
+                &:hover { background-color: rgba(255,255,255,0.4); }
+            }
+        }
+    }
+
     html.embedded {
         body {
             min-height: 500px;

--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -1,7 +1,6 @@
 import {
-  Component, OnInit, AfterViewInit, ChangeDetectorRef, ViewChild, ElementRef, Inject
+  Component, OnInit, AfterViewInit, ChangeDetectorRef, ViewChild, ElementRef
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { MapComponent } from '../map/map/map.component';
 import * as pym from 'pym.js';
 
@@ -37,8 +36,7 @@ export class EmbedComponent implements OnInit, AfterViewInit {
     private translate: TranslateService,
     private route: ActivatedRoute,
     private cdRef: ChangeDetectorRef,
-    private el: ElementRef,
-    @Inject(DOCUMENT) private document: any
+    private el: ElementRef
   ) {
     this.routing.setActivatedRoute(route);
     this.mapToolService.embed = true;
@@ -59,6 +57,7 @@ export class EmbedComponent implements OnInit, AfterViewInit {
         this.mapConfig['year'] = data['year'];
         this.mapToolService.setCurrentData(mapData);
         this.mapConfig = { ...this.mapConfig, ...this.mapToolService.mapConfig };
+        this.routing.updatePymSearch();
       });
     this.cdRef.detectChanges();
     // Turn off auto-switching so locked into initial layer
@@ -67,6 +66,7 @@ export class EmbedComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit() {
     const pymChild = new pym.Child();
+    pymChild.sendHeight();
   }
 
 }

--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -1,5 +1,9 @@
-import { Component, OnInit, ChangeDetectorRef, ViewChild } from '@angular/core';
+import {
+  Component, OnInit, AfterViewInit, ChangeDetectorRef, ViewChild, ElementRef, Inject
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { MapComponent } from '../map/map/map.component';
+import * as pym from 'pym.js';
 
 import { MapToolService } from '../map-tool.service';
 import { MapService } from '../map/map.service';
@@ -12,7 +16,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './embed.component.html',
   styleUrls: ['./embed.component.scss']
 })
-export class EmbedComponent implements OnInit {
+export class EmbedComponent implements OnInit, AfterViewInit {
   id = 'embed-map';
   @ViewChild(MapComponent) map;
 
@@ -32,7 +36,9 @@ export class EmbedComponent implements OnInit {
     private routing: RoutingService,
     private translate: TranslateService,
     private route: ActivatedRoute,
-    private cdRef: ChangeDetectorRef
+    private cdRef: ChangeDetectorRef,
+    private el: ElementRef,
+    @Inject(DOCUMENT) private document: any
   ) {
     this.routing.setActivatedRoute(route);
     this.mapToolService.embed = true;
@@ -57,6 +63,10 @@ export class EmbedComponent implements OnInit {
     this.cdRef.detectChanges();
     // Turn off auto-switching so locked into initial layer
     this.map.autoSwitch = false;
+  }
+
+  ngAfterViewInit() {
+    const pymChild = new pym.Child();
   }
 
 }

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -14,6 +14,7 @@ import { MapFeature } from './map-feature';
 
 @Injectable()
 export class MapService {
+  embedded = false;
   private map: mapboxgl.Map;
   private _isLoading = new BehaviorSubject<boolean>(true);
   isLoading$ = this._isLoading.asObservable();
@@ -197,6 +198,7 @@ export class MapService {
    * @param features Array of active features to highlight
    */
   updateHighlightFeatures(layerId: string, features: MapFeature[]) {
+    if (this.embedded) { return; }
     const highlightSource = this.getSourceData('highlight');
     const geoids = highlightSource.map(f => f['properties']['GEOID']);
 

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -351,15 +351,14 @@ app-ui-map-legend {
 
 // Embed view overrides
 //    Ignores time slider, cards
-:host-context(.embed) app-ui-map-legend {
+.embed :host-context(.slider-active) app-ui-map-legend,
+.embed :host-context(.cards-active.slider-active) app-ui-map-legend {
   bottom: 0;
 }
-.embed.gt-mobile :host-context(.cards-active) .mobile-scroll-indicator,
-.embed.gt-mobile :host-context(.slider-active) .mobile-scroll-indicator,
-.embed.gt-mobile :host-context(.cards-active.slider-active) .mobile-scroll-indicator,
-.embed.gt-tablet :host-context(.cards-active) .mobile-scroll-indicator,
-.embed.gt-tablet :host-context(.slider-active) .mobile-scroll-indicator,
-.embed.gt-tablet :host-context(.cards-active.slider-active) .mobile-scroll-indicator {
+
+.embed :host-context(.cards-active) .mobile-scroll-indicator,
+.embed :host-context(.slider-active) .mobile-scroll-indicator,
+.embed :host-context(.cards-active.slider-active) .mobile-scroll-indicator {
   display: none;
 }
 .embed.gt-mobile :host-context(.slider-active) app-ui-map-legend,

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -21,8 +21,7 @@ import { PlatformService } from '../../../services/platform.service';
 @Component({
   selector: 'app-map',
   templateUrl: './map.component.html',
-  styleUrls: ['./map.component.scss'],
-  providers: [ MapService ]
+  styleUrls: ['./map.component.scss']
 })
 export class MapComponent implements OnInit, OnChanges {
   censusYear = 2010;

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -54,6 +54,7 @@ export class MapboxComponent implements AfterViewInit {
    */
   ngAfterViewInit() {
     this.embedded = this.platform.nativeWindow.document.querySelector('app-embed');
+    this.mapService.embedded = this.embedded;
     this.map = this.mapService.createMap({
       ...this.mapConfig, container: this.mapEl.nativeElement, attributionControl: false
     });

--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -30,6 +30,7 @@ export class RoutingService {
     geography: 'auto',
     bounds: '-136.80,20.68,-57.60,52.06'
   });
+  private pymSearchStr: string;
   private mapRouteKeys = ['year', 'geography', 'bounds']; // keys mandatory for map route
 
   private defaultViews = {
@@ -41,7 +42,9 @@ export class RoutingService {
   constructor(
     private router: Router,
     private platform: PlatformService
-  ) {}
+  ) {
+    this.pymSearchStr = this.platform.nativeWindow.location.search;
+  }
 
   /** Gets route data for the map component */
   getMapRouteData() {
@@ -102,6 +105,19 @@ export class RoutingService {
     ];
     // reset router with dynamic routes
     this.router.resetConfig(appRoutes);
+  }
+
+  /**
+   * Pym.js uses window.location.search which is overriden by the current hash routing.
+   * We need to place it back without triggering a page refresh in order for elements to
+   * resize correctly
+   */
+  updatePymSearch() {
+    const location = this.platform.nativeWindow.location;
+    const newUrl = location.origin + this.pymSearchStr + location.hash;
+    this.platform.nativeWindow.history.replaceState(
+      {}, this.platform.nativeWindow.document.title, newUrl
+    );
   }
 
 }

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -22,7 +22,10 @@ export class ScrollService {
    * IE 11 requires an empty string rather than null to unset styles.
    */
   set allowScroll(val: boolean) {
-    const changeScroll = !val && this.document.documentElement.scrollTop === 0;
+    const changeScroll = (
+      !val && this.document.documentElement.scrollTop === 0 &&
+      !this.document.documentElement.classList.contains('embedded')
+    );
     this.document.body.style.position = changeScroll ? 'fixed' : '';
     this.document.body.style.overflowY = changeScroll ? 'scroll' : '';
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,23 @@ html, body {
   font-family: $fontStack!important;
 }
 
+html.embedded, html.not-embedded {
+  body {
+    height: 500px;
+    position: relative;
+
+    app-root, app-embed, app-map {
+      display: block;
+      height: 100%;
+
+      .map-ui-wrapper, .map-wrapper {
+        position: absolute;
+        height: 100%;
+      }
+    }
+  }
+}
+
 body {
   height:auto;
   overflow-x:hidden;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,23 +30,6 @@ html, body {
   font-family: $fontStack!important;
 }
 
-html.embedded, html.not-embedded {
-  body {
-    min-height: 500px;
-    position: relative;
-
-    app-root, app-embed, app-map {
-      display: block;
-      height: 100%;
-
-      .map-ui-wrapper, .map-wrapper {
-        position: absolute;
-        height: 100%;
-      }
-    }
-  }
-}
-
 body {
   height:auto;
   overflow-x:hidden;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,7 +32,7 @@ html, body {
 
 html.embedded, html.not-embedded {
   body {
-    height: 500px;
+    min-height: 500px;
     position: relative;
 
     app-root, app-embed, app-map {


### PR DESCRIPTION
Closes #509, since the rest of the functionality is in #568 and #651. Getting pym.js set up was a bit of a pain initially since it sets up query parameters that are swallowed by our hash routing, but after swapping those back in it looks like this will be a lot easier than trying to create an iframe with the right set of parameters