### PR TITLE
Add loading indicator to rankings

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,4 @@
-app-progress-bar {  top: 0; z-index: 1000;}
+app-progress-bar { position: fixed; top: 0; z-index: 1000;}
 app-header-bar { position: fixed; top:0; left:0; right:0; width:100%; z-index:999;}
 
 app-footer {

--- a/src/app/ranking/ranking-list/ranking-list.component.html
+++ b/src/app/ranking/ranking-list/ranking-list.component.html
@@ -1,3 +1,6 @@
+<h4 *ngIf="!list">
+  Loading...
+</h4>
 <ul *ngIf="dataProperty && list && maxValue" class="ranking-list">
   <li 
     *ngFor="let location of list; let i = index" 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -8,6 +8,7 @@ import 'rxjs/add/operator/takeUntil';
 import { RankingLocation } from '../ranking-location';
 import { RankingService } from '../ranking.service';
 import { ScrollService } from '../../services/scroll.service';
+import { LoadingService } from '../../services/loading.service';
 import { RankingUiComponent } from '../ranking-ui/ranking-ui.component';
 
 @Component({
@@ -80,6 +81,7 @@ export class RankingToolComponent implements OnInit, OnDestroy {
 
   constructor(
     public rankings: RankingService,
+    public loader: LoadingService,
     private route: ActivatedRoute,
     private router: Router,
     private scroll: ScrollService,
@@ -89,9 +91,13 @@ export class RankingToolComponent implements OnInit, OnDestroy {
 
   /** Listen for when the data is ready and for route changes */
   ngOnInit() {
+    this.loader.start('rankings');
     this.rankings.isReady.subscribe((ready) => {
       this.isDataReady = ready;
-      if (ready) { this.updateEvictionList(); }
+      if (ready) {
+        this.updateEvictionList();
+        this.loader.end('rankings');
+      }
     });
     this.translate.onLangChange.takeUntil(this.ngUnsubscribe)
       .subscribe(lang => {


### PR DESCRIPTION
Closes #680. Adds the loading bar on the rankings page, as well as "Loading..." in the rankings list when it's empty. I also updated the `app-progress-bar` to use `position: fixed`, otherwise it was hidden on scroll for me. Wasn't sure what styles to use for the loading text, so open to other ideas there

![rankings-loading](https://user-images.githubusercontent.com/8291663/36555807-b08b3038-17c8-11e8-958d-11eed5d711fd.gif)
