### PR TITLE
Reset mobile vh transition on window resize

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -110,6 +110,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   onResize(e) {
     this.panelOffset =
       this.verticalOffset + this.dividerEl.nativeElement.getBoundingClientRect().bottom;
+    this.resetVhTransition();
   }
 
   /**
@@ -317,6 +318,18 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     } else {
       this.enableZoom = false;
     }
+  }
+
+  /**
+   * Toggle mobile vh transition to force a height change on resize
+   */
+  private resetVhTransition() {
+    this.map.el.nativeElement.style.transition = 'none';
+    this.map.el.nativeElement.style.height = '100vh';
+    setTimeout(() => {
+      this.map.el.nativeElement.style.height = null;
+      setTimeout(() => this.map.el.nativeElement.style.transition = null);
+    }, 350);
   }
 
 }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -215,6 +215,7 @@ export class MapComponent implements OnInit, OnChanges {
   );
 
   constructor(
+    public el: ElementRef,
     private map: MapService,
     private loader: LoadingService,
     private platform: PlatformService,


### PR DESCRIPTION
Progress on #725. Definitely a hack, but it overrides the `transition` property, updates the height (so that it actually changes), changes the height back to its default after a timeout (350 was the shortest I could make it and have it still work), and then changes the transition back

![resize-transition](https://user-images.githubusercontent.com/8291663/36993005-390c550c-2072-11e8-8c14-100274863e93.gif)
