### PR TITLE
Snap to slider position on release

### DIFF
--- a/src/app/ui/ui-slider/ui-slider.component.ts
+++ b/src/app/ui/ui-slider/ui-slider.component.ts
@@ -94,6 +94,7 @@ export class UiSliderComponent implements AfterViewInit {
   @HostListener('document:mouseup', ['$event']) onRelease(e) {
     if (this.pressed) {
       this.pressed = false;
+      this.updatePosition(this.value);
     }
   }
 
@@ -116,6 +117,7 @@ export class UiSliderComponent implements AfterViewInit {
   @HostListener('touchend', ['$event']) onTouchEnd(e) {
     if (this.pressed) {
       this.pressed = false;
+      this.updatePosition(this.value);
     }
   }
 


### PR DESCRIPTION
Closes #650. I may have missed something in the original PR #521, but it looks like we can still call `updatePosition` without introducing the same errors we fixed there because now position only updates the `position` property and not `value`.