### PR TITLE
Handle download errors, update translations

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,7 +26,8 @@ import { ScrollService } from './services/scroll.service';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  providers: [ TranslatePipe ]
 })
 export class AppComponent implements OnInit {
   mapComponent: MapToolComponent;
@@ -61,6 +62,7 @@ export class AppComponent implements OnInit {
     public loader: LoadingService,
     private platform: PlatformService,
     private translate: TranslateService,
+    private translatePipe: TranslatePipe,
     private routing: RoutingService,
     private router: Router,
     private toastr: ToastsManager,
@@ -104,9 +106,9 @@ export class AppComponent implements OnInit {
   onActivate(component: any) {
     if (component.id === 'map-tool') {
       this.mapComponent = component;
-      this.titleService.setTitle('Eviction Lab - Map & Data'); // TODO: translate
+      this.titleService.setTitle(this.translatePipe.transform('MAP.TITLE'));
     } else if (component.id === 'ranking-tool') {
-      this.titleService.setTitle('Eviction Lab - Eviction Rankings'); // TODO: translate
+      this.titleService.setTitle(this.translatePipe.transform('RANKINGS.TITLE'));
     }
     this.updateClassAttributes(component.id);
     const loadedData = {

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -222,11 +222,11 @@ export class DataPanelComponent implements OnInit {
     this.platform.nativeWindow.addEventListener('blur', () => clearTimeout(timeout));
     timeout = setTimeout(() => {
       this.dialogService.showDialog({
-        title: 'Email Link Error',
+        title: this.translatePipe.transform('FOOTER.SHARE_EMAIL_ERROR'),
         content: [
           {
             type: 'text',
-            data: 'Please set a default mail client in your browser to use the email link.'
+            data: this.translatePipe.transform('FOOTER.SHARE_EMAIL_ERROR_MESSAGE')
           }
         ]
       });

--- a/src/app/map-tool/data-panel/download-form/download-form.component.spec.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.spec.ts
@@ -5,6 +5,7 @@ import { ModalModule, BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
 import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import { UiModule } from '../../../ui/ui.module';
+import { ToastModule } from 'ng2-toastr';
 import { DownloadFormComponent } from './download-form.component';
 import { FileExportService } from './file-export.service';
 import {Observable} from 'rxjs/Observable';
@@ -41,7 +42,13 @@ describe('DownloadFormComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ FormsModule, ModalModule.forRoot(), UiModule, TranslateModule.forRoot() ],
+      imports: [
+        FormsModule,
+        ModalModule.forRoot(),
+        UiModule,
+        TranslateModule.forRoot(),
+        ToastModule.forRoot()
+      ],
       declarations: [ DownloadFormComponent ],
       providers: [ BsModalService, BsModalRef ]
     });

--- a/src/app/map-tool/data-panel/download-form/download-form.component.ts
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.ts
@@ -3,6 +3,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 import { DialogResponse } from '../../../ui/ui-dialog/ui-dialog.types';
+import { ToastsManager } from 'ng2-toastr';
 import { FileExportService, ExportType } from './file-export.service';
 
 @Component({
@@ -21,8 +22,12 @@ export class DownloadFormComponent implements OnInit {
   constructor(
     public exportService: FileExportService,
     public bsModalRef: BsModalRef,
-    private translatePipe: TranslatePipe
-  ) { }
+    private translatePipe: TranslatePipe,
+    private toast: ToastsManager
+  ) {
+    // Add click to dimiss to all toast messages
+    this.toast.onClickToast().subscribe(t => this.toast.dismissToast(t));
+  }
 
   ngOnInit() {
     this.filetypes = this.exportService.getFileTypes();
@@ -65,6 +70,9 @@ export class DownloadFormComponent implements OnInit {
           this.dismiss({ accepted: true });
           this.loading = false;
         }
+      }, err => {
+        this.loading = false;
+        this.toast.error(this.translatePipe.transform('DATA.DOWNLOAD_ERROR'));
       });
   }
 

--- a/src/app/map-tool/map-tool.component.spec.ts
+++ b/src/app/map-tool/map-tool.component.spec.ts
@@ -13,10 +13,18 @@ import { DataLevels } from './data/data-levels';
 import { ToastModule } from 'ng2-toastr';
 import { LoadingService } from '../services/loading.service';
 import { ServicesModule } from '../services/services.module';
+import { Pipe, PipeTransform } from '@angular/core';
 
 export class TranslateServiceStub {
   public get(key: any): any {
     Observable.of(key);
+  }
+}
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
   }
 }
 
@@ -59,6 +67,7 @@ describe('MapToolComponent', () => {
       set: {
         providers: [
           {provide: MapToolService, useClass: MapToolServiceStub },
+          { provide: TranslatePipe, useClass: TranslatePipeMock },
           TranslateService
         ]
       }

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -37,7 +37,6 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   private ngUnsubscribe: Subject<any> = new Subject();
   @ViewChild(MapComponent) map;
   @ViewChild('divider') dividerEl: ElementRef;
-  title = 'Eviction Lab - Map';
   id = 'map-tool';
   enableZoom = true; // controls if map scroll zoom is enabled
   wheelEvent = false; // tracks if there is an active wheel event

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -30,7 +30,8 @@ import { ScrollService } from '../services/scroll.service';
 @Component({
   selector: 'app-map-tool',
   templateUrl: './map-tool.component.html',
-  styleUrls: ['./map-tool.component.scss']
+  styleUrls: ['./map-tool.component.scss'],
+  providers: [ TranslatePipe ]
 })
 export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   private ngUnsubscribe: Subject<any> = new Subject();
@@ -62,6 +63,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     private routing: RoutingService,
     private scroll: ScrollService,
     private translate: TranslateService,
+    private translatePipe: TranslatePipe,
     private toast: ToastsManager,
     private platform: PlatformService,
     private dialogService: UiDialogService,
@@ -122,9 +124,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     this.loader.start('feature');
     const maxLocations = this.mapToolService.addLocation(feature);
     if (maxLocations) {
-      this.toast.error(
-        'Maximum limit reached. Please remove a location to add another.'
-      );
+      this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
     }
     // track event
     const selectEvent = {
@@ -207,7 +207,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
         layerId, feature.geometry['coordinates'], feature.properties['name'] as string, true
       ).subscribe(data => {
           if (!data.properties.n) {
-            this.toast.error('Could not find data for location.');
+            this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
           } else {
             this.mapToolService.addLocation(data);
           }

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, fakeAsync, tick, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateModule, TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
@@ -13,6 +13,14 @@ import { ScrollService } from '../../../services/scroll.service';
 import { UiMapLegendComponent } from '../map-legend/ui-map-legend.component';
 import { LocationCardsModule } from '../../location-cards/location-cards.module';
 import { ServicesModule } from '../../../services/services.module';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 class MapServiceStub {
   updateCensusSource() {}
@@ -50,6 +58,7 @@ describe('MapComponent', () => {
       set: {
         providers: [
           { provide: MapService, useValue: new MapServiceStub() },
+          { provide: TranslatePipe, useClass: TranslatePipeMock }
         ],
       }
     })

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -3,7 +3,7 @@ import {
   HostListener, ElementRef
 } from '@angular/core';
 import { environment } from '../../../../environments/environment';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/distinctUntilChanged';
 import * as _isEqual from 'lodash.isequal';
@@ -21,7 +21,8 @@ import { PlatformService } from '../../../services/platform.service';
 @Component({
   selector: 'app-map',
   templateUrl: './map.component.html',
-  styleUrls: ['./map.component.scss']
+  styleUrls: ['./map.component.scss'],
+  providers: [ TranslatePipe ]
 })
 export class MapComponent implements OnInit, OnChanges {
   censusYear = 2010;
@@ -217,7 +218,8 @@ export class MapComponent implements OnInit, OnChanges {
     private map: MapService,
     private loader: LoadingService,
     private platform: PlatformService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private translatePipe: TranslatePipe
   ) {
     loader.start('map');
     translate.onLangChange.subscribe(l => this.updateSelectedLayerName());
@@ -438,10 +440,9 @@ export class MapComponent implements OnInit, OnChanges {
   /**
    * Updates the selected layer's name with the word "auto" if
    * auto switch is enabled
-   * TODO: translate "auto"
    */
   private updateSelectedLayerName() {
-    const autoLabel = '<span>(auto)</span>';
+    const autoLabel = `<span>(${this.translatePipe.transform('MAP.AUTO')})</span>`;
     if (this._store.layer) {
       const layerId = this._store.layer.id;
       const layerOptions = this.layerOptions.filter(l => l.id === layerId);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -77,6 +77,7 @@
     "BLOCK_GROUPS": "Block Groups"
   },
   "MAP": {
+    "TITLE": "Eviction Lab - Map & Data",
     "EVICTION_SELECT": "Eviction Data",
     "CENSUS_SELECT": "Census Data",
     "LAYER_SELECT": "Map Level",
@@ -87,7 +88,8 @@
     "SCROLL_DATA_SINGLE": "Scroll for More Data",
     "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
     "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
-    "NO_DATA_ERROR": "Could not find data for location."
+    "NO_DATA_ERROR": "Could not find data for location.",
+    "AUTO": "auto"
   },
   "NAV": {
     "HOME": "Home",
@@ -126,6 +128,7 @@
     "PCT_OTHER": "% Other Race"
   },
   "RANKINGS": {
+    "TITLE": "Eviction Lab - Eviction Rankings",
     "CITIES": "Cities",
     "MID_SIZED_AREAS": "Mid-sized Areas",
     "RURAL_AREAS": "Rural Areas",
@@ -165,6 +168,8 @@
     "SHARE_TWITTER": "Share on Twitter",
     "SHARE_FACEBOOK": "Share on Facebook",
     "SHARE_EMAIL": "Share via E-mail",
+    "SHARE_EMAIL_ERROR": "Email Link Error",
+    "SHARE_EMAIL_ERROR_MESSAGE": "Please set a default mail client in your browser to use the email link.",
     "SHARE_LINK": "Share Link",
     "CONNECT": "Connect With Us",
     "COPYRIGHT": "<p>All content &copy; 2017 Eviction Lab. All rights reserved.</p><p>Made possible by Princeton University</p>"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -14,6 +14,7 @@
     "DOWNLOAD_HEADING": "Download Reports",
     "DOWNLOAD_HINT": "Download the current data and graphs in PowerPoint, PDF, or spreadsheet files",
     "DOWNLOAD_BUTTON": "Select Report(s)",
+    "DOWNLOAD_ERROR": "There was an error completing your download. Please try again.",
     "GET_DATA_HEADING": "Get More Data",
     "GET_DATA": "Select Data Set(s)",
     "GET_DATA_HINT": "Access spreadsheets of full data sets from across the U.S.",
@@ -84,7 +85,9 @@
     "DATA_LINK_SINGLE": "View More Data",
     "DATA_LINK_MULTIPLE": "View Full Comparison",
     "SCROLL_DATA_SINGLE": "Scroll for More Data",
-    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison"
+    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
+    "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
+    "NO_DATA_ERROR": "Could not find data for location."
   },
   "NAV": {
     "HOME": "Home",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -14,6 +14,7 @@
     "DOWNLOAD_HEADING": "Download Reports",
     "DOWNLOAD_HINT": "Descargar los datos y gráficos actuales en un archivo PowerPoint, PDF, u hoja de cálculo",
     "DOWNLOAD_BUTTON": "Select Report(s)",
+    "DOWNLOAD_ERROR": "There was an error completing your download. Please try again.",
     "GET_DATA_HEADING": "Acceder a Más Datos",
     "GET_DATA": "Select Data Set(s)",
     "GET_DATA_HINT": "Access spreadsheets of full data sets from across the U.S.",
@@ -84,7 +85,9 @@
     "DATA_LINK_SINGLE": "Ver más datos",
     "DATA_LINK_MULTIPLE": "Ver comparación completa",
     "SCROLL_DATA_SINGLE": "Scroll for More Data",
-    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison"
+    "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
+    "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
+    "NO_DATA_ERROR": "Could not find data for location."
   },
   "STATS": {
     "DEMOGRAPHICS": "Desglose Demográfico",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -77,6 +77,7 @@
     "BLOCK_GROUPS": "Grupos de Cuadras"
   },
   "MAP": {
+    "TITLE": "Eviction Lab - Map & Data",
     "EVICTION_SELECT": "Tipo de Desalojo",
     "CENSUS_SELECT": "Tipo de Datos del Censo ",
     "LAYER_SELECT": "Nivel del Mapa",
@@ -87,7 +88,8 @@
     "SCROLL_DATA_SINGLE": "Scroll for More Data",
     "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
     "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
-    "NO_DATA_ERROR": "Could not find data for location."
+    "NO_DATA_ERROR": "Could not find data for location.",
+    "AUTO": "auto"
   },
   "STATS": {
     "DEMOGRAPHICS": "Desglose Demográfico",
@@ -115,6 +117,7 @@
     "PCT_OTHER": "% Otra Raza"
   },
   "RANKINGS": {
+    "TITLE": "Eviction Lab - Eviction Rankings",
     "CITIES": "Cities",
     "MID_SIZED_AREAS": "Mid-sized Areas",
     "RURAL_AREAS": "Rural Areas",
@@ -154,6 +157,8 @@
     "SHARE_TWITTER": "Share on Twitter",
     "SHARE_FACEBOOK": "Share on Facebook",
     "SHARE_EMAIL": "Share via E-mail",
+    "SHARE_EMAIL_ERROR": "Email Link Error",
+    "SHARE_EMAIL_ERROR_MESSAGE": "Please set a default mail client in your browser to use the email link.",
     "SHARE_LINK": "Share Link"
   }
 }


### PR DESCRIPTION
Closes #715, #717. There are still likely places to translate in the HTML, but all strings in the component TypeScript files should be using `i18n` after this

![download-error](https://user-images.githubusercontent.com/8291663/36732581-28dfcf4a-1b9c-11e8-9eba-e77cfe003534.gif)
