### PR TITLE
Condensed logo fix

### DIFF
--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -245,7 +245,9 @@ app-location-cards {
     position:absolute;
     top:0;
     right:0;
-    display:block;
+    display:flex;
+    align-items: center;
+    justify-content: center;
     width: grid(5);
     height: grid(6);
     background: #fff;

--- a/src/theme/base/header.scss
+++ b/src/theme/base/header.scss
@@ -245,6 +245,8 @@
 @media(min-width: $gtTablet) {
   .condensed {
     .header-logo img {
+      width: grid(40); // 320px
+      height: 24px;
       transform: scale(0.775);
     }
   }


### PR DESCRIPTION
Logo was scaling too much in the header on large displays.  This fixes that, and adjusts the "overview" icon so it is centered in the container.