### PR TITLE
Fix route error

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,7 +53,7 @@ export class CustomOption extends ToastOptions {
       }
     }),
     ServicesModule.forRoot(),
-    RouterModule.forRoot([], { useHash: true }),
+    RouterModule.forRoot([], { useHash: true, enableTracing: true }),
     TooltipModule.forRoot(),
     ToastModule.forRoot(),
     Ng2PageScrollModule.forRoot()

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,7 +53,7 @@ export class CustomOption extends ToastOptions {
       }
     }),
     ServicesModule.forRoot(),
-    RouterModule.forRoot([], { useHash: true, enableTracing: true }),
+    RouterModule.forRoot([], { useHash: true }),
     TooltipModule.forRoot(),
     ToastModule.forRoot(),
     Ng2PageScrollModule.forRoot()

--- a/src/app/ranking/ranking.service.ts
+++ b/src/app/ranking/ranking.service.ts
@@ -34,7 +34,6 @@ export class RankingService {
     private translate: TranslateService,
     @Inject('config') private config: any
   ) {
-    this.updateLanguage(this.translate.translations[this.translate.currentLang]);
     this.translate.onLangChange.subscribe(lang => {
       console.log('lang change', lang);
       this.updateLanguage(lang.translations);
@@ -60,6 +59,8 @@ export class RankingService {
       .subscribe(locations => {
         this.data = locations;
         this.ready.next(true);
+        this.translate.getTranslation(this.translate.currentLang).take(1)
+          .subscribe(translations => this.updateLanguage(translations));
       });
   }
 
@@ -156,6 +157,7 @@ export class RankingService {
   }
 
   private updateLanguage(translations) {
+    // console.log('updating language', translations);
     if (translations.hasOwnProperty('STATS')) {
       const stats = translations['STATS'];
       this.sortProps = this.sortProps.map(p => {

--- a/src/theme/base/header.scss
+++ b/src/theme/base/header.scss
@@ -48,7 +48,7 @@
     .icon {
       width:22px;
       height: 22px;
-      margin-bottom: grid(1);
+      margin: auto auto grid(1);
     }
     // icon colors
     .btn-icon { color: $headerButtonColor; }


### PR DESCRIPTION
Was receiving an error thrown by translations being undefined on first load of the rankings page which would kick back to the `/` route.  This PR changes it so the translations are set from the translations observable once the ranking data loads.

Also contains a small fix for icon alignment in the mobile header.