### PR TITLE
Fix/ranking routes

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="location" class="content-inner">
-  <div class="close-button" (click)="close.emit(true)">
-    <app-ui-icon icon="close"></app-ui-icon>
-  </div>
+<div class="close-button" (click)="close.emit(true)">
+  <app-ui-icon icon="close"></app-ui-icon>
+</div>
+<div *ngIf="location && rank && dataProperty" class="content-inner">
   <button class="panel-arrow panel-prev" (click)="goToPrevious.emit(true)">
     <app-ui-icon icon="arrow-left"></app-ui-icon>
   </button>
@@ -9,9 +9,14 @@
     <div class="panel-top">
       <span class="rank-number">{{ rank }}</span>
       <div class="panel-summary-heading">
-        <h2 class="rank-location" [class.in-list]="rank <= topCount" (click)="locationClick.emit(rank)">{{ location.name }} <span>{{ location.displayParentLocation }}</span></h2>
+        <h2 class="rank-location" 
+          [class.in-list]="rank <= topCount" 
+          (click)="locationClick.emit(rank)"
+        >
+          {{ location.name }} <span>{{ location.displayParentLocation }}</span>
+        </h2>
         <span class="rank-value">{{dataProperty.name}} {{location[dataProperty.value]}}{{dataProperty.value.includes('Rate') ? '%' : '' }}</span>
-        <a href="" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
+        <a href="#" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
       </div>
     </div>
     <div class="panel-summary-content">

--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -283,8 +283,6 @@
   .rank-location { color: $color3; }
 }
 
-
-// TODO: refactor so close button styles live in one place
 .close-button {
   cursor: pointer;
   text-align: center;
@@ -294,8 +292,9 @@
   box-shadow: $z1shadow;
   background-color: $rankingsBg1;
   position: absolute;
-  right: 0;
-  top: grid(-10);
+  right: $pageMargin;
+  top: -1*$pageMargin;
+  transform: translate3d(0,-100%,0);
   .icon {
     height: grid(2.5);
     width: grid(2.5);
@@ -305,5 +304,11 @@
   &:hover, &:active {
     background-color: $color1;
     .icon { fill: $white; }
+  }
+}
+@media(min-width: $gtMobile) {
+  .close-button {
+    top: -1*$pageMarginLg;
+    right: $pageMarginLg;
   }
 }

--- a/src/app/ranking/ranking-panel/ranking-panel.component.ts
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.ts
@@ -8,7 +8,7 @@ import { RankingLocation } from '../ranking-location';
   styleUrls: ['./ranking-panel.component.scss'],
   providers: [DecimalPipe]
 })
-export class RankingPanelComponent implements OnInit {
+export class RankingPanelComponent {
   @Input() rank: number;
   @Input() topCount: number;
   @Input() location: RankingLocation;
@@ -17,9 +17,5 @@ export class RankingPanelComponent implements OnInit {
   @Output() goToNext = new EventEmitter();
   @Output() close = new EventEmitter();
   @Output() locationClick = new EventEmitter<number>();
-  constructor() { }
-
-  ngOnInit() {
-  }
 
 }

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.html
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.html
@@ -6,7 +6,7 @@
     </button>
     <app-ranking-ui class="ranking-ui-panel"
       [class.show]="showUiPanel"
-      [locationList]="fullData"
+      [locationList]="rankings.evictions"
       [regions]="rankings.regionList"
       [areaTypes]="rankings.areaTypes"
       [dataProperties]="rankings.sortProps"
@@ -24,7 +24,7 @@
       <div class="share-wrapper">
         <span class="share-intro">{{ 'RANKINGS.SHARE_VIA' | translate }}</span>
         <app-ui-social-share
-          [tweet]="getTweet()"
+          [tweet]="tweet"
           emailSubject="Eviction Lab"
         ></app-ui-social-share>
       </div>
@@ -44,8 +44,9 @@
     ></app-ranking-list>
   </div>
 </div>
-<div class="page-fixed-bottom" *ngIf="canRetrieveData && (selectedIndex || selectedIndex === 0)">
+<div class="page-fixed-bottom" [class.visible]="canRetrieveData && (selectedIndex || selectedIndex === 0)">
   <app-ranking-panel
+    *ngIf="canRetrieveData && (selectedIndex || selectedIndex === 0)"
     [class]="'area-'+areaType.value"
     [topCount]="topCount"
     [rank]="selectedIndex+1"

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.html
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.html
@@ -1,4 +1,4 @@
-<div class="content-inner content-evictions">
+<div class="content-inner content-evictions" [class.panel-open]="canRetrieveData && (selectedIndex || selectedIndex === 0)">
   <div class="ranking-ui-container">
     <button class="search-filter" (click)="showUiPanel = true">
       <app-ui-icon icon="search"></app-ui-icon>
@@ -44,7 +44,9 @@
     ></app-ranking-list>
   </div>
 </div>
-<div class="page-fixed-bottom" [class.visible]="canRetrieveData && (selectedIndex || selectedIndex === 0)">
+<div class="page-fixed-bottom" 
+  [class.visible]="canRetrieveData && (selectedIndex || selectedIndex === 0)"
+>
   <app-ranking-panel
     *ngIf="canRetrieveData && (selectedIndex || selectedIndex === 0)"
     [class]="'area-'+areaType.value"

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.scss
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.scss
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.spec.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.spec.ts
@@ -46,8 +46,6 @@ export class RankingServiceStub {
   ];
   loadEvictionsData = () => {};
   setReady = (ready) => {};
-  
-
 }
 
 describe('EvictionsComponent', () => {

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.spec.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.spec.ts
@@ -33,8 +33,20 @@ export class TranslatePipeMock implements PipeTransform {
 export class RankingServiceStub {
   ready = new BehaviorSubject<boolean>(false);
   isReady = this.ready.asObservable();
+  sortProps = [
+    { value: 'evictionRate', langKey: 'STATS.JUDGMENT_RATE' },
+    { value: 'evictions', langKey: 'STATS.JUDGMENTS' },
+    { value: 'filingRate', langKey: 'STATS.FILING_RATE' },
+    { value: 'filings', langKey: 'STATS.FILINGS'}
+  ];
+  areaTypes = [
+    { value: 0, langKey: 'RANKINGS.CITIES' },
+    { value: 1, langKey: 'RANKINGS.MID_SIZED_AREAS' },
+    { value: 2, langKey: 'RANKINGS.RURAL_AREAS' }
+  ];
   loadEvictionsData = () => {};
   setReady = (ready) => {};
+  
 
 }
 

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.ts
@@ -26,6 +26,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   /** string representing the region */
   @Input()
   set region(regionValue) {
+    if (!regionValue) { return; }
     if (regionValue !== this.store.region) {
       console.log('set region', regionValue, this.store.region);
       this.store.region = regionValue;
@@ -37,6 +38,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   /** ID representing the selected area type */
   @Input()
   set areaType(newType) {
+    if (!newType) { return; }
     if ((!this.store.areaType || newType.value !== this.store.areaType.value) && newType) {
       console.log('set areaType', newType, this.store.areaType);
       this.store.areaType = newType;
@@ -48,6 +50,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   /** object key representing the data property to sort by */
   @Input()
   set dataProperty(newProp) {
+    if (!newProp) { return; }
     if ((!this.store.dataProperty || newProp.value !== this.store.dataProperty.value) && newProp) {
       console.log('set dataProp', newProp, this.store.dataProperty);
       this.store.dataProperty = newProp;
@@ -76,8 +79,8 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   tweet: string;
   private store = {
     region: 'United States',
-    areaType: null,
-    dataProperty: null
+    areaType: this.rankings.areaTypes[0],
+    dataProperty: this.rankings.sortProps[0]
   };
   /** returns if all of the required params are set to be able to fetch data */
   get canRetrieveData(): boolean {
@@ -103,7 +106,10 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
     private decimal: DecimalPipe,
     private changeDetectorRef: ChangeDetectorRef,
     @Inject(DOCUMENT) private document: any
-  ) { }
+  ) {
+    this.store.areaType = this.rankings.areaTypes[0];
+    this.store.dataProperty = this.rankings.sortProps[0];
+  }
 
   ngOnInit() {
     this.loader.start('evictions');
@@ -131,9 +137,9 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   onRegionChange(newRegion: string) {
     if (this.canNavigate) {
       if (newRegion !== this.region) { this.selectedIndex = null; }
-      const newLocation = this.getCurrentNavArray();
-      newLocation[2] = newRegion;
-      this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
+      const params = this.getQueryParams();
+      params['region'] = newRegion;
+      this.router.navigate(this.getCurrentNavArray(), { queryParams: params });
     }
   }
 
@@ -143,9 +149,9 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.areaType !== null && areaType.value !== this.areaType.value) {
         this.selectedIndex = null;
       }
-      const newLocation = this.getCurrentNavArray();
-      newLocation[3] = areaType.value;
-      this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
+      const params = this.getQueryParams();
+      params['areaType'] = areaType.value;
+      this.router.navigate(this.getCurrentNavArray(), { queryParams: params });
     }
   }
 
@@ -155,22 +161,22 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.dataProperty !== null && dataProp.value !== this.dataProperty.value) {
         this.selectedIndex = null;
       }
-      const newLocation = this.getCurrentNavArray();
-      newLocation[4] = dataProp.value;
-      this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
+      const params = this.getQueryParams();
+      params['dataProperty'] = dataProp.value;
+      this.router.navigate(this.getCurrentNavArray(), { queryParams: params });
     }
   }
 
   /** Update current location */
   setCurrentLocation(locationIndex: number) {
     if (this.canNavigate) {
-      const newLocation = this.getCurrentNavArray();
+      const params = this.getQueryParams();
       if (locationIndex || locationIndex === 0) {
-        newLocation[5] = locationIndex;
+        params['selectedIndex'] = locationIndex;
       } else {
-        newLocation.splice(-1, 1);
+        params['selectedIndex'] = null;
       }
-      this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
+      this.router.navigate(this.getCurrentNavArray(), { queryParams: params });
     }
   }
 
@@ -231,7 +237,17 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private getQueryParams() {
-    return { lang: this.translate.currentLang };
+    // this.selectedIndex
+    const params = {
+      lang: this.translate.currentLang,
+      region: this.region,
+      areaType: this.areaType.value,
+      dataProperty: this.dataProperty.value
+    };
+    if (this.selectedIndex || this.selectedIndex === 0) {
+      params['selectedIndex'] = this.selectedIndex;
+    }
+    return params;
   }
 
   /**
@@ -365,14 +381,8 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   private getCurrentNavArray() {
     const routeArray =  [
       '/',
-      'evictions',
-      this.region,
-      this.areaType.value,
-      this.dataProperty.value
+      'evictions'
     ];
-    if (this.selectedIndex || this.selectedIndex === 0) {
-      routeArray.push(this.selectedIndex);
-    }
     return routeArray;
   }
 

--- a/src/app/ranking/ranking-tool/evictors/evictors.component.scss
+++ b/src/app/ranking/ranking-tool/evictors/evictors.component.scss
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/src/app/ranking/ranking-tool/evictors/evictors.component.spec.ts
+++ b/src/app/ranking/ranking-tool/evictors/evictors.component.spec.ts
@@ -33,6 +33,17 @@ export class TranslatePipeMock implements PipeTransform {
 export class RankingServiceStub {
   ready = new BehaviorSubject<boolean>(false);
   isReady = this.ready.asObservable();
+  sortProps = [
+    { value: 'evictionRate', langKey: 'STATS.JUDGMENT_RATE' },
+    { value: 'evictions', langKey: 'STATS.JUDGMENTS' },
+    { value: 'filingRate', langKey: 'STATS.FILING_RATE' },
+    { value: 'filings', langKey: 'STATS.FILINGS'}
+  ];
+  areaTypes = [
+    { value: 0, langKey: 'RANKINGS.CITIES' },
+    { value: 1, langKey: 'RANKINGS.MID_SIZED_AREAS' },
+    { value: 2, langKey: 'RANKINGS.RURAL_AREAS' }
+  ];
   loadEvictorsData = () => {};
   setReady = (ready) => {};
 }

--- a/src/app/ranking/ranking-tool/evictors/evictors.component.ts
+++ b/src/app/ranking/ranking-tool/evictors/evictors.component.ts
@@ -36,6 +36,7 @@ export class EvictorsComponent implements OnInit, OnDestroy, AfterViewInit {
   /** object key representing the data property to sort by */
   @Input()
   set dataProperty(newProp) {
+    if (!newProp) { return; }
     if (!this.store.dataProperty || newProp.value !== this.store.dataProperty.value) {
       this.store.dataProperty = newProp;
       this.updateEvictorsList();
@@ -82,7 +83,9 @@ export class EvictorsComponent implements OnInit, OnDestroy, AfterViewInit {
     private translatePipe: TranslatePipe,
     private decimal: DecimalPipe,
     @Inject(DOCUMENT) private document: any
-  ) { }
+  ) {
+    this.store.dataProperty = this.rankings.sortProps[0];
+  }
 
   ngOnInit() {
     this.loader.start('evictors');
@@ -118,9 +121,9 @@ export class EvictorsComponent implements OnInit, OnDestroy, AfterViewInit {
   /** Update the sort property when the area type changes */
   onDataPropertyChange(dataProp: { value: string }) {
     if (this.canNavigate) {
-      const newLocation = this.getCurrentNavArray();
-      newLocation[2] = dataProp.value;
-      this.router.navigate(newLocation, { queryParams: this.getQueryParams() });
+      const params = this.getQueryParams();
+      params['dataProperty'] = dataProp.value;
+      this.router.navigate(this.getCurrentNavArray(), { queryParams: params });
     }
   }
 
@@ -129,7 +132,10 @@ export class EvictorsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private getQueryParams() {
-    return { lang: this.translate.currentLang };
+    return {
+      lang: this.translate.currentLang,
+      dataProperty: this.dataProperty
+    };
   }
 
   /**
@@ -141,11 +147,7 @@ export class EvictorsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private getCurrentNavArray() {
-    const route = [ '/', 'evictors', this.dataProperty.value ];
-    if (this.place) {
-      route.push(this.place);
-    }
-    return route;
+    return [ '/', 'evictors' ];
   }
 
   /**

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -14,7 +14,7 @@
       </ul>
     </div>
   </div>
-  <div class="page-content">
+  <div class="page-content" #content>
     <app-evictions
       class="ranking-component"
       *ngIf="activeTab === 'evictions'"
@@ -29,7 +29,12 @@
       [dataProperty]="dataProperty"
     ></app-evictors>
   </div>
-  <div *ngIf="showScrollButton" class="scroll-to-top-button" (click)="scrollToTop()">
+  <div 
+    class="scroll-to-top-button"
+    [class.visible]="showScrollButton"
+    [class.panel-open]="selectedIndex && activeTab === 'evictions'"
+    (click)="scrollToTop()"
+  >
     <app-ui-icon icon="arrow-up"></app-ui-icon>
   </div>
 </div>

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -2,6 +2,9 @@
 
 $navBarHeight: grid(8);
 $sidePanelHeight: grid(55);
+$panelHeightSm: 181px;
+$panelHeightMd: 188px;
+$panelHeightLg: 194px;
 
 // add margin so header doesn't overlap page content
 .ranking-page {
@@ -33,6 +36,11 @@ $sidePanelHeight: grid(55);
   .page-content .ranking-component > .content-inner {
     padding: grid(6) $pageMarginLg;
   }
+}
+
+.content-evictions {
+  margin-bottom: -1*$panelHeightSm;
+  &.panel-open { margin-bottom: 0; }
 }
 
 .hero {
@@ -296,9 +304,7 @@ app-ranking-ui.ranking-ui-panel {
   }
 }
 
-$panelHeightSm: 181px;
-$panelHeightMd: 188px;
-$panelHeightLg: 194px;
+
 
 // bottom data panel
 .page-fixed-bottom {
@@ -311,6 +317,7 @@ $panelHeightLg: 194px;
   background: $white;
   z-index:21;
   box-shadow: $z1shadow;
+  transition: transform 0.4s ease;
   transform: translate3d(0, 100%, 0);
   &.visible {
     transform: translate3d(0,0,0);

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -296,6 +296,10 @@ app-ranking-ui.ranking-ui-panel {
   }
 }
 
+$panelHeightSm: 181px;
+$panelHeightMd: 188px;
+$panelHeightLg: 194px;
+
 // bottom data panel
 .page-fixed-bottom {
   position: fixed; // fallback for IE11
@@ -303,17 +307,32 @@ app-ranking-ui.ranking-ui-panel {
   bottom:0;
   left:0;
   right:0;
+  height: $panelHeightSm;
   background: $white;
   z-index:21;
   box-shadow: $z1shadow;
+  transform: translate3d(0, 100%, 0);
+  &.visible {
+    transform: translate3d(0,0,0);
+  }
   app-ranking-panel {
     display:block;
   }
 }
 
+@media(min-width: $gtMobile) {
+  .page-fixed-bottom {
+    height: $panelHeightMd;
+  }
+}
+@media(min-width: $gtLaptop) {
+  .page-fixed-bottom {
+    height: $panelHeightLg;
+  }
+}
+
 .scroll-to-top-button {
   position: fixed;
-  position: sticky;
   cursor: pointer;
   text-align: center;
   padding: grid(1.25);
@@ -321,10 +340,22 @@ app-ranking-ui.ranking-ui-panel {
   height: grid(5);
   box-shadow: $z1shadow;
   background-color: $rankingsBg1;
-  right: grid(3);
-  bottom: grid(3);
+  right: $pageMargin;
+  bottom: $pageMargin;
   margin-left: auto;
   z-index: 2;
+  transition: transform 0.4s ease;
+  transform: translate3d(0, 200%, 0);
+  &.visible {
+    transform: translate3d(0, 0, 0);
+  }
+  &.panel-open {
+    transform: translate3d(-100%, 0, 0);
+    right: $pageMargin + grid(2);
+  }
+  &.visible.panel-open {
+    transform: translate3d(-100%, -1*$panelHeightSm, 0);
+  }
   .icon {
     width: grid(2);
     height: grid(2);
@@ -335,7 +366,24 @@ app-ranking-ui.ranking-ui-panel {
     background-color: $color1;
     .icon { fill: $white; }
   }
-  
+}
+
+@media(min-width: $gtMobile) {
+  .scroll-to-top-button {
+    right: $pageMarginLg;
+    bottom: $pageMarginLg;
+    &.panel-open {
+      right: $pageMarginLg + grid(2);
+    }
+    &.visible.panel-open {
+      transform: translate3d(-100%, -1*$panelHeightMd, 0);
+    }
+  }
+}
+@media(min-width: $gtLaptop) {
+  .scroll-to-top-button.visible.panel-open {
+    transform: translate3d(-100%, -1*$panelHeightLg, 0);
+  }
 }
 
 .share-wrapper {
@@ -366,10 +414,3 @@ app-ranking-ui.ranking-ui-panel {
   }
 }
 
-
-
-@media(min-width: $gtMobile) {
-  .scroll-to-top-button {
-    display: none;
-  }
-}

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, OnDestroy, ViewChild, Inject, ViewEncapsulation } from '@angular/core';
+import {
+  Component, OnInit, OnDestroy, ViewChild, Inject, ViewEncapsulation, ElementRef, AfterViewInit
+} from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { DOCUMENT, DecimalPipe } from '@angular/common';
@@ -20,8 +22,9 @@ import { RankingUiComponent } from '../ranking-ui/ranking-ui.component';
   providers: [TranslatePipe, DecimalPipe],
   encapsulation: ViewEncapsulation.None
 })
-export class RankingToolComponent implements OnInit, OnDestroy {
-  private ngUnsubscribe: Subject<any> = new Subject();
+export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
+  /** page content element */
+  @ViewChild('content') contentEl: ElementRef;
   /** identifier for the component so AppComponent can detect type */
   id = 'ranking-tool';
   /** tab ID for the active tab */
@@ -32,6 +35,8 @@ export class RankingToolComponent implements OnInit, OnDestroy {
   selectedIndex;
   /** Boolean of whether to show scroll to top button */
   showScrollButton = false;
+
+  private ngUnsubscribe: Subject<any> = new Subject();
 
   constructor(
     public rankings: RankingService,
@@ -53,6 +58,10 @@ export class RankingToolComponent implements OnInit, OnDestroy {
       .subscribe(this.onRouteChange.bind(this));
     this.route.queryParams.takeUntil(this.ngUnsubscribe)
       .subscribe(this.onQueryParamChange.bind(this));
+  }
+
+  ngAfterViewInit() {
+    this.setupPageScroll();
   }
 
   switchTab(id: string) {
@@ -77,7 +86,9 @@ export class RankingToolComponent implements OnInit, OnDestroy {
    * in the route, and then update the list data
    */
   onRouteChange(url) {
-    this.activeTab = url[0].path;
+    if (this.activeTab !== url[0].path) {
+      this.activeTab = url[0].path;
+    }
     if (this.activeTab === 'evictions') {
       this.region = url[1].path;
       this.areaType = this.rankings.areaTypes.find(a => a.value === parseInt(url[2].path, 10));
@@ -89,13 +100,13 @@ export class RankingToolComponent implements OnInit, OnDestroy {
   }
 
   scrollToTop() {
-    this.scroll.scrollTo('app-ranking-list');
+    this.scroll.scrollTo(this.contentEl.nativeElement);
   }
 
 
   private setupPageScroll() {
     this.scroll.defaultScrollOffset = 175;
-    const listYOffset = this.document.querySelector('app-ranking-list').getBoundingClientRect().top;
+    const listYOffset = this.contentEl.nativeElement.getBoundingClientRect().top;
     this.scroll.verticalOffset$.debounceTime(100)
       .subscribe(offset => {
         this.showScrollButton = offset > listYOffset;

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -74,6 +74,15 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   onQueryParamChange(params) {
     this.translate.use(params['lang'] || 'en');
+    if (this.activeTab === 'evictions') {
+      this.region = params['region'];
+      this.areaType =
+        this.rankings.areaTypes.find(a => a.value === parseInt(params['areaType'], 10));
+      this.dataProperty = this.rankings.sortProps.find(p => p.value === params['dataProperty']);
+      this.selectedIndex = params['selectedIndex'] ? parseInt(params['selectedIndex'], 10) : null;
+    } else if (this.activeTab === 'evictors') {
+      this.dataProperty = this.rankings.sortProps.find(p => p.value === params['dataProperty']);
+    }
   }
 
   ngOnDestroy() {
@@ -88,14 +97,6 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
   onRouteChange(url) {
     if (this.activeTab !== url[0].path) {
       this.activeTab = url[0].path;
-    }
-    if (this.activeTab === 'evictions') {
-      this.region = url[1].path;
-      this.areaType = this.rankings.areaTypes.find(a => a.value === parseInt(url[2].path, 10));
-      this.dataProperty = this.rankings.sortProps.find(p => p.value === url[3].path);
-      this.selectedIndex = url[4] ? parseInt(url[4].path, 10) : null;
-    } else if (this.activeTab === 'evictors') {
-      this.dataProperty = this.rankings.sortProps.find(p => p.value === url[1].path);
     }
   }
 

--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -35,7 +35,7 @@ export class RoutingService {
 
   private defaultViews = {
     map: `/${environment.maxYear}/auto/-136.80,20.68,-57.60,52.06`,
-    rankings: '/evictions/United%20States/0/evictionRate',
+    rankings: '/evictions',
     evictors: '/evictors/evictionRate'
   };
 
@@ -98,11 +98,8 @@ export class RoutingService {
     const appRoutes: Routes = [
       { path: 'embed/:year/:geography/:bounds', component: components.embed },
       { path: ':year/:geography/:bounds', component: components.map },
-      { path: 'evictors/:sortProp', component: components.rankings },
-      { path: 'evictions/:region/:areaType/:sortProp', component: components.rankings },
-      { path: 'evictions/:region/:areaType/:sortProp/:location', component: components.rankings },
-      { path: 'evictions', redirectTo: this.defaultViews.rankings },
-      { path: 'evictors', redirectTo: this.defaultViews.evictors },
+      { path: 'evictions', component: components.rankings  },
+      { path: 'evictors', component: components.rankings },
       { path: '', redirectTo: defaultRoute, pathMatch: 'full' } // default route based on URL path
     ];
     // reset router with dynamic routes


### PR DESCRIPTION
  - Changes ranking routing to user query params instead or route params.  This change is required to fix #699, which was caused by the component being re-initialized by the route changes.  Using query params does not re-initialize the component when updates are made. (closes #699)
  - Animates ranking location panel into view (closes #750 )
  - Re-adds the scroll to top button, places it beside the "close" button when the data panel is open. 