### PR TITLE
Mobile style fixes

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -5,17 +5,16 @@
 .data-header {
   @include dataPanelHeader(14px);
   text-align: center;  
-  margin: grid(3) grid(4) 0;
+  padding: grid(3) grid(4) 0;
   p { margin:0; }
-  // margin: grid(5) grid(4);
 }
 // increase header spacing for devices larger than mobile
 :host-context(.gt-mobile) {
-  .data-header { margin: grid(4) 0 grid(2); }
+  .data-header { padding: grid(4) 0 grid(2); }
 }
 // increase spacing for devices larger than tablet
 :host-context(.gt-tablet) {
-  .data-header { margin: grid(8) 0 grid(4); }
+  .data-header { padding: grid(8) 0 grid(4); }
 }
 
 .data-content {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -249,7 +249,9 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    * Triggers a scroll to the top of the page
    */
   goToTop() {
-    this.scroll.scrollTo('#top');
+    if (this.getVerticalOffset() > 0) {
+      this.scroll.scrollTo('#top');
+    }
   }
 
   /**

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -124,7 +124,7 @@
 
   // circle marker for scrubber
   .scrubber-marker {
-    width: grid(7);
+    width: grid(5.5);
     height: grid(4);
     line-height: grid(4);
     @include numberFont(13px);

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -50,12 +50,12 @@
 
 .slider-label:first-child {
   margin-left: 0;
-  margin-right: grid(3);
+  margin-right: grid(4);
 }
 
 .slider-label:last-child {
   margin-right: 0;
-  margin-left: grid(3);
+  margin-left: grid(4);
 }
 
 .el-slider {
@@ -81,13 +81,13 @@
   }  
   .scrubber {
     position: absolute;
-    width: grid(7);
+    width: grid(6);
     height: grid(4);
     top: 0;
     left: 0;
     bottom: 0;
     margin: auto;
-    margin-left: -1 * grid(7) / 2;
+    margin-left: -1 * grid(6) / 2;
     cursor: move;
     transition: transform 0.4s ease;
   }  
@@ -104,7 +104,7 @@
     margin: auto;
     letter-spacing: 0.4px;
     line-height: grid(4);
-    width: grid(7);
+    width: grid(6);
     height: grid(4);
     border-radius: 0;  
     &:after {
@@ -124,7 +124,7 @@
 
   // circle marker for scrubber
   .scrubber-marker {
-    width: grid(5.5);
+    width: grid(6);
     height: grid(4);
     line-height: grid(4);
     @include numberFont(13px);
@@ -155,10 +155,15 @@
     margin-left: grid(5);
   }
   .el-slider {
+    .scrubber {
+      width: grid(8);
+      margin-left: -1 * grid(8) / 2;
+    }
     .scrubber-label {
       top: -1 * grid(6.5);
       @include numberFont(15px);
       width:grid(8);
+      
       height: grid(5);
       line-height: grid(5);
       &:after {


### PR DESCRIPTION
Some small mobile fix items:

* Fixes a transparent gap between the map and data panel

<img width="863" alt="screen shot 2018-02-21 at 4 26 32 pm" src="https://user-images.githubusercontent.com/8291663/36511330-dc234336-172b-11e8-9675-439daaaa583d.png">
Fixed: 
<img width="325" alt="screen shot 2018-02-21 at 5 25 10 pm" src="https://user-images.githubusercontent.com/8291663/36511423-32803108-172c-11e8-83fd-81aae0a091cd.png">

* Makes the year slider marker a little more narrow so that it doesn't overlap the year label

<img width="324" alt="screen shot 2018-02-21 at 5 25 53 pm" src="https://user-images.githubusercontent.com/8291663/36511453-4d0a245c-172c-11e8-8ec5-d0e097182b53.png">
<img width="318" alt="screen shot 2018-02-21 at 5 25 03 pm" src="https://user-images.githubusercontent.com/8291663/36511458-4e79967e-172c-11e8-82cd-570b0dc22c20.png">

* Fixes #556, unless you had a different method in mind
