### PR TITLE
Update public data link

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -120,7 +120,7 @@
           </svg>
           <h2>{{ 'DATA.GET_DATA_HEADING' | translate }}</h2>
           <span>{{ 'DATA.GET_DATA_HINT' | translate }}</span>
-          <a class="btn btn-border" href="http://eviction-lab-public-data.s3-website-us-east-1.amazonaws.com/">
+          <a class="btn btn-border" href="https://data.evictionlab.org/" target="_blank">
             {{ 'DATA.GET_DATA' | translate }}
           </a>
         </div>


### PR DESCRIPTION
Updates the public data link and sets it to open in a new tab. I don't feel strongly about opening in a new tab, it's just generally what I've done for external links so let me know if you want to take that out