### PR TITLE
Add embed code sharing

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -81,6 +81,7 @@
             </a>
             <ng-template #popTemplate>
               <app-ui-copy-clipboard [copyText]="getCurrentUrl()" [hintText]="'DATA.SHARE_HINT' | translate"></app-ui-copy-clipboard>
+              <app-ui-copy-clipboard [copyText]="getEmbedCode()" [hintText]="'DATA.EMBED_SHARE_HINT' | translate"></app-ui-copy-clipboard>
             </ng-template>
             <button class="btn btn-border icon btn-link" (click)="trackShare('link')" container="body" [outsideClick]="true" [popover]="popTemplate" [popoverTitle]="'DATA.SHARE_LINK' | translate" [attr.aria-label]="'FOOTER.SHARE_LINK' | translate">
               <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -152,3 +152,10 @@ app-location-cards {
     text-decoration: none;
   }
 }
+
+// Margin in link/embed share popover
+::ng-deep {
+  .popover .popover-content app-ui-copy-clipboard:not(:last-child) {
+    margin-bottom: grid(2);
+  }
+}

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -177,6 +177,16 @@ export class DataPanelComponent implements OnInit {
   }
 
   /**
+   * Get pym.js HTML for embedding map
+   */
+  getEmbedCode() {
+    const splitUrl = this.platform.nativeWindow.location.href.split('#');
+    const embedUrl = [splitUrl[0], '#/embed', ...splitUrl.slice(1)].join('');
+    return `<div data-pym-src="${embedUrl}">Loading...</div>` +
+      '<script type="text/javascript" src="https://pym.nprapps.org/pym-loader.v1.min.js"></script>';
+  }
+
+  /**
    * Display dialog with error message if mailto link doesn't open after 1 second
    * @param e
    */

--- a/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.html
+++ b/src/app/ui/ui-copy-clipboard/ui-copy-clipboard.component.html
@@ -1,4 +1,4 @@
-<p *ngIf="hintText">{{ hintText }}</p>
+<p *ngIf="hintText" [innerHTML]="hintText"></p>
 <div class="input-wrapper">
   <input #textInput [value]="copyText">
   <button #btn #pop="bs-tooltip" placement="bottom" [tooltip]="'DATA.COPY_SUCCESS' | translate" triggers="" class="btn">

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -24,6 +24,7 @@
     "MAP_LINK": "Back To Map",
     "SHARE_LINK": "Share a Link",
     "SHARE_HINT": "Copy the link below:",
+    "EMBED_SHARE_HINT": "Copy this embed code into your website. <a href='#' target='_blank'>More information here.</a>",
     "COPY_SUCCESS": "Copied!",
     "DOWNLOAD_TITLE": "Download",
     "EXPORT_ONE_FEATURE_DESCRIPTION": "Generate a file export for <b>{{feature1}}</b> between {{startYear}} and {{endYear}}",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -24,6 +24,7 @@
     "MAP_LINK": "Mapa",
     "SHARE_LINK": "Compartir enlace",
     "SHARE_HINT": "Copiar el enlace abajo:",
+    "EMBED_SHARE_HINT": "Copy the embed code into your website. <a href='#' target='_blank'>More information here.</a>",
     "COPY_SUCCESS": "Copied!",
     "DOWNLOAD_TITLE": "Descargar",
     "EXPORT_ONE_FEATURE_DESCRIPTION": "Generate a file export for {{feature1}} between {{startYear}} and {{endYear}}",


### PR DESCRIPTION
Closes #675. Adds the embed code to the link share popover, and includes a placeholder link in case we decide to link to more context/instructions for that.

<img width="358" alt="screen shot 2018-02-22 at 10 36 08 am" src="https://user-images.githubusercontent.com/8291663/36551045-4e2b2210-17bc-11e8-95ff-8bbceb9c6a00.png">
