### PR TITLE
hide horizontal overflow on map only

### DIFF
--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -1,5 +1,9 @@
 @import '../../theme';
 
+::ng-deep {
+  html { overflow-x: hidden; }
+}
+
 // Page Layout
 .app-wrapper {
   min-height:100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -20,9 +20,6 @@
 
 // PAGE STYLES
 
-html {
-  overflow-x: hidden;
-}
 
 html, body {
   margin:0;


### PR DESCRIPTION
Move the rule that hides horizontal overflow to the map only, because it breaks sticky elements on the rankings page.