### PR TITLE
Load initial translations before change

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,6 +86,7 @@ export class AppComponent implements OnInit {
     this.scroll.setupScroll(this.pageScroll);
     this.translate.setDefaultLang('en');
     this.translate.use('en');
+    this.updateLanguage(this.translate.translations);
     this.translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
     });

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -62,6 +62,7 @@ export class MapToolService {
     private analytics: AnalyticsService,
     private platform: PlatformService
   ) {
+    this.updateLanguage(translate.translations);
     translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
     });

--- a/src/app/ranking/ranking.service.ts
+++ b/src/app/ranking/ranking.service.ts
@@ -32,6 +32,7 @@ export class RankingService {
     private translate: TranslateService,
     @Inject('config') private config: any
   ) {
+    this.updateLanguage(this.translate.translations);
     this.translate.onLangChange.subscribe(lang => {
       console.log('lang change', lang);
       this.updateLanguage(lang.translations);


### PR DESCRIPTION
Fixes #618. It looks like this issue was coming from `onLangChange` not getting fired on initial load for `evictions` if the `lang` query param isn't set. It usually gets fired in the map tool and app, but I'm calling their manual `updateLanguage` methods to be safe, since I saw the issue on the map tool sometimes when navigating from rankings