### PR TITLE
Disable map hover events on iOS, Android

### DIFF
--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -172,7 +172,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.eventLayers.forEach((layer) => {
-      if (this.platform.isLargerThanMobile || this.embedded) {
+      if (!(this.platform.isIos || this.platform.isAndroid) || this.embedded) {
         this.map.on('mouseenter', layer, (ev) => this.onMouseEnterFeature(ev));
         this.map.on('mouseleave', layer, (ev) => this.onMouseLeaveFeature());
         this.map.on('mousemove', layer, (ev) => this.featureMouseMove.emit(ev));


### PR DESCRIPTION
Closes #756. iOS requires two taps to trigger any click event that also has a hover event associated (the first triggers the hover state), and we were only disabling hover events for the map on mobile screen sizes. Checking for device type now instead, since it's really tablets we're looking for here. Works when tested in BrowserStack and on physical iPad