### PR TITLE
Fix hash routing specific code for embed

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -187,7 +187,13 @@ export class DataPanelComponent implements OnInit {
   }
 
   getEmbedUrl() {
-    const splitUrl = this.platform.currentUrl().split('#');
-    return [splitUrl[0], '#/embed', ...splitUrl.slice(1)].join('');
+    const url = this.platform.currentUrl();
+    if (url.includes('#')) {
+      const splitUrl = url.split('#');
+      return [splitUrl[0], '#/embed', ...splitUrl.slice(1)].join('');
+    } else {
+      const splitUrl = url.split('/map/');
+      return [splitUrl[0], '/map/embed/', ...splitUrl.slice(1)].join('');
+    }
   }
 }

--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -107,16 +107,18 @@ export class RoutingService {
   }
 
   /**
-   * Pym.js uses window.location.search which is overriden by the current hash routing.
-   * We need to place it back without triggering a page refresh in order for elements to
-   * resize correctly
+   * Pym.js uses window.location.search which is overriden by hash routing.
+   * We need to place it back if hash routing is used without triggering
+   * a page refresh in order for elements to resize correctly
    */
   updatePymSearch() {
     const location = this.platform.nativeWindow.location;
-    const newUrl = location.origin + this.pymSearchStr + location.hash;
-    this.platform.nativeWindow.history.replaceState(
-      {}, this.platform.nativeWindow.document.title, newUrl
-    );
+    if (location.hash) {
+      const newUrl = location.origin + this.pymSearchStr + location.hash;
+      this.platform.nativeWindow.history.replaceState(
+        {}, this.platform.nativeWindow.document.title, newUrl
+      );
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #771. Leaves hash routing code in for prototypes and on the off chance we need to bring it back, but checks if a hash exists first