### PR TITLE
Update highway thickness, county bubble outline

### DIFF
--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -541,13 +541,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgba(150,150,150,0.5)",
-        "line-opacity": {
-          "stops": [
-            [ 7, 0 ],
-            [ 14, 1 ]
-          ]
-        },
+        "line-color": "rgba(150,150,150,0.9)",
         "line-width": {
           "stops": [
             [
@@ -556,7 +550,7 @@
             ],
             [
               11,
-              2
+              3
             ]
           ]
         }
@@ -790,7 +784,7 @@
           "default": 1,
           "stops": [
             [
-              2,
+              1,
               0.1
             ],
             [


### PR DESCRIPTION
Closes #501. Worth taking a look at to see what you think, but increases the thickness and opacity of highway lines so that they look like consistent shapes instead of the stringy lines we have now. Also fixed an issue with the county bubble outlines where they basically didn't show up at all at the lowest zoom

<img width="1143" alt="screen shot 2018-03-07 at 12 31 20 pm" src="https://user-images.githubusercontent.com/8291663/37110993-25b2234a-2204-11e8-8022-09e47b4d562d.png">
