### PR TITLE
Refactor tile data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -472,19 +472,6 @@
         }
       }
     },
-    "@turf/inside": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-4.7.3.tgz",
-      "integrity": "sha1-5KhJafKIaJGzQ7Ebg/2jCV+6VCw=",
-      "requires": {
-        "@turf/invariant": "4.7.3"
-      }
-    },
-    "@turf/invariant": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-4.7.3.tgz",
-      "integrity": "sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0="
-    },
     "@turf/meta": {
       "version": "6.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.0-beta.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@ngx-translate/http-loader": "^2.0.0",
     "@turf/area": "^5.1.5",
     "@turf/bbox": "^4.7.3",
-    "@turf/inside": "^4.7.3",
     "@turf/meta": "^6.0.0-beta.3",
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -140,7 +140,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     };
     this.analytics.trackEvent('locationSelection', selectEvent);
     // pull full data for the location
-    this.mapToolService.getTileData(feature['layer']['id'], featureLonLat, null, true)
+    this.mapToolService.getTileData(feature.properties['GEOID'] as string, featureLonLat, true)
       .subscribe(data => {
         this.mapToolService.updateLocation(data);
         this.updateRoute();
@@ -209,7 +209,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
       this.loader.start('search');
       const layerId = feature.properties['layerId'] as string;
       this.mapToolService.getTileData(
-        layerId, feature.geometry['coordinates'], feature.properties['name'] as string, true
+        feature.properties['GEOID'] as string, feature.geometry['coordinates'], true
       ).subscribe(data => {
           if (!data.properties.n) {
             this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));

--- a/src/app/map-tool/map-tool.service.spec.ts
+++ b/src/app/map-tool/map-tool.service.spec.ts
@@ -31,7 +31,7 @@ describe('MapToolService', () => {
     inject(
       [MapToolService, HttpTestingController],
       (service: MapToolService, backend: HttpTestingController) => {
-        service.getTileData('states', [50, 50], 'featureName', false).subscribe();
+        service.getTileData('17', [50, 50], false).subscribe();
         backend.expectOne((req: HttpRequest<any>) => {
           return req.url.includes('states')
             && req.method === 'GET'

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -179,9 +179,26 @@ export class MapboxComponent implements AfterViewInit {
       }
       this.map.on('click', layer, (e) => {
         if (e.features.length) {
-          this.featureClick.emit(e.features[0]);
+          const feat = e.features[0];
+          // Merge in center feature props if found so there's no delay in displaying them
+          const centerFeatures = this.queryFeatureCenter(feat);
+          if (centerFeatures.length > 0) {
+            feat.properties = { ...feat.properties, ...centerFeatures[0].properties };
+          }
+          this.featureClick.emit(feat);
         }
       });
+    });
+  }
+
+  /**
+   * Queries map for the center feature of a given polygon feature
+   * @param feat Feature to find center feature for
+   */
+  private queryFeatureCenter(feat: MapFeature) {
+    return this.map.querySourceFeatures(feat['layer']['source'], {
+      sourceLayer: `${feat['layer']['source-layer']}-centers`,
+      filter: ['==', 'GEOID', feat.properties['GEOID']]
     });
   }
 


### PR DESCRIPTION
I've been looking into the fact that eviction data is duplicated across the shape features and the centers (because initially it was difficult to combine them with the way the app is set up), and I've got it working now in a way that lets us remove all eviction data properties from the shape layer and reduce the tile size by about 15% (in local tests)

* Determines the `queryZoom` for the Mapbox tiles based on layer and area. This is necessary because the most detailed layer at zoom 10 won't always have the centers layer in the tile (even though hypothetically it should). By decreasing the zoom a bit for layers with larger shapes, we make sure that the tile will always have the centers layer.
* Uses GEOID instead of layer in URL query params for location, pulling layer from the GEOID length. It can get relatively long for tracts and block groups, but "block-groups" is the same length as block group GEOID, so it shouldn't be too bad. This is necessary because decreasing the zoom increases the amount of features returned, and it's a much faster and simpler way of making sure we get the right feature than some of the geography queries we were doing
* Queries the map for the centers data and merges it with the feature data on click to preserve the same experience of an immediate update

I've tested this locally by adding some lines that remove all eviction properties on the shape feature so that it's dependent on the centers layer, and everything seems to be working out. This should hopefully be a noticeable performance boost at least for load time