### PR TITLE
Ignore topology exceptions for highlight features

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -154,12 +154,15 @@ export class MapService {
       filter: ['==', 'GEOID', feature.properties['GEOID']]
     });
     if (queryFeatures.length > 0) {
-      return queryFeatures.reduce((currFeat, nextFeat) => {
-        return union(
-          currFeat as GeoJSON.Feature<GeoJSON.Polygon>,
-          nextFeat as GeoJSON.Feature<GeoJSON.Polygon>
-        );
-      }) as GeoJSON.Feature<GeoJSON.Polygon>;
+      // Combine features, ignoring any TopologyExceptions
+      try {
+        return queryFeatures.reduce((currFeat, nextFeat) => {
+          return union(
+            currFeat as GeoJSON.Feature<GeoJSON.Polygon>,
+            nextFeat as GeoJSON.Feature<GeoJSON.Polygon>
+          );
+        }) as GeoJSON.Feature<GeoJSON.Polygon>;
+      } catch (e) { }
     }
     return null;
   }


### PR DESCRIPTION
Small tweak, ignores any errors from the call to `union` in `getUnionFeature`. Alaska is large enough that it throws a `TopologyException` at the minimum zoom (I think because it crosses over the coordinates for longitude) which can mess up the rest of the map. 

Ignoring it seems to make the most sense, especially because the highlights change frequently anyway, and this avoids any other exceptions we run into