### PR TITLE
Condense header on scroll

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,7 @@
 <app-progress-bar [indeterminate]="loader.isLoading"></app-progress-bar>
 <app-header-bar
   role="banner"
+  [class.condensed]="!isAtTop"
   [activeMenuItem]="currentMenuItem"
   [languageOptions]="languageOptions"
   (activeMenuItemChange)="onMenuSelect($event)"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -55,6 +55,7 @@ export class AppComponent implements OnInit {
     { id: 'es', name: '', langKey: 'HEADER.ES' }
   ];
   selectedLanguage;
+  isAtTop = true;
   private activeMenuItem;
 
   constructor(
@@ -84,6 +85,7 @@ export class AppComponent implements OnInit {
     };
     this.routing.setupRoutes(components);
     this.scroll.setupScroll(this.pageScroll);
+    this.scroll.scrolledToTop$.subscribe(top => this.isAtTop = top);
     this.translate.setDefaultLang('en');
     this.translate.use('en');
     this.translate.onLangChange.subscribe((lang) => {

--- a/src/app/header-bar/header-bar.component.scss
+++ b/src/app/header-bar/header-bar.component.scss
@@ -1,22 +1,75 @@
 @import '../../theme';
-// Ranking tool overrides
-:host-context(.ranking-tool) {
-  .btn.btn-icon {
-    display: none;
+
+// Map Tool Mobile Overrides
+@media(max-width: $gtMobile) {
+  :host-context(.map-tool) {
+    // no logo on mobile
+    .header-logo { 
+      display: none;
+    }
+    // show all icons on map tool
+    .header-icons {
+      width: 100%;
+      .btn.btn-icon {
+        display: block;
+      }
+    }
+    // no language select in mobile toolbar
+    .language-select {
+      display: none;
+    }
+    // place search below toolbar
+    .header-search {
+      display:none;
+      margin-top: grid(2);
+      &.active { 
+        display: block;
+        position: absolute;
+        top: grid(7);
+        left: 0;
+        right: 0;
+        z-index: 10;
+        padding-bottom: grid(1); // pad a bit so glow doesn't get cutoff
+      }
+    }
   }
-  .btn.btn-icon.el-button-menu {
-    display: block;
+}
+
+@media(min-width: $gtMobile) {
+  :host-context(.map-tool) {
+    // show search in header
+    .header-search {
+      position:relative;
+      display:flex;
+      order: 2;
+      flex: 1;
+      max-width: grid(37.5);
+      margin: 0 0 0 grid(3);
+      .search {
+        width: 100%;
+      }
+      // override mobile positioning
+      &.active { 
+        position:relative; 
+        top:auto; 
+        left:auto; 
+        right: auto; 
+        padding-bottom:0;
+      }
+    }
   }
-  .header-wrapper .header-logo {
-    display: block;
-    flex:1;
+}
+
+// Desktop+ Styles
+@media(min-width: $gtTablet) {
+  :host-context(.map-tool) {
+    .header-search {
+      flex:1;
+      max-width: none;
+      display:flex;
+      align-items: center;
+      justify-content: flex-end;
+      margin-right: grid(1);
+    }
   }
-  .header-wrapper .header-icons {
-    width: grid(5);
-    margin-right: -6px; // nudge a bit so menu icon aligns properly
-  }
-  .header-wrapper .language-select {
-    display: block;
-  }
-  .header-wrapper .header-search { display: none; }
 }

--- a/src/app/map-tool/map-tool.component.html
+++ b/src/app/map-tool/map-tool.component.html
@@ -1,6 +1,5 @@
 <div id="top" role="main" class="app-wrapper">
   <app-map
-    [class.map-inactive]="!enableZoom"
     [mapConfig]="mapToolService.mapConfig"
     [dataAttributes]="mapToolService.dataAttributes"
     [layerOptions]="mapToolService.dataLevels"

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -248,7 +248,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    * Triggers a scroll to the top of the page
    */
   goToTop() {
-    if (this.getVerticalOffset() > 0) {
+    if (this.scroll.getVerticalOffset() > 0) {
       const topEl = this.document.getElementById('top');
       this.scroll.scrollTo('#top', { pageScrollOffset: topEl.offsetTop });
     }
@@ -278,19 +278,11 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  private getVerticalOffset() {
-    return this.platform.nativeWindow.pageYOffset ||
-      this.document.documentElement.scrollTop ||
-      this.document.body.scrollTop || 0;
-  }
-
   /**
    * Configures options for the `ng2-page-scroll` module, and setup scroll observables
    * to enable / disable map zoom
-   * TODO: use the scroll service!
    */
   private setupPageScroll() {
-
     // Setup scroll events to handle enable / disable map zoom
     Observable.fromEvent(this.document, 'wheel')
       .debounceTime(250)
@@ -300,10 +292,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
       // only fire when wheel event hasn't been triggered yet
       .filter(() => !this.wheelEvent)
       .subscribe(e => this.wheelEvent = true);
-    Observable.fromEvent(this.platform.nativeWindow, 'scroll')
-      // trailing scroll event is needed so verticalOffset = 0 event is fired
-      .throttleTime(10, undefined, { trailing: true, leading: true })
-      .subscribe(e => this.onScroll());
+    this.scroll.verticalOffset$.subscribe(this.onScroll.bind(this));
   }
 
   /**
@@ -312,7 +301,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    * the wheel events
    */
   private onWheel() {
-    this.verticalOffset = this.getVerticalOffset();
+    this.verticalOffset = this.scroll.getVerticalOffset();
     this.wheelEvent = false;
     this.enableZoom = (this.verticalOffset === 0);
   }
@@ -321,8 +310,8 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    * If scrolled to the top, enable the zoom.  Unless
    * there is a wheel event currently happening.
    */
-  private onScroll() {
-    this.verticalOffset = this.getVerticalOffset();
+  private onScroll(yOffset: number) {
+    this.verticalOffset = yOffset;
     if (!this.wheelEvent) {
       this.enableZoom = (this.verticalOffset === 0);
     } else {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -287,6 +287,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   /**
    * Configures options for the `ng2-page-scroll` module, and setup scroll observables
    * to enable / disable map zoom
+   * TODO: use the scroll service!
    */
   private setupPageScroll() {
 

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -48,7 +48,7 @@
     (clickedHeader)="clickedCardHeader.emit($event)"
     (dismissedCard)="dismissedCard.emit($event)"
   ></app-location-cards>
-  <div class="mobile-scroll-indicator">
+  <div class="mobile-scroll-indicator" [class.inactive]="!scrollZoom">
     <p *ngIf="activeFeatures.length === 1">{{ 'MAP.SCROLL_DATA_SINGLE' | translate}}</p>
     <p *ngIf="activeFeatures.length > 1">{{ 'MAP.SCROLL_DATA_MULTIPLE' | translate}}</p>
   </div>

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -74,51 +74,9 @@
   display: inherit;
 }
 
-:host-context(.map-inactive) {
-  .mobile-scroll-indicator p { opacity: 0; }
-}
-// - End mobile scroll indicator
+.mobile-scroll-indicator.inactive p { opacity: 0; }
 
-// Map Zoom Controls
-// ----
-// Hide rotate button because it's confusing
-app-mapbox ::ng-deep .mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
-  display: none;
-}
-// center controls vertically on the right side of the map
-app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
-  top: 0;
-  bottom: $timeSliderHeight + $mobileScrollIndicatorHeight + grid(5);
-  margin:auto;
-  height:grid(22);
-  right:$pageMargin;
-  left: auto;
-  .mapboxgl-ctrl-group {
-    float: right;
-    border-radius:0;
-    box-shadow: $z1shadow;
-    overflow:visible;
-     & > button {
-       border-bottom: none;
-       border-radius:0;
-       width: grid(5);
-       height: grid(5);
-       &.mapboxgl-ctrl-zoom-in {
-         border-bottom: 1px solid $shadingColor;
-       }
-     }
-  }
-}
-// increase page margins and account for larger time slider
-@media(min-width: $gtMobile) {
-  app-mapbox ::ng-deep .mapboxgl-ctrl-top-left {
-    top: 0;
-    bottom:$timeSliderLg;
-    right:$pageMarginLg;
-    left: auto;
-  }
-}
-// - End Map Zoom Control
+// - End mobile scroll indicator
 
 
 // Map Location Cards

--- a/src/app/map-tool/map/mapbox/mapbox.component.scss
+++ b/src/app/map-tool/map/mapbox/mapbox.component.scss
@@ -12,114 +12,150 @@ $infoIcon: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox
   left:0;right:0;top:0;bottom:0;
 }
 
-
-::ng-deep {
-  .mapboxgl-ctrl-icon {
-    background-size: 16px 16px;
-    background-repeat: no-repeat;
-    background-position: center;
+// Map Zoom Controls
+// ----
+// Hide rotate button because it's confusing
+.mapboxgl-ctrl-group > button.mapboxgl-ctrl-compass {
+  display: none;
+}
+// center controls vertically on the right side of the map
+.mapboxgl-ctrl-top-left {
+  top: 0;
+  bottom: $timeSliderHeight + $mobileScrollIndicatorHeight + grid(5);
+  margin:auto;
+  height:grid(22);
+  right:$pageMargin;
+  left: auto;
+  .mapboxgl-ctrl-group {
+    float: right;
+    border-radius:0;
+    box-shadow: $z1shadow;
+    overflow:visible;
+     & > button {
+       border-bottom: none;
+       border-radius:0;
+       width: grid(5);
+       height: grid(5);
+       &.mapboxgl-ctrl-zoom-in {
+         border-bottom: 1px solid $shadingColor;
+       }
+     }
   }
-  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
-    background-image: url($zoomInIcon);
-  }
-  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
-    background-image: url($zoomOutIcon);
-  }
-  .mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate {
-    background-image: url($geolocateIcon);
-    background-size: 22px 22px;
-  }
-  .mapboxgl-ctrl-attrib.mapboxgl-compact:after {
-    background-image: url($infoIcon);
-    background-size: 16px 16px;
-    background-repeat: no-repeat;
-    background-position: center;
-  }
-  .mapboxgl-canvas:focus {
-    outline: 4px solid transparentize($color1, 0.5);
-    outline-offset: -4px;
-  }
-  .mapboxgl-popup, .mapboxgl-popup-content {
-    cursor: pointer;
-    pointer-events: none;
-  }
-  .mapboxgl-popup-tip {
-    border: $tooltipArrowSize solid transparent;
-    transform: scale(0.75, 1); 
-  }
-  
-  .mapboxgl-popup-content {
-    @include tooltip();
-  }
-  .mapboxgl-popup-content p {
-    margin: 0;
-  }
-  .mapboxgl-popup-anchor-right .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
-    transform: scale(1, 0.75); 
-  }
-  .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
-    border-bottom: none;
-    border-top-color: $tooltipBackground;
-  }
-  .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
-    border-right: none;
-  }
-  .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
-    border-left: none;
-  }
-  .mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
-    border-right: none;
-    border-left-color: $tooltipBackground;
-  }
-  .mapboxgl-popup-anchor-left .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
-    border-left: none;
-    border-right-color: $tooltipBackground;
-  }
-  .mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip,
-  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
-    border-top: none;
-    border-bottom-color: $tooltipBackground;
-  }
-  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
-    border-right: none;
-  }
-  .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
-    border-left: none;
-  }
-  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact {
-    margin: grid(1);
-  }
-  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+}
+// increase page margins and account for larger time slider
+@media(min-width: $gtMobile) {
+  .mapboxgl-ctrl-top-left {
     top: 0;
-    bottom: auto;
+    bottom:$timeSliderLg;
+    right:$pageMarginLg;
+    left: auto;
   }
-  .mapboxgl-ctrl-bottom-left {
+}
+// - End Map Zoom Control
+
+
+.mapboxgl-ctrl-icon {
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
+  background-image: url($zoomInIcon);
+}
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+  background-image: url($zoomOutIcon);
+}
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate {
+  background-image: url($geolocateIcon);
+  background-size: 22px 22px;
+}
+.mapboxgl-ctrl-attrib.mapboxgl-compact:after {
+  background-image: url($infoIcon);
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.mapboxgl-canvas:focus {
+  outline: 4px solid transparentize($color1, 0.5);
+  outline-offset: -4px;
+}
+.mapboxgl-popup, .mapboxgl-popup-content {
+  cursor: pointer;
+  pointer-events: none;
+}
+.mapboxgl-popup-tip {
+  border: $tooltipArrowSize solid transparent;
+  transform: scale(0.75, 1); 
+}
+
+.mapboxgl-popup-content {
+  @include tooltip();
+}
+.mapboxgl-popup-content p {
+  margin: 0;
+}
+.mapboxgl-popup-anchor-right .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+  transform: scale(1, 0.75); 
+}
+.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
+  border-bottom: none;
+  border-top-color: $tooltipBackground;
+}
+.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+  border-right: none;
+}
+.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip {
+  border-left: none;
+}
+.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+  border-right: none;
+  border-left-color: $tooltipBackground;
+}
+.mapboxgl-popup-anchor-left .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-left: none;
+  border-right-color: $tooltipBackground;
+}
+.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip,
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-top: none;
+  border-bottom-color: $tooltipBackground;
+}
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-right: none;
+}
+.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-left: none;
+}
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact {
+  margin: grid(1);
+}
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+  top: 0;
+  bottom: auto;
+}
+.mapboxgl-ctrl-bottom-left {
+  display: none;
+}
+@media(min-width: $gtTablet) {
+  .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib {
     display: none;
   }
-  @media(min-width: $gtTablet) {
-    .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib {
-      display: none;
-    }
-    .mapboxgl-ctrl-bottom-left {
-      display: inherit;
-      top: auto;
-      bottom: 0;
-      left: 0;
-      right: auto;
-    }
-    
+  .mapboxgl-ctrl-bottom-left {
+    display: inherit;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: auto;
   }
 }
 
-:host-context(.slider-active) {
-  ::ng-deep {
-    .mapboxgl-ctrl-bottom-left {
-      bottom: $timeSliderLg;
-    }
+.slider-active {
+  .mapboxgl-ctrl-bottom-left {
+    bottom: $timeSliderLg;
   }
 }

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, OnInit, Input, Output, AfterViewInit,
-  EventEmitter, ViewChild, ElementRef, NgZone, HostListener
+  EventEmitter, ViewChild, ElementRef, NgZone, HostListener, ViewEncapsulation
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -18,6 +18,7 @@ import 'rxjs/add/operator/distinctUntilChanged';
   selector: 'app-mapbox',
   templateUrl: './mapbox.component.html',
   styleUrls: ['./mapbox.component.scss'],
+  encapsulation: ViewEncapsulation.None,
   providers: [ TranslatePipe, DecimalPipe ]
 })
 export class MapboxComponent implements AfterViewInit {

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -92,7 +92,7 @@ $sidePanelHeight: grid(55);
   .nav-bar {
     position: sticky;
     z-index:30;
-    top: $headerHeightLg - 1px; // fix 1px showing through
+    top: $headerHeightSm - 1px; // fix 1px showing through
     height: grid(8);
     ul {
       flex-direction: row;

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -30,6 +30,7 @@ export class ScrollService {
     this.document.body.style.overflowY = changeScroll ? 'scroll' : '';
   }
   verticalOffset$: Observable<number>;
+  scrolledToTop$: Observable<boolean>;
 
   constructor(
     @Inject(DOCUMENT) private document: any,
@@ -38,8 +39,13 @@ export class ScrollService {
     // provide observable with top / bottom vertical offset
     this.verticalOffset$ = Observable
       .fromEvent(this.platform.nativeWindow, 'scroll')
+      .throttleTime(10, undefined, { trailing: true, leading: true })
       .map(e => this.getVerticalOffset());
+    this.scrolledToTop$ = this.verticalOffset$
+      .map(offset => offset === 0)
+      .distinctUntilChanged();
   }
+
 
   /**
    * Sets up PageScrollConfig with defaults

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -31,6 +31,8 @@ export class ScrollService {
   }
   verticalOffset$: Observable<number>;
   scrolledToTop$: Observable<boolean>;
+  /** Determines the range that triggers `scrolledToTop` to emit */
+  private topOffset = 56;
 
   constructor(
     @Inject(DOCUMENT) private document: any,
@@ -42,7 +44,7 @@ export class ScrollService {
       .throttleTime(10, undefined, { trailing: true, leading: true })
       .map(e => this.getVerticalOffset());
     this.scrolledToTop$ = this.verticalOffset$
-      .map(offset => offset === 0)
+      .map(offset => offset < this.topOffset)
       .distinctUntilChanged();
   }
 
@@ -68,7 +70,7 @@ export class ScrollService {
     this.pageScroll.start(scrollInstance);
   }
 
-  private getVerticalOffset() {
+  getVerticalOffset() {
     return this.platform.nativeWindow.pageYOffset ||
       this.document.documentElement.scrollTop ||
       this.document.body.scrollTop || 0;

--- a/src/theme/base/header.scss
+++ b/src/theme/base/header.scss
@@ -1,15 +1,23 @@
-@mixin iconLabelFont() {
+// Header Mixins
+// ---
+@mixin iconLabelText() {
   @include altSmallCapsText(10px);
 }
-
-@mixin iconLabelFontLg() {
+@mixin iconLabelTextLg() {
   @include altSmallCapsText(14px);
 }
+@mixin langSelectText() {
+  @include defaultFont(10px);
+  letter-spacing: 0.3px;
+  text-transform: none;
+}
+@mixin langSelectTextLg() {
+  @include defaultFont(15px);
+  letter-spacing: 0;
+}
 
-// HEADER BAR
-
-// Mobile styles
-// - 5 icons at the top
+// Header Container / Layout
+// ---
 .header-wrapper {
   position:absolute;
   top:0;left:0;right:0;
@@ -32,197 +40,213 @@
     align-content: center;
     align-items: center;
   }
-  // toolbar icon row
-  .header-icons {
-    width: 100%;
-    height: 100%;
-    display:flex;
-    justify-content: space-between;
-    align-content: center;
-    align-items: center;
-    .btn.btn-icon {
-      width: grid(5);
-      height: grid(5);
-      @include iconLabelFont();
-    }
-    .icon {
-      width:22px;
-      height: 22px;
-      margin: auto auto grid(1);
-    }
-    // icon colors
-    .btn-icon { color: $headerButtonColor; }
-    .icon { fill: $headerButtonColor; }
-    .btn-icon.active { color: $headerActiveButtonColor; }
-    .btn-icon.active .icon { fill: $headerActiveButtonColor; }
-  }
-  // no logo on mobile
-  .header-logo { 
-    display: none;
-    img { width: 152px; }
-  }
-  // place search below toolbar
-  .header-search {
-    display:none;
-    margin-top: grid(2);
-    &.active { 
-      display: block;
-      position: absolute;
-      top: grid(7);
-      left: 0;
-      right: 0;
-      z-index: 10;
-      padding-bottom: grid(1); // pad a bit so glow doesn't get cutoff
-    }
-  }
-  .language-select {
-    display: none;
-    .btn.dropdown-toggle {
-      .dropdown-value {
-        @include defaultFont(13px);
-        text-transform: none;
-      }
-    }
-  }
 }
-// Override language select font/icon on mobile only
-@media(max-width: $gtMobile) {
-  .header-wrapper .language-select {
-    margin-right: grid(1);
-    width: grid(9);
-    .el-select {
-      .btn { 
-        padding: grid(1); 
-        height: grid(5); 
-      }
-      .btn .dropdown-value { font-size:10px; }
-      .btn .icon { width: 8px; right: 8px; }
-    } 
-  }
-}
-
-// Tablet+ Styles
+// boost header height on tablet+
 @media(min-width: $gtMobile) {
-  // boost header height
   .header-wrapper {
     height: $headerHeightLg;
     padding: 0 $pageMarginLg;    
-    .header-icons {
-      flex:none;
-      width:grid(5);
-      height:grid(7);
-      order: 4;
+  }
+}
+
+// Search
+// ---
+.header-search { display: none; } // Hide search by default
+
+// Toolbar Icons (show menu button only by default)
+// ---
+.header-icons {
+  width: grid(5);
+  margin-right: -6px; // nudge a bit so menu icon aligns properly
+  height: 100%;
+  display:flex;
+  justify-content: space-between;
+  align-content: center;
+  align-items: center;
+  .btn.btn-icon {
+    display: none;
+    width: grid(5);
+    height: grid(5);
+    @include iconLabelText();
+    // only show menu button by default
+    &.el-button-menu {
+      display: block;
     }
-    // hide icons
-    .header-icons .btn-icon {
-      display: none;
-    }
+  }
+  .icon {
+    width:22px;
+    height: 22px;
+    margin: 2px auto 6px;
+  }
+  // icon colors
+  .btn-icon { color: $headerButtonColor; }
+  .icon { fill: $headerButtonColor; }
+  .btn-icon.active { color: $headerActiveButtonColor; }
+  .btn-icon.active .icon { fill: $headerActiveButtonColor; }
+}
+// boost icon size on tablet+
+@media(min-width: $gtMobile) {
+  .header-icons {
+    flex:none;
+    width:grid(5);
+    height:grid(7);
+    order: 4;
     // increase menu button size and show
-    .header-icons .btn.btn-icon.el-button-menu {
+    & .btn.btn-icon.el-button-menu {
       display:flex;
       width: grid(5);
-      height: grid(7);
-      color: $color1;
       height: $headerContentHeight;
+      color: $color1;
       .icon {
         width:grid(5);
         height: grid(4.5);
         fill: $color1;
+        transition: width, height 0.4s ease;
       }
       span {
         position:relative;
         top:1px;
-        @include iconLabelFontLg();
+        @include iconLabelTextLg();
         line-height: 1;
-      }
-    }
-    // show logo
-    .header-logo {
-      order:1;
-      display:block;
-      flex: 1;
-      a { display: inline-block; line-height:1; }
-      img { 
-        width:grid(36); // 288px 
-      }
-    }
-    // show search
-    .header-search {
-      position:relative;
-      display:flex;
-      order: 2;
-      flex: 1;
-      max-width: grid(37.5);
-      margin: 0 0 0 grid(3);
-      .search {
-        width: 100%;
-      }
-      // override mobile positioning
-      &.active { 
-        position:relative; 
-        top:auto; 
-        left:auto; 
-        right: auto; 
-        padding-bottom:0;
-      }
-    }
-    // show language toggle
-    .language-select {
-      display:block;
-      margin: 0 grid(3) 0 grid(2);
-      order: 3;
-      // Vertical treatment with arrow on bottom
-      .el-select .dropdown-toggle.btn {
-        height:grid(7);
-        padding: 6px 12px;
-        text-align: center;
-        padding-right: grid(1.5)!important; // never want to add padding for down arrow
-        span {
-          position: relative;
-          top: -7px;
-        }
-        .icon {
-          top:auto;
-          left: 0;
-          bottom: 11px;
-          right: 0!important; // need to force override for vertical select
-          margin: 0 auto;
-        }
+        transition: font-size 0.4s ease;
       }
     }
   }
 }
 
-// Desktop+ Styles
+// Logo
+// ---
+.header-logo {
+  display: block;
+  flex:1;
+  img { 
+    transform-origin: 0 0;
+    transition: transform 0.4s ease;
+    width: 152px; 
+  }
+}
+// boost logo size on tablet
+@media(min-width: $gtMobile) {
+  .header-logo {
+    order:1;
+    display:block;
+    flex: 1;
+    a { display: inline-block; line-height:1; }
+    img { 
+      width:grid(31); // 248px 
+      height: 18px;
+    }
+  }
+}
+// boost size on laptop+
 @media(min-width: $gtTablet) {
-  .header-wrapper {
-    .header-logo img {
-      width: grid(40); // 320px
+  .header-logo img {
+    width: grid(40); // 320px
+    height: 24px;
+  }
+}
+
+// Language Toggle
+// ---
+.language-select {
+  display: block;
+  margin-right: grid(1);
+  width: grid(9);
+  .dropdown-toggle.btn {
+    padding: grid(1) grid(2.5) grid(1) grid(1); 
+    height: grid(5);
+    text-align:center;
+    .dropdown-value {
+      @include langSelectText();
+      position: relative;
+      top: -2px; // nudge text up so it is vertically centered
     }
-    .header-content {
-      justify-content: flex-start;
-      align-content: center;
-      align-items: center;
-    }
-    .header-search {
-      flex:1;
-      max-width: none;
-      display:flex;
-      align-items: center;
-      justify-content: flex-end;
-      margin-right: grid(1);
+    .icon { width: grid(1); right: grid(1); }
+  }
+}
+// Boost toggle size on tablet+
+@media(min-width: $gtMobile) {
+  .language-select {
+    display:block;
+    margin: 0 grid(3) 0 grid(2);
+    height: grid(7);
+    width: grid(14);
+    order: 3;
+    transition: all 0.4s ease;
+    .dropdown-toggle.btn {
+      text-align:left;
+      height: grid(7);
+      padding: grid(1) grid(3) grid(1) grid(2);
+      .dropdown-value {
+        top:auto;
+        @include langSelectTextLg();
+        transition: font-size 0.4s ease;
+      }
+      .icon {
+        width: 14px;
+        right: grid(2);
+      }
     }
   }
 }
 
 // Condensed Header
-
+// ---
 @media(min-width: $gtMobile) {
   .header-wrapper {
     transition: height 0.4s ease;
   }
-  .condensed .header-wrapper {
-    height: $headerHeightSm;
+  .condensed {
+    .header-wrapper {
+      height: $headerHeightSm;
+    }
+    .header-logo img {
+      width: grid(31); // 248px
+      height: 18px;
+    }
+    .header-search {
+      .form-control {
+        height: grid(5);
+        font-size:13px;
+      }
+    }
+    .language-select {
+      width: grid(12);
+      height: grid(5);
+      .dropdown-toggle.btn {
+        height: grid(5);
+        .dropdown-value {
+          @include defaultFont(10px);
+          top: -2px; // nudge text up so it is vertically centered
+          letter-spacing: 0.3px;
+        }
+        .icon { width: grid(1); }
+      }
+    }
+    // resize menu icon
+    .header-icons {
+      width:grid(4);
+      height:grid(5);
+      & .btn.btn-icon.el-button-menu {
+        width: grid(4);
+        height: grid(5);
+        .icon {
+          width: 22px;
+          height: 22px;
+        }
+        span {
+          top:auto;
+          @include iconLabelText();
+        }
+      }
+    }
   }
 }
-
+// scale header
+@media(min-width: $gtTablet) {
+  .condensed {
+    .header-logo img {
+      transform: scale(0.775);
+    }
+  }
+}

--- a/src/theme/base/header.scss
+++ b/src/theme/base/header.scss
@@ -215,3 +215,14 @@
   }
 }
 
+// Condensed Header
+
+@media(min-width: $gtMobile) {
+  .header-wrapper {
+    transition: height 0.4s ease;
+  }
+  .condensed .header-wrapper {
+    height: $headerHeightSm;
+  }
+}
+


### PR DESCRIPTION
Drops the header from 80px to 56px on scroll.  Also adjusts so `header.scss` has the base header site-wide styles and `header.component.scss` has the style overrides for the map tool.

Adds a `scrolledToTop$` observable that emits true when the user scrolls into the top 56px of the page, and emits `false` when they scroll past that.  