### PR TITLE
Fix scroll top button alignment

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -351,7 +351,7 @@ app-ranking-ui.ranking-ui-panel {
   background: $white;
   right: $pageMargin;
   bottom: $pageMargin;
-  margin:  -1*grid(8) 0 grid(2) auto;
+  margin:  -1*grid(7) 0 grid(2) auto;
   z-index: 20;
   transition: transform 0.4s ease;
   transform: translate3d(0, 250%, 0);


### PR DESCRIPTION
Fixes misalignment of scroll to top button at the bottom of the page on mobile screens

Before:
<img width="652" alt="screen shot 2018-03-12 at 9 49 26 am" src="https://user-images.githubusercontent.com/8291663/37290671-e1fee612-25da-11e8-8e25-4436d87bc46d.png">

After:
<img width="661" alt="screen shot 2018-03-12 at 9 49 53 am" src="https://user-images.githubusercontent.com/8291663/37290674-e36975ee-25da-11e8-8acd-7d8e44cd4cdf.png">