### PR TITLE
Fix footer overlapping dropdowns

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -12,5 +12,5 @@ app-header-bar {
 app-footer {
   display:block;
   position:relative;
-  z-index:997;
+  z-index:990;
 }

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -93,7 +93,7 @@ $panelHeightLg: 194px;
 @media(min-width: $gtMobile) {
   .nav-bar {
     position: sticky;
-    z-index:30;
+    z-index:998;
     top: $headerHeightSm - 1px; // fix 1px showing through
     height: grid(8);
     ul {

--- a/src/app/ranking/ranking-ui/ranking-ui.component.html
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.html
@@ -33,6 +33,7 @@
       [values]="dataProperties"
       [selectedValue]="selectedDataProperty"
       (change)="selectedDataPropertyChange.emit($event)"
+      #dataSelect
     ></app-ui-select>
   </div>
   <div class="ranking-ui-actions">

--- a/src/app/ranking/ranking-ui/ranking-ui.component.scss
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.scss
@@ -63,6 +63,10 @@ app-ui-select {
       overflow: hidden;
     }
   }
+  // keep dropdown max height low so it doesn't get overlapped by footer
+  & ::ng-deep .dropdown-menu {
+    max-height: grid(33);
+  }
 }
 
 .ranking-ui-actions {

--- a/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
@@ -2,6 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { UiModule } from '../../ui/ui.module';
 import { RankingUiComponent } from './ranking-ui.component';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { UiSelectComponent } from '../../ui/ui-select/ui-select.component';
 
 describe('RankingUiComponent', () => {
   let component: RankingUiComponent;
@@ -9,8 +11,8 @@ describe('RankingUiComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [RankingUiComponent],
-      imports: [ UiModule, TranslateModule.forRoot() ]
+      declarations: [ RankingUiComponent ],
+      imports: [ BsDropdownModule.forRoot(), UiModule, TranslateModule.forRoot() ]
     })
     .compileComponents();
   }));

--- a/src/app/ranking/ranking-ui/ranking-ui.component.ts
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.ts
@@ -1,12 +1,17 @@
-import { Component, OnInit, Input, Output, EventEmitter, ElementRef } from '@angular/core';
+import {
+  Component, OnInit, Input, Output, EventEmitter, ViewChild, ElementRef, AfterViewInit, OnDestroy
+} from '@angular/core';
 import { RankingLocation } from '../ranking-location';
+import { UiSelectComponent } from '../../ui/ui-select/ui-select.component';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/takeUntil';
 
 @Component({
   selector: 'app-ranking-ui',
   templateUrl: './ranking-ui.component.html',
   styleUrls: ['./ranking-ui.component.scss']
 })
-export class RankingUiComponent implements OnInit {
+export class RankingUiComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() locationList: Array<RankingLocation>;
   @Input() regions; // Array of regions (states) to filter by
   @Input() areaTypes; // Array of area types (rural, mid-sized, etc)
@@ -21,8 +26,36 @@ export class RankingUiComponent implements OnInit {
   @Output() applyFilters = new EventEmitter<any>();
   @Output() clearFilters = new EventEmitter<any>();
   @Output() closePanel = new EventEmitter<any>();
+  @ViewChild('dataSelect') dataPropSelect: UiSelectComponent;
+  private destroy = new Subject<any>();
+
   constructor(public el: ElementRef) { }
 
   ngOnInit() {}
+
+  ngOnDestroy() {
+    this.destroy.next();
+    this.destroy.complete();
+  }
+
+  ngAfterViewInit() {
+    // bring the z-index of the panel up when the data property dropdown opens
+    if (this.dataPropSelect) {
+      this.dataPropSelect.dropdown.isOpenChange
+        .takeUntil(this.destroy)
+        .subscribe(isOpen => {
+          this.togglePanelOnTop(isOpen);
+        });
+    }
+  }
+
+  /** Boost the z-index of the panel so it is above other elements */
+  private togglePanelOnTop(moveOnTop: boolean) {
+    if (moveOnTop) {
+      this.el.nativeElement.parentElement.style.zIndex = 997;
+    } else {
+      this.el.nativeElement.parentElement.style.zIndex = null;
+    }
+  }
 
 }


### PR DESCRIPTION
Sets a max height on the ranking ui panel dropdowns so they don't go into the footer.  Fixes #730 and also seems to fix #729 

![image](http://g.recordit.co/JZt1ABxPkU.gif)