### PR TITLE
Specify options on scroll to fix mobile flicker

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -249,7 +249,8 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   goToTop() {
     if (this.getVerticalOffset() > 0) {
-      this.scroll.scrollTo('#top');
+      const topEl = this.document.getElementById('top');
+      this.scroll.scrollTo('#top', { pageScrollOffset: topEl.offsetTop });
     }
   }
 

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -54,9 +54,11 @@ export class ScrollService {
   /**
    * Helper method for scrolling to an element on the page
    * @param selector Query selector for element to scroll to
+   * @param options Additional parameters for PageScrollOptions object
    */
-  scrollTo(selector: string) {
-    const scrollInstance = PageScrollInstance.simpleInstance(this.document, selector);
+  scrollTo(selector: string, scrollOptions?: Object) {
+    const options = { document: this.document, scrollTarget: selector, ...(scrollOptions || {}) };
+    const scrollInstance = PageScrollInstance.newInstance(options);
     this.pageScroll.start(scrollInstance);
   }
 


### PR DESCRIPTION
Closes #692. The back to map button's offset was larger than needed, so it was attempting to scroll past the top of the page, which lead to the flickering on mobile. This adds an optional `scrollOptions` parameter to the `scrollTo` helper of the scroll service to make it easier to override defaults for just one function. It uses the `offsetTop` of the `#top` element here to make sure that the scroll doesn't go farther than necessary. This might also help with #699 since it gives us more control over scrolling