### PR TITLE
fix header width, dropdown alignment, bottom aligned UI

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,13 @@
 app-progress-bar { position: fixed; top: 0; z-index: 1000;}
-app-header-bar { position: fixed; top:0; left:0; right:0; width:100%; z-index:999;}
+app-header-bar { 
+  position: fixed; 
+  top:0; 
+  left:0; 
+  right:0; 
+  width:100vw; 
+  z-index:999;
+  max-width: 100%;
+}
 
 app-footer {
   display:block;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -39,7 +39,7 @@
 }
 // larger than mobile:
 //    show select boxes by default
-.gt-mobile :host-context {
+@media(min-width: $gtMobile) {
   .map-ui { 
     display: block;
     width: calc(100% - #{($pageMarginLg*2)});    
@@ -110,7 +110,7 @@ app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
   }
 }
 // increase page margins and account for larger time slider
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
     top: 0;
     bottom:$timeSliderLg;
@@ -146,7 +146,7 @@ app-location-cards {
 // greater than tablet:
 //    Adjust cards container to account for the larger header height
 //    center cards vertically over the map
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   app-location-cards {
     background: none;
     pointer-events: none;
@@ -170,12 +170,14 @@ app-location-cards {
 }
 // greater than tablet when slider is active:
 //    Drop height of card container
-.gt-tablet :host-context(.slider-active) {
-  app-location-cards {
-    top:0;
-    bottom: auto;
-    margin:auto;
-    height: calc(100vh - #{$headerHeightLg} - #{$timeSliderLg});
+@media(min-width: $gtTablet) {
+  :host-context(.slider-active) {
+    app-location-cards {
+      top:0;
+      bottom: auto;
+      margin:auto;
+      height: calc(100vh - #{$headerHeightLg} - #{$timeSliderLg});
+    }
   }
 }
 // - End Map Location Cards
@@ -294,7 +296,7 @@ app-ui-map-legend {
 }
 // larger than tablet: 
 //    move legend to bottom right of the map
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   app-ui-map-legend {
     height: grid(6); // 6 * 8 = 48px
     width: grid(42.5); // 42.5 * 8 = 340px
@@ -313,21 +315,25 @@ app-ui-map-legend {
 }
 // large than mobile:
 //    legend is on the bottom right of the map, above cards
-.gt-mobile :host-context(.slider-active) app-ui-map-legend {
-  bottom: $timeSliderLg + $pageMarginLg;
+@media(min-width: $gtMobile) {
+  :host-context(.slider-active) app-ui-map-legend {
+    bottom: $timeSliderLg + $pageMarginLg;
+  }
+  :host-context(.cards-active.slider-active) app-ui-map-legend {
+    bottom: $timeSliderLg + $cardHeaderHeight + $pageMarginLg + $mobileScrollIndicatorHeight;
+  }
 }
-.gt-mobile :host-context(.cards-active.slider-active) app-ui-map-legend {
-  bottom: $timeSliderLg + $cardHeaderHeight + $pageMarginLg + $mobileScrollIndicatorHeight;
-}
-
 // large than tablet:
 //    cards removed from bottom, adjust accordingly
-.gt-tablet :host-context(.cards-active.slider-active) app-ui-map-legend {
-  bottom: $timeSliderLg + $pageMarginLg;
+@media(min-width: $gtTablet) {
+  :host-context(.cards-active.slider-active) app-ui-map-legend {
+    bottom: $timeSliderLg + $pageMarginLg;
+  }
+  :host-context(.cards-active) .mobile-scroll-indicator {
+    display: none;
+  }
 }
-.gt-tablet :host-context(.cards-active) .mobile-scroll-indicator {
-  display: none;
-}
+
 
 // - End Map Legend
 
@@ -337,8 +343,13 @@ app-ui-map-legend {
 // default: 
 //    Place year slider at the bottom of the window below the map
 .year-slider-container {
-  @include fill-parent();
+  position:absolute;
+  width: 100vw;
+  max-width: 100%;
   top: auto;
+  left:0;
+  right:0;
+  bottom:0;
   height: $timeSliderHeight;
   z-index: 49;
   background: $timeSliderBackground;
@@ -359,21 +370,24 @@ app-ui-map-legend {
     transform: translateY(0);
   }
 }
-// increase offset from the bottom if cards are shown
-:host-context(.cards-active) {
-  .year-slider-container { bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight; }
+// increase offset from the bottom if cards are shown (only up to tablet)
+@media(max-width: $gtTablet) {
+  :host-context(.cards-active) {
+    .year-slider-container { bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight; }
+  }
 }
-.gt-mobile :host-context {
+
+@media(min-width: $gtMobile) {
   .year-slider-container {
     padding: 0 ($pageMarginLg + grid(2)) 0 $pageMarginLg; // add grid(2) so slider marker aligns with margin edge
     height: $timeSliderLg;
     box-shadow: 0 -1px 2px rgba(0,0,0,0.2);
   }
-  .year-slider { height: $timeSliderLg; }
+  .year-slider-container .year-slider { height: $timeSliderLg; }
 }
 // fixed at the bottom of the screen abover the overlay on 
 // devices larger than tablet
-.gt-tablet :host-context {
+@media(min-width: $gtTablet) {
   .year-slider-container {
     bottom: 0; 
     z-index:51;
@@ -385,37 +399,78 @@ app-ui-map-legend {
 // TODO: Move device specific styles to separate overrides file
 // Device-specific adjustments
 
-// Additional spacing for iOS Safari
-.ios-safari:not(.gt-tablet) :host-context(.slider-active) {
-  .year-slider-container { height: $timeSliderHeight + $iosSafariPadding; }
-}
-.ios-safari:not(.gt-tablet) :host-context(.legend-active) {
-  app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
-}
-.ios-safari:not(.gt-tablet) :host-context(.cards-active) {
-  .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-  app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-  .year-slider-container {
-    height: $timeSliderHeight;
-    bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
+// iPhones w/ safari
+@media(max-width: $gtMobile) {
+  .ios-safari :host-context(.slider-active) {
+    .year-slider-container { height: $timeSliderHeight + $iosSafariPadding; }
   }
-  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
+  .ios-safari :host-context(.legend-active) {
+    app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
+  }
+  .ios-safari :host-context(.cards-active) {
+    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
+    app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
+    .year-slider-container {
+      height: $timeSliderHeight;
+      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
+    }
+    app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
+  }
+}
+// iPads w/ Safari
+@media(min-width: $gtMobile) and (max-width: $gtTablet) {
+  .ios-safari :host-context(.slider-active) {
+    .year-slider-container { height: $timeSliderLg + $iosSafariPadding; }
+  }
+  .ios-safari :host-context(.legend-active) {
+    app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderLg; }
+  }
+  .ios-safari :host-context(.cards-active) {
+    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
+    app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
+    .year-slider-container {
+      height: $timeSliderLg;
+      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
+    }
+    app-ui-map-legend { bottom: $timeSliderLg + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
+  }
+}
+// Android - Mobile
+@media(max-width: $gtMobile) {
+  .android :host-context(.slider-active) {
+    .year-slider-container { height: $timeSliderHeight + $androidPadding; }
+  }
+  .android :host-context(.legend-active) {
+    app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
+  }
+  .android :host-context(.cards-active) {
+    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
+    app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
+    .year-slider-container {
+      height: $timeSliderHeight;
+      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
+    }
+    app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
+  }
+}
+// Android - Tablet
+@media(min-width: $gtMobile) and (max-width: $gtTablet) {
+  .android :host-context(.slider-active) {
+    .year-slider-container { height: $timeSliderLg + $androidPadding; }
+  }
+  .android :host-context(.legend-active) {
+    app-ui-map-legend { bottom: $androidPadding + $timeSliderLg; }
+  }
+  .android :host-context(.cards-active) {
+    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
+    app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
+    .year-slider-container {
+      height: $timeSliderLg;
+      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
+    }
+    app-ui-map-legend { bottom: $timeSliderLg + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
+  }
 }
 
-// Additional spacing for Android
-.android:not(.gt-tablet) :host-context(.slider-active) {
-  .year-slider-container { height: $timeSliderHeight + $androidPadding; }
-}
-.android:not(.gt-tablet) :host-context(.legend-active) {
-  app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
-}
-.android:not(.gt-tablet) :host-context(.cards-active) {
-  .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
-  app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
-  .year-slider-container {
-    height: $timeSliderHeight;
-    bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
-  }
-  app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
-}
+
 // - End of device adjustments

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -10,7 +10,7 @@ function _window(): any {
 
 const breakpoints = {
   'mobile': 767,
-  'tablet': 1024,
+  'tablet': 1023,
   'smallDesktop': 1279,
   'largeDesktop': 1599
 };

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -16,9 +16,9 @@ $defaultPadding: grid(2); // default padding for containers
 $pageMargin: grid(2); // page margin on mobile
 $pageMarginLg: grid(3); // page margin on tablet+
 $maxContentWidth: 1200px; // max width for page content
-$gtMobile: 768px; // greater than mobile device breakpoint
-$gtTablet: 1024px; // greater than tablet device breakpoint
-$gtLaptop: 1440px; // greater than laptop device breakpoint
+$gtMobile: 767px; // greater than mobile device breakpoint
+$gtTablet: 1023px; // greater than tablet device breakpoint
+$gtLaptop: 1439px; // greater than laptop device breakpoint
 
 
 // Typography


### PR DESCRIPTION
- Reduce breakpoints by 1px so they trigger at the correct resolutions
- Add tablet styles for `ios-safari` and `android` so time slider doesn't overlap cards
- Use `width: 100vw` + `max-width:100%` to prevent elements from exceeding the viewport width

Some issues that still exist for tablet:
- Switching orientation doesn't always fire a window resize event.  We should listen for a orientation change and then manually trigger window resize when that happens.
- Some bottom alignment might still be off due to shrinking URL bar
- Tapping on the map doesn't active a location, it only activates its hover state