### PR TITLE
Null check on graph locations

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -65,7 +65,7 @@ export class EvictionGraphsComponent implements OnInit {
     this._locations = value;
     this.setGraphData();
   }
-  get locations() { return this._locations; }
+  get locations() { return this._locations ? this._locations.filter(l => l) : []; }
   @Output() locationRemoved = new EventEmitter();
 
   /** Graph type input and output (allows double binding) */


### PR DESCRIPTION
Closes #707. This is probably over-cautious, but checks that `this._locations` is not undefined, and that each location is not undefined