### PR TITLE
Disable top evictors link

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -8,8 +8,8 @@
         <li [class.active]="activeTab === 'evictions'">
           <a (click)="switchTab('evictions')">{{ 'RANKINGS.TOP_EVICTING_AREAS' | translate }}</a>
         </li>
-        <li [class.active]="activeTab === 'evictors'">
-          <a (click)="switchTab('evictors')">{{ 'RANKINGS.TOP_EVICTORS' | translate }}</a>
+        <li class="disabled">
+          <a disabled>{{ 'RANKINGS.TOP_EVICTORS' | translate }} ({{ 'RANKINGS.COMING_SOON' | translate }})</a>
         </li>
       </ul>
     </div>

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -82,7 +82,9 @@ $panelHeightLg: 194px;
           text-decoration: none;
         }
       }
-      &.active {
+      /* Temporarily disabling top evictors */
+      &.disabled { a:hover { color: $grey1a; } }
+      &.active:not(.disabled) {
         a { color: $color1; }
       }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -143,6 +143,7 @@
     "EVICTION_RANKINGS": "Eviction Rankings",
     "TOP_EVICTING_AREAS": "Top Evicting Areas",
     "TOP_EVICTORS": "Top Evictors",
+    "COMING_SOON": "Coming Soon",
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} evictions in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -132,6 +132,7 @@
     "RANKING_BY": "Ranking By",
     "TOP_EVICTING_AREAS": "Top Evicting Areas",
     "TOP_EVICTORS": "Top Evictors",
+    "COMING_SOON": "Coming Soon",
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",


### PR DESCRIPTION
Closes #765. I just removed the link and changed the styles rather than actually removing any functionality, so something can theoretically still manually go to the route. I can disable that entirely if it makes sense, but it seemed like overkill.

On hover:
<img width="446" alt="screen shot 2018-03-07 at 3 12 21 pm" src="https://user-images.githubusercontent.com/8291663/37118490-0a07267a-221a-11e8-9718-2fc2ca020f78.png">

