### PR TITLE
Fix border button focus state

### DIFF
--- a/src/theme/base/buttons.scss
+++ b/src/theme/base/buttons.scss
@@ -119,7 +119,7 @@
 }
 
 // Square buttons with border
-.btn-border {
+.btn-border, .btn-border:focus {
   background: $defaultBackground;
   color: $grey1;
   border: 5px solid $grey5;


### PR DESCRIPTION
Fixes #726. Adds `btn-border` styles to `:focus` state

Before:
<img width="365" alt="screen shot 2018-02-28 at 7 57 45 am" src="https://user-images.githubusercontent.com/8291663/36799798-01ce9cc0-1c7c-11e8-9ff0-31d28f2b07c8.png">
 
After:
<img width="389" alt="screen shot 2018-02-28 at 11 37 16 am" src="https://user-images.githubusercontent.com/8291663/36799792-005a5f00-1c7c-11e8-823b-54b1c3d74a86.png">
