### PR TITLE
Update choropleth scale assignment, values

### DIFF
--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -100,14 +100,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 10,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [10, 'rgba(215, 227, 244, 0.7)'],
-        [20, 'rgba(170, 191, 226, 0.75)'],
-        [30, 'rgba(133, 157, 204, 0.8)'],
-        [40, 'rgba(81, 101, 165, 0.85)'],
-        [50, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([10, 20, 30, 40, 50])
     }
   },
   {

--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -66,7 +66,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'default': 'rgba(0, 0, 0, 0)',
     'order': 7,
     'stops': {
-      'default': getScale([0, 25, 50, 75, 100])
+      'default': getScale([0, 15, 30, 45, 60])
     }
   },
   {
@@ -77,7 +77,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 8,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': getScale([0, 250, 500, 750, 1000])
+      'default': getScale([0, 300, 600, 900, 1200])
     }
   },
   {

--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -1,5 +1,25 @@
 import { MapDataAttribute } from './map-data-attribute';
 
+const colorScales = {
+  3: [
+    'rgba(238, 226, 239, 0.7)',
+    'rgba(137, 140, 206, 0.8)',
+    'rgba(64, 71, 124, 0.9)'
+  ],
+  5: [
+    'rgba(215, 227, 244, 0.7)',
+    'rgba(170, 191, 226, 0.75)',
+    'rgba(133, 157, 204, 0.8)',
+    'rgba(81, 101, 165, 0.85)',
+    'rgba(37, 51, 132, 0.9)'
+  ]
+};
+
+function getScale(scaleVals: Array<number>): Array<any> {
+  const nullArr = [[-1.0, 'rgba(0, 0, 0, 0)']];
+  return nullArr.concat(colorScales[scaleVals.length].map((v, i) => [scaleVals[i], v]));
+}
+
 export const DataAttributes: Array<MapDataAttribute> = [
   {
     'id': 'none',
@@ -19,52 +39,12 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'default': 'rgba(0, 0, 0, 0)',
     'order': 6,
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(238, 226, 239, 0.7)'],
-        [50000, 'rgba(137, 140, 206, 0.8)'],
-        [100000, 'rgba(64, 71, 124, 0.9)']
-      ],
-      'block-groups': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [1250, 'rgba(170, 191, 226, 0.75)'],
-        [2500, 'rgba(133, 157, 204, 0.8)'],
-        [3750, 'rgba(81, 101, 165, 0.85)'],
-        [5000, 'rgba(37, 51, 132, 0.9)']
-      ],
-      'tracts': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [2500, 'rgba(170, 191, 226, 0.75)'],
-        [5000, 'rgba(133, 157, 204, 0.8)'],
-        [7500, 'rgba(81, 101, 165, 0.85)'],
-        [10000, 'rgba(37, 51, 132, 0.9)']
-      ],
-      'cities': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [250000, 'rgba(170, 191, 226, 0.75)'],
-        [500000, 'rgba(133, 157, 204, 0.8)'],
-        [750000, 'rgba(81, 101, 165, 0.85)'],
-        [1000000, 'rgba(37, 51, 132, 0.9)']
-      ],
-      'counties': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [250000, 'rgba(170, 191, 226, 0.75)'],
-        [500000, 'rgba(133, 157, 204, 0.8)'],
-        [750000, 'rgba(81, 101, 165, 0.85)'],
-        [1000000, 'rgba(37, 51, 132, 0.9)']
-      ],
-      'states': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [7500000, 'rgba(170, 191, 226, 0.75)'],
-        [15000000, 'rgba(133, 157, 204, 0.8)'],
-        [22500000, 'rgba(81, 101, 165, 0.85)'],
-        [30000000, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 50000, 100000]),
+      'block-groups': getScale([0, 1250, 2500, 3750, 5000]),
+      'tracts': getScale([0, 2500, 5000, 7500, 10000]),
+      'cities': getScale([0, 250000, 500000, 750000, 1000000]),
+      'counties': getScale([0, 250000, 500000, 750000, 1000000]),
+      'states': getScale([0, 7500000, 15000000, 22500000, 30000000])
     }
   },
   {
@@ -75,14 +55,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 5,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [5, 'rgba(170, 191, 226, 0.75)'],
-        [10, 'rgba(133, 157, 204, 0.8)'],
-        [15, 'rgba(81, 101, 165, 0.85)'],
-        [20, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 5, 10, 15, 20])
     }
   },
   {
@@ -93,14 +66,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'default': 'rgba(0, 0, 0, 0)',
     'order': 7,
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -111,14 +77,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 8,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [250, 'rgba(170, 191, 226, 0.75)'],
-        [500, 'rgba(133, 157, 204, 0.8)'],
-        [750, 'rgba(81, 101, 165, 0.85)'],
-        [1000, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 250, 500, 750, 1000])
     }
   },
   {
@@ -129,14 +88,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 9,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [50000, 'rgba(170, 191, 226, 0.75)'],
-        [100000, 'rgba(133, 157, 204, 0.8)'],
-        [150000, 'rgba(81, 101, 165, 0.85)'],
-        [200000, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 50000, 100000, 150000, 200000])
     }
   },
   {
@@ -147,14 +99,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 10,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25000, 'rgba(170, 191, 226, 0.75)'],
-        [50000, 'rgba(133, 157, 204, 0.8)'],
-        [75000, 'rgba(81, 101, 165, 0.85)'],
-        [100000, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25000, 50000, 75000, 100000])
     }
   },
   {
@@ -165,14 +110,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 11,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -183,14 +121,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 12,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -201,14 +132,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'default': 'rgba(0, 0, 0, 0)',
     'format': 'percent',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -219,14 +143,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 14,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -237,14 +154,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 15,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -255,14 +165,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 16,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -273,14 +176,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 17,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {
@@ -291,14 +187,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'order': 18,
     'default': 'rgba(0, 0, 0, 0)',
     'stops': {
-      'default': [
-        [-1.0, 'rgba(198, 204, 207, 0.6)'],
-        [0, 'rgba(215, 227, 244, 0.7)'],
-        [25, 'rgba(170, 191, 226, 0.75)'],
-        [50, 'rgba(133, 157, 204, 0.8)'],
-        [75, 'rgba(81, 101, 165, 0.85)'],
-        [100, 'rgba(37, 51, 132, 0.9)']
-      ]
+      'default': getScale([0, 25, 50, 75, 100])
     }
   },
   {


### PR DESCRIPTION
Progress on #454. Not calling it closed, because we may want to do another pass later, but adds a `getScale` function so that we aren't manually typing the values over and over again. Also updates some of the scale ranges based off of the distribution in the data.

The main thing I'm not sure of is how to update the % race distributions. Because the US is so segregated, even if the 75th percentile is only 15% for a category, that doesn't mean there aren't a significant amount of areas where it isn't closer to 90%, making a range that only went to 20% pretty useless.