### PR TITLE
Add momentum scrolling to horizontal location cards

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -43,6 +43,7 @@ app-location-cards {
   justify-content: space-between;
   margin-top: grid(3);
   margin-bottom: grid(6);
+  -webkit-overflow-scrolling: touch;
 }
 
 // Data Panel Footer Container

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -103,6 +103,7 @@ app-location-cards {
   align-items: flex-end;
   width:100%;
   overflow:auto;
+  -webkit-overflow-scrolling: touch;
   &.no-cards {
     height: 0;
   }


### PR DESCRIPTION
(sort of) progress on #530. I remember we had talked about this, and not sure if something changed in terms of browser support, but `-webkit-overflow-scrolling` actually works on iOS Safari, Firefox, and Chrome without changing anything else. It seems like a nice backup option if we don't get to implement scroll snapping