### PR TITLE
Hide tooltips on document touchstart

### DIFF
--- a/src/app/ui/ui-hint/ui-hint.component.html
+++ b/src/app/ui/ui-hint/ui-hint.component.html
@@ -1,3 +1,3 @@
-<button *ngIf="hint" class="hint-button" container="body" [tooltip]="hint" [triggers]="triggers" [placement]="placement">
+<button *ngIf="hint" class="hint-button" container="body" [tooltip]="hint" [triggers]="triggers" [placement]="placement" (onShown)="onTooltipShown($event)">
   <app-ui-icon icon="hint"></app-ui-icon>
 </button>

--- a/src/app/ui/ui-hint/ui-hint.component.ts
+++ b/src/app/ui/ui-hint/ui-hint.component.ts
@@ -1,4 +1,7 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewChildren, Inject, QueryList } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { DOCUMENT } from '@angular/common';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   selector: 'app-ui-hint',
@@ -9,4 +12,17 @@ export class UiHintComponent {
   @Input() hint: string;
   @Input() placement = 'top';
   @Input() triggers = 'hover focus';
+  @Input() docHideTrigger = 'touchstart';
+  @ViewChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
+
+  constructor(@Inject(DOCUMENT) private document: any) {}
+
+  /**
+   * Hide tooltip on first instance of document event while shown
+   */
+  onTooltipShown(event: any) {
+    Observable.fromEvent(this.document, this.docHideTrigger)
+      .take(1)
+      .subscribe(e => this.tooltips.forEach(t => t.hide()));
+  }
 }


### PR DESCRIPTION
Closes #567. Hides any tooltip on mobile once the user starts to scroll somewhere else so that they don't linger