### PR TITLE
IE11 Style Fixes

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -56,6 +56,7 @@
     }
   }
   .card-heading { 
+    width: 100%;
     margin: 0; 
     @include cardHeading(16px);
   }

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -254,7 +254,10 @@ app-location-cards {
     height: grid(6);
     background: #fff;
     box-shadow: $z1shadow;
+    // make sure icon is centered (IE11)
     .icon {
+      position: absolute;
+      top:0; right:0; bottom:0; left: 0;
       margin:auto;
       width: 22px;
       height:22px;

--- a/src/app/ui/ui-social-share/ui-social-share.component.scss
+++ b/src/app/ui/ui-social-share/ui-social-share.component.scss
@@ -12,7 +12,12 @@
   a:hover {
     text-decoration: none;
   }
+  .btn {
+    position:relative;
+  }
   .btn .icon {
+    position:absolute;
+    top:0; left:0; bottom:0; right:0; // force center (IE11)
     width: grid(2.5);
     height: grid(2.5);
     fill: $grey1;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -159,3 +159,8 @@ a:focus {
 
 // force hide tooltip in header on ranking tool
 .ranking-tool .header-icons .tooltip { display: none; }
+
+/* IE10+ hide clear button on inputs */
+::-ms-clear {
+  display: none;
+}

--- a/src/theme/base/footer.scss
+++ b/src/theme/base/footer.scss
@@ -183,6 +183,7 @@ footer {
     .horizontal-logo {
       display: block;
       width: grid(31);
+      height: 18px;
     }
     .vertical-logo {
       display: none;
@@ -193,6 +194,7 @@ footer {
   .footer-logo {
     .horizontal-logo {
       width: grid(38);
+      height: 22px;
     }
   }
 }


### PR DESCRIPTION
A few IE11 style fixes:

- Fixes location header overflowing outside of the map cards (closes #574)
- Fixes icon alignment on the "feature overview" icon, as well as the data panel footer icons.
- Fixes footer layout