### PR TITLE
Fix card order

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -152,7 +152,7 @@ export class DataPanelComponent implements OnInit {
       this.tweetTranslation = 'DATA.TWEET_NO_FEATURES';
     } else {
       const sortProp = `${action}-${yearSuffix}`;
-      features = this.locations.sort((a, b) =>
+      features = [ ...this.locations ].sort((a, b) =>
         a.properties[sortProp] > b.properties[sortProp] ? -1 : 1);
 
       // TODO: Potentially pull state abbreviation into place name


### PR DESCRIPTION
I thought this would be a quick fix but it took me a looonnng time to track down! The `activeFeatures` were being passed to the data panel, which sorts the location with `.sort()` and causes the original array to be modified in place.  Switched so that we sort a copy of the locations instead of the original array.