### PR TITLE
Only set doc title if translations loaded

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -107,11 +107,16 @@ export class AppComponent implements OnInit {
 
   /** Fired when a route is activated */
   onActivate(component: any) {
+    let title;
     if (component.id === 'map-tool') {
       this.mapComponent = component;
-      this.titleService.setTitle(this.translatePipe.transform('MAP.TITLE'));
+      title = this.translatePipe.transform('MAP.TITLE');
     } else if (component.id === 'ranking-tool') {
-      this.titleService.setTitle(this.translatePipe.transform('RANKINGS.TITLE'));
+      title = this.translatePipe.transform('RANKINGS.TITLE');
+    }
+    // Only set title if not empty
+    if (title) {
+      this.titleService.setTitle(title);
     }
     this.updateClassAttributes(component.id);
     const loadedData = {


### PR DESCRIPTION
Closes #774. Leave the document title as-is if translations haven't been loaded. Otherwise it's set to a blank string