### PR TITLE
Use offsetHeight instead of 100vh in vh reset

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -336,7 +336,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   private resetVhTransition() {
     this.map.el.nativeElement.style.transition = 'none';
-    this.map.el.nativeElement.style.height = '100vh';
+    this.map.el.nativeElement.style.height = this.map.el.nativeElement.offsetHeight;
     setTimeout(() => {
       this.map.el.nativeElement.style.height = null;
       setTimeout(() => this.map.el.nativeElement.style.transition = null);


### PR DESCRIPTION
Small fix based on updates in the website repo. Sets the static element height in resetting the `vh` transition to its current offset height rather than `100vh` to prevent a small jump