### PR TITLE
Set up production deployment at sub paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,38 +25,15 @@ before_deploy:
 - export PATH=$PATH:$HOME/.local/bin
 deploy:
 - skip_cleanup: true
-  provider: s3
-  access_key_id: $AWS_KEY
-  secret_access_key: $AWS_SECRET
-  bucket: eviction-maps-prod
-  region: us-east-2
-  acl: public_read
-  local_dir: dist
+  provider: script
+  script: ./build/deploy.sh
   on:
     branch: master
-- provider: script
-  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_PROD --paths="/*"
-  on:
-    branch: master
-- skip_cleanup: true
-  provider: s3
-  access_key_id: $AWS_KEY
-  secret_access_key: $AWS_SECRET
-  region: us-east-2
-  bucket: eviction-maps
-  acl: public_read
-  local_dir: dist
-  on:
-    branch: development
-- provider: script
-  script: aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID_DEV --paths="/*"
-  on:
-    branch: development
 - skip_cleanup: true
   provider: script
-  script: bash -c "if [[ $TRAVIS_BRANCH == prototypes/* ]]; then aws s3 cp dist/ s3://eviction-lab-prototypes/${TRAVIS_BRANCH:11} --recursive --acl=public-read; fi"
+  script: ./build/deploy.sh
   on:
-    all_branches: true
+    branch: development
 notifications:
   slack:
     template:

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+TOOL_BUCKET=eviction-lab-tool-staging
+MAP_BUCKET=eviction-lab-map-staging
+RANKINGS_BUCKET=eviction-lab-rankings-staging
+CLOUDFRONT_ID=$CLOUDFRONT_ID_DEV
+
+if [ "$TRAVIS_BRANCH" = "master" ]; then
+    TOOL_BUCKET=eviction-lab-tool
+    MAP_BUCKET=eviction-lab-map
+    RANKINGS_BUCKET=eviction-lab-rankings
+    CLOUDFRONT_ID=$CLOUDFRONT_ID_PROD
+fi
+
+aws s3 cp dist/ s3://$TOOL_BUCKET/tool --acl=public-read --recursive
+aws s3 cp dist/index.html s3://$MAP_BUCKET/map/index.html --acl=public-read
+
+node ./build/update-metadata.js
+aws s3 cp dist/index.html s3://$RANKINGS_BUCKET/rankings/index.html --acl=public-read
+
+aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_ID --paths="/*"

--- a/build/update-metadata.js
+++ b/build/update-metadata.js
@@ -1,0 +1,13 @@
+// Updates rankings metadata in index.html
+const path = require('path');
+const fs = require('fs');
+const metadata = require('../src/environments/metadata');
+
+let indexStr = fs.readFileSync(path.join(__dirname + '/../dist/index.html')).toString();
+
+Object.keys(metadata.map).forEach(k => {
+  const re = new RegExp(metadata.map[k], 'g');
+  indexStr = indexStr.replace(re, metadata.rankings[k]);
+});
+
+fs.writeFileSync(path.join(__dirname, '../dist/index.html'), indexStr);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "node ./build/pre-build.js && ng build",
-    "build-prod": "node ./build/pre-build.js && ng build --prod --env=prod",
-    "build-dev": "node ./build/pre-build.js && ng build --prod --env=staging",
+    "build-prod": "node ./build/pre-build.js && ng build --prod --env=prod --base-href=/map/ --deploy-url=https://beta.evictionlab.org/tool/",
+    "build-dev": "node ./build/pre-build.js && ng build --prod --env=staging --base-href=/map/ --deploy-url=https://staging.evictionlab.org/tool/",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e --port 4000"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,7 +24,7 @@ import { ServicesModule } from './services/services.module';
 import { EmbedComponent } from './map-tool/embed/embed.component';
 
 export function createTranslateLoader(http: HttpClient) {
-  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, `${environment.deployUrl}assets/i18n/`, '.json');
 }
 
 export class CustomOption extends ToastOptions {
@@ -54,7 +54,7 @@ export class CustomOption extends ToastOptions {
       }
     }),
     ServicesModule.forRoot(),
-    RouterModule.forRoot([], { useHash: true }),
+    RouterModule.forRoot([], { useHash: !environment.production }),
     TooltipModule.forRoot(),
     ToastModule.forRoot(),
     Ng2PageScrollModule.forRoot()

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -91,7 +91,7 @@
     </div>
     <div class="footer-copyright">
       <div class="copyright-text" [innerHTML]="'FOOTER.COPYRIGHT' | translate"></div>
-      <img src="./assets/images/princeton-logo.svg" /> 
+      <img src="{{deployUrl}}assets/images/princeton-logo.svg" /> 
     </div>
   </div>
 </footer>

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input } from '@angular/core';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html'
 })
 export class FooterComponent {
+  deployUrl = environment.deployUrl;
 
   @Input() navigation: Array<any> = [];
 

--- a/src/app/header-bar/header-bar.component.html
+++ b/src/app/header-bar/header-bar.component.html
@@ -2,7 +2,7 @@
   <div class="header-content">
     <div class="header-logo">
       <a href="/">
-        <img src="./assets/images/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Home" />
+        <img src="{{deployUrl}}assets/images/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Home" />
       </a>
     </div>
     <div [class.active]="activeMenuItem === 'search'" class="header-search">

--- a/src/app/header-bar/header-bar.component.ts
+++ b/src/app/header-bar/header-bar.component.ts
@@ -2,6 +2,7 @@ import {
   Component, Input, Output, EventEmitter, HostListener, OnInit, AfterViewInit, ViewChild
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-header-bar',
@@ -24,6 +25,7 @@ export class HeaderBarComponent implements OnInit, AfterViewInit {
   @Output() selectLanguage = new EventEmitter();
   @ViewChild('pop') mapTooltip;
   tooltipEnabled = true;
+  deployUrl = environment.deployUrl;
   private state = { menuItem: null };
   get selectedLanguage() {
     return this.languageOptions.filter(l => l.id === this.translate.currentLang)[0];

--- a/src/app/map-tool/embed/embed.component.html
+++ b/src/app/map-tool/embed/embed.component.html
@@ -1,6 +1,6 @@
 <div id="embed-branding">
   <a href="/" target="_blank">
-    <img src="./assets/images/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Home" />
+    <img src="{{deployUrl}}assets/images/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Home" />
   </a>
 </div>
 <app-map

--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { MapComponent } from '../map/map/map.component';
 import * as pym from 'pym.js';
+import { environment } from '../../../environments/environment';
 
 import { MapToolService } from '../map-tool.service';
 import { MapService } from '../map/map.service';
@@ -18,10 +19,11 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class EmbedComponent implements OnInit, AfterViewInit {
   id = 'embed-map';
+  deployUrl = environment.deployUrl;
   @ViewChild(MapComponent) map;
 
   private defaultMapConfig = {
-    style: './assets/style.json',
+    style: `${environment.deployUrl}assets/style.json`,
     center: [-98.5795, 39.8283],
     zoom: 3,
     minZoom: 2,

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -47,7 +47,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   activeMenuItem; // tracks the active menu item on mobile
   helpData: string; // translated title / content for help dialog.
   private defaultMapConfig = {
-    style: './assets/style.json',
+    style: `${environment.deployUrl}assets/style.json`,
     center: [-98.5795, 39.8283],
     zoom: 3,
     minZoom: 2,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,8 +3,9 @@ import { version } from './version';
 
 export const environment = {
   production: true,
+  deployUrl: 'https://beta.evictionlab.org/tool/',
   tileBaseUrl: 'https://tiles.evictionlab.org/',
-  evictorsRankingDataUrl: './assets/MOCK_EVICTORS.csv',
+  evictorsRankingDataUrl: 'https://beta.evictionlab.org/tool/assets/MOCK_EVICTORS.csv',
   cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',
   stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/states-rankings.csv',
   usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,13 +6,13 @@ export const environment = {
   deployUrl: 'https://beta.evictionlab.org/tool/',
   tileBaseUrl: 'https://tiles.evictionlab.org/',
   evictorsRankingDataUrl: 'https://beta.evictionlab.org/tool/assets/MOCK_EVICTORS.csv',
-  cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',
-  stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/states-rankings.csv',
-  usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+  cityRankingDataUrl: 'https://beta.evictionlab.org/data/rankings/cities-rankings.csv',
+  stateRankingDataUrl: 'https://beta.evictionlab.org/data/rankings/states-rankings.csv',
+  usAverageDataUrl: 'https://beta.evictionlab.org/data/avg/us.json',
   mapboxApiKey: 'pk.' +
     'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqY20zamVpcTBwb3gzM28yb292YzM3dXoifQ.' +
     'uKgAjsMd4qkJNqEtr3XyPQ',
-  mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+  mapboxCountyUrl: 'https://beta.evictionlab.org/data/search/counties.csv',
   downloadBaseUrl: 'https://exports.evictionlab.org',
   minYear: 2000,
   maxYear: 2016,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -6,13 +6,13 @@ export const environment = {
     deployUrl: 'https://staging.evictionlab.org/tool/',
     tileBaseUrl: 'https://tiles.evictionlab.org/',
     evictorsRankingDataUrl: 'https://staging.evictionlab.org/tool/assets/MOCK_EVICTORS.csv',
-    cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',
-    stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/states-rankings.csv',
-    usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+    cityRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/cities-rankings.csv',
+    stateRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/states-rankings.csv',
+    usAverageDataUrl: 'https://staging.evictionlab.org/data/avg/us.json',
     mapboxApiKey: 'pk.' +
         'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
         '4et5d5nstXWM5P0JG67XEQ',
-    mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+    mapboxCountyUrl: 'https://staging.evictionlab.org/data/search/counties.csv',
     downloadBaseUrl: 'https://exports-dev.evictionlab.org',
     minYear: 2000,
     maxYear: 2016,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -3,8 +3,9 @@ import { version } from './version';
 
 export const environment = {
     production: true,
+    deployUrl: 'https://staging.evictionlab.org/tool/',
     tileBaseUrl: 'https://tiles.evictionlab.org/',
-    evictorsRankingDataUrl: './assets/MOCK_EVICTORS.csv',
+    evictorsRankingDataUrl: 'https://staging.evictionlab.org/tool/assets/MOCK_EVICTORS.csv',
     cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',
     stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/states-rankings.csv',
     usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,6 +7,7 @@ import { version } from './version';
 
 export const environment = {
   production: false,
+  deployUrl: './',
   tileBaseUrl: 'https://tiles.evictionlab.org/',
   evictorsRankingDataUrl: './assets/MOCK_EVICTORS.csv',
   cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,13 +10,13 @@ export const environment = {
   deployUrl: './',
   tileBaseUrl: 'https://tiles.evictionlab.org/',
   evictorsRankingDataUrl: './assets/MOCK_EVICTORS.csv',
-  cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/cities-rankings.csv',
-  stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/rankings/states-rankings.csv',
-  usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-data/avg/us.json',
+  cityRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/cities-rankings.csv',
+  stateRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/states-rankings.csv',
+  usAverageDataUrl: 'https://staging.evictionlab.org/data/avg/us.json',
   mapboxApiKey: 'pk.' +
     'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
     '4et5d5nstXWM5P0JG67XEQ',
-  mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-data/search/counties.csv',
+  mapboxCountyUrl: 'https://staging.evictionlab.org/data/search/counties.csv',
   downloadBaseUrl: 'https://exports-dev.evictionlab.org',
   minYear: 2000,
   maxYear: 2016,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,13 +10,14 @@ export const environment = {
   deployUrl: './',
   tileBaseUrl: 'https://tiles.evictionlab.org/',
   evictorsRankingDataUrl: './assets/MOCK_EVICTORS.csv',
-  cityRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/cities-rankings.csv',
-  stateRankingDataUrl: 'https://staging.evictionlab.org/data/rankings/states-rankings.csv',
-  usAverageDataUrl: 'https://staging.evictionlab.org/data/avg/us.json',
+  // tslint:disable-next-line:max-line-length
+  cityRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-tool-data/data/rankings/cities-rankings.csv',
+  stateRankingDataUrl: 'https://s3.amazonaws.com/eviction-lab-tool-data/data/rankings/states-rankings.csv',
+  usAverageDataUrl: 'https://s3.amazonaws.com/eviction-lab-tool-data/data/avg/us.json',
   mapboxApiKey: 'pk.' +
     'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
     '4et5d5nstXWM5P0JG67XEQ',
-  mapboxCountyUrl: 'https://staging.evictionlab.org/data/search/counties.csv',
+  mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-tool-data/data/search/counties.csv',
   downloadBaseUrl: 'https://exports-dev.evictionlab.org',
   minYear: 2000,
   maxYear: 2016,

--- a/src/environments/metadata.js
+++ b/src/environments/metadata.js
@@ -1,0 +1,18 @@
+module.exports = {
+    map: {
+        base: '/map/',
+        title: 'Eviction Lab: Map',
+        description: 'We’ve built the first nationwide database of evictions. Use our tools to find and compare eviction rates in your neighborhood, city, or state.',
+        facebookImg: 'https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg',
+        twitterImg: 'https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg',
+        url: 'https://d24ep4gf2mq4il.cloudfront.net/'
+    },
+    rankings: {
+        base: '/rankings/',
+        title: 'Eviction Lab: Rankings',
+        description: 'We’ve built the first nationwide database of evictions. Use our tools to find and compare eviction rates in your neighborhood, city, or state.',
+        facebookImg: 'https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg',
+        twitterImg: 'https://d24ep4gf2mq4il.cloudfront.net/assets/images/el-facebook-img.jpg',
+        url: 'https://d24ep4gf2mq4il.cloudfront.net/',
+    }
+};

--- a/src/environments/version.ts
+++ b/src/environments/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.0';
+export const version = '0.9.1';

--- a/src/index.html
+++ b/src/index.html
@@ -15,11 +15,11 @@
     })(window,document,'script','dataLayer','GTM-M955JVB');</script>
 
   <!-- Favicons / mobile icons -->
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
-  <link rel="manifest" href="/assets/manifest.json">
+  <link rel="icon" type="image/x-icon" href="https://d24ep4gf2mq4il.cloudfront.net/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://d24ep4gf2mq4il.cloudfront.net/assets/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://d24ep4gf2mq4il.cloudfront.net/assets/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://d24ep4gf2mq4il.cloudfront.net/assets/images/favicon-16x16.png">
+  <link rel="manifest" href="https://d24ep4gf2mq4il.cloudfront.net/assets/manifest.json">
   <meta name="theme-color" content="#ffffff">
 
   <!-- Custom Fonts -->

--- a/src/theme/base/typography.scss
+++ b/src/theme/base/typography.scss
@@ -1,29 +1,29 @@
 @font-face {
   font-family: "Akkurat-Bold";
-  src:url("./assets/fonts/lineto-akkurat-bold.eot");
-  src:url("./assets/fonts/lineto-akkurat-bold.eot?#iefix") format("embedded-opentype"),
-      url("./assets/fonts/lineto-akkurat-bold.woff2") format("woff2"),
-      url("./assets/fonts/lineto-akkurat-bold.woff") format("woff");
+  src:url("assets/fonts/lineto-akkurat-bold.eot");
+  src:url("assets/fonts/lineto-akkurat-bold.eot?#iefix") format("embedded-opentype"),
+      url("assets/fonts/lineto-akkurat-bold.woff2") format("woff2"),
+      url("assets/fonts/lineto-akkurat-bold.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Akkurat-Regular";
-  src:url("./assets/fonts/lineto-akkurat-regular.eot");
-  src:url("./assets/fonts/lineto-akkurat-regular.eot?#iefix") format("embedded-opentype"),
-      url("./assets/fonts/lineto-akkurat-regular.woff2") format("woff2"),
-      url("./assets/fonts/lineto-akkurat-regular.woff") format("woff");
+  src:url("assets/fonts/lineto-akkurat-regular.eot");
+  src:url("assets/fonts/lineto-akkurat-regular.eot?#iefix") format("embedded-opentype"),
+      url("assets/fonts/lineto-akkurat-regular.woff2") format("woff2"),
+      url("assets/fonts/lineto-akkurat-regular.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "GT-Eesti-Text-Bold";
-  src:url("./assets/fonts/GT-Eesti-Display-Bold.eot");
-  src:url("./assets/fonts/GT-Eesti-Display-Bold.eot?#iefix") format("embedded-opentype"),
-      url("./assets/fonts/GT-Eesti-Display-Bold.woff2") format("woff2"),
-      url("./assets/fonts/GT-Eesti-Display-Bold.woff") format("woff");
+  src:url("assets/fonts/GT-Eesti-Display-Bold.eot");
+  src:url("assets/fonts/GT-Eesti-Display-Bold.eot?#iefix") format("embedded-opentype"),
+      url("assets/fonts/GT-Eesti-Display-Bold.woff2") format("woff2"),
+      url("assets/fonts/GT-Eesti-Display-Bold.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Adds script and functionality for deploying the tool to /map and /rankings with separate metadata (closing #644) while sharing a common set of cached assets. Also allows for using non-hash routing (closing #194) by redirecting all errored requests to S3 buckets to the bucket's index document. Also relates to #332 since the map tool is part of the website Cloudfront distribution. I'll need to update the Cloudfront ID env vars in Travis once we're ready to go ahead with this

This may take some tweaking, and we might have to ask someone about the SEO implications of returning 404s for tool sub-paths, but it should be fine for /map and /rankings which are the only pages with unique metadata anyway