### PR TITLE
Re-fix translation loading

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,7 +86,6 @@ export class AppComponent implements OnInit {
     this.scroll.setupScroll(this.pageScroll);
     this.translate.setDefaultLang('en');
     this.translate.use('en');
-    this.updateLanguage(this.translate.translations);
     this.translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
     });

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -62,7 +62,6 @@ export class MapToolService {
     private analytics: AnalyticsService,
     private platform: PlatformService
   ) {
-    this.updateLanguage(translate.translations);
     translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
     });

--- a/src/app/ranking/ranking.service.spec.ts
+++ b/src/app/ranking/ranking.service.spec.ts
@@ -1,9 +1,18 @@
+import { EventEmitter } from '@angular/core';
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule, HttpRequest } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { RankingService } from './ranking.service';
 import { RankingModule } from './ranking.module';
+import { Observable } from 'rxjs/Observable';
+
+export class TranslateServiceStub {
+  currentLang = 'en';
+  translations = { 'en': {} };
+  public get onLangChange(): EventEmitter<any> { return new EventEmitter<any>(); }
+}
+
 
 describe('RankingService', () => {
   // tslint:disable-next-line:max-line-length
@@ -32,7 +41,10 @@ describe('RankingService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [RankingService, TranslateService],
+      providers: [
+        RankingService,
+        { provide: TranslateService, useClass: TranslateServiceStub },
+      ],
       imports: [
         RankingModule.forRoot({ dataUrl: 'https://fakeurl.com/' }),
         HttpClientModule,

--- a/src/app/ranking/ranking.service.ts
+++ b/src/app/ranking/ranking.service.ts
@@ -32,7 +32,7 @@ export class RankingService {
     private translate: TranslateService,
     @Inject('config') private config: any
   ) {
-    this.updateLanguage(this.translate.translations);
+    this.updateLanguage(this.translate.translations[this.translate.currentLang]);
     this.translate.onLangChange.subscribe(lang => {
       console.log('lang change', lang);
       this.updateLanguage(lang.translations);


### PR DESCRIPTION
Fixes #618. Removes the `updateLanguage` calls in everything but the rankings because they aren't needed, and uses the `translations` object correctly this time