### PR TITLE
Rankings Accessibility

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,17 +1,17 @@
 <div class="newsletter-signup">
   <div class="content-inner">
-    <p>Sign up to receive news about events and new features from Eviction Lab.</p>
+    <p>{{ 'FOOTER.EMAIL_SIGNUP' | translate }}</p>
     <div id="mc_embed_signup">
       <form action="//evictionlab.us16.list-manage.com/subscribe/post?u=8e16f46a586eeb4578fbfe6ba&amp;id=9c55c12d21" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate="">
         <div class="signup-form" id="mc_embed_signup_scroll">            	
-          <input value="" name="EMAIL" class="form-control light" id="mce-EMAIL" placeholder="Email Address" required="" type="email">
+          <input value="" name="EMAIL" class="form-control light" id="mce-EMAIL" [attr.placeholder]="'DATA.SIGNUP_EMAIL_LABEL' | translate" required="" type="email">
           <input style="display:none" type="checkbox" value="1" checked name="group[4647][1]" id="mce-group[4647]-4647-0">
           <input style="display:none" type="checkbox" value="2" name="group[4647][2]" id="mce-group[4647]-4647-1">
           <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
           <div style="position: absolute; left: -5000px;" aria-hidden="true">
             <input name="b_8e16f46a586eeb4578fbfe6ba_9c55c12d21" tabindex="-1" value="" type="text">
           </div>
-          <input value="Submit" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary" type="submit">
+          <input [attr.value]="'FOOTER.EMAIL_SUBSCRIBE' | translate" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary" type="submit">
         </div>
       </form>
     </div>
@@ -75,17 +75,17 @@
       <p>{{ 'FOOTER.CONNECT' | translate }}</p>
       <ul>
         <li>
-          <a class="btn btn-border dark icon" href="#">
+          <a [attr.aria-label]="'NAV.FACEBOOK' | translate" class="btn btn-border dark icon" href="https://www.facebook.com/evictionlab/" target="_blank">
             <app-ui-icon icon="facebook"></app-ui-icon>
           </a>
         </li>
         <li>
-          <a class="btn btn-border dark icon" href="#">
+          <a [attr.aria-label]="'NAV.TWITTER' | translate" class="btn btn-border dark icon" href="https://twitter.com/evictionlab" target="_blank">
             <app-ui-icon icon="twitter"></app-ui-icon>
           </a>
         </li>
         <li>
-          <a class="btn btn-border dark icon" href="https://github.com/EvictionLab/eviction-maps" target="_blank">
+          <a [attr.aria-label]="'NAV.GITHUB' | translate"  class="btn btn-border dark icon" href="https://github.com/EvictionLab/eviction-maps" target="_blank">
             <app-ui-icon icon="github"></app-ui-icon>
           </a>
         </li>
@@ -93,7 +93,7 @@
     </div>
     <div class="footer-copyright">
       <div class="copyright-text" [innerHTML]="'FOOTER.COPYRIGHT' | translate"></div>
-      <img src="{{deployUrl}}assets/images/princeton-logo.svg" /> 
+      <img src="{{deployUrl}}assets/images/princeton-logo.svg" alt="Princeton Logo" /> 
     </div>
   </div>
 </footer>

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -66,7 +66,7 @@
         <li *ngFor="let location of locations; let i = index;">
           <app-ui-icon class="legend-marker" icon="marker"></app-ui-icon>
           <span class="legend-label">{{ location.properties["n"] }}</span>
-          <app-ui-close-button class="clear-location" [attr.aria-label]="'DATA.REMOVE_LOCATION' | translate:{'name':location.properties.n}" (onPress)="locationRemoved.emit(location)"></app-ui-close-button>
+          <app-ui-close-button class="clear-location" [ariaLabel]="'DATA.REMOVE_LOCATION' | translate:{'name':location.properties.n}" (onPress)="locationRemoved.emit(location)"></app-ui-close-button>
           <p class="legend-data">
             <span>{{ getLegendValue(location, i) }}</span>
           </p>
@@ -75,7 +75,7 @@
         <li *ngIf="average" class="us-average" [class.active]="showAverage">
           <app-ui-icon class="legend-marker" icon="marker"></app-ui-icon>
           <span class="legend-label">{{ average.properties["n"] }}</span>
-          <app-ui-close-button class="clear-location"  [attr.aria-label]="(!showAverage ? 'DATA.ADD_LOCATION' : 'DATA.REMOVE_LOCATION') | translate:{'name':average.properties.n}" (onPress)="showAverage = !showAverage"></app-ui-close-button>
+          <app-ui-close-button class="clear-location"  [ariaLabel]="(!showAverage ? 'DATA.ADD_LOCATION' : 'DATA.REMOVE_LOCATION') | translate:{'name':average.properties.n}" (onPress)="showAverage = !showAverage"></app-ui-close-button>
           <p class="legend-data">
               <span>{{ getLegendValue(average, this.locations.length) }}</span>
           </p>

--- a/src/app/map-tool/feature-overview/feature-overview.component.spec.ts
+++ b/src/app/map-tool/feature-overview/feature-overview.component.spec.ts
@@ -3,8 +3,16 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FeatureOverviewComponent } from './feature-overview.component';
 import { NgxCarousel, NgxCarouselModule } from 'ngx-carousel';
 import { UiModule } from '../../ui/ui.module';
-import { TranslateModule } from '@ngx-translate/core';
 import { ModalModule, BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 describe('FeatureOverviewComponent', () => {
   let component: FeatureOverviewComponent;
@@ -19,7 +27,9 @@ describe('FeatureOverviewComponent', () => {
         ModalModule.forRoot()
       ],
       declarations: [ FeatureOverviewComponent ],
-      providers: [ BsModalService, BsModalRef ]
+      providers: [ BsModalService, BsModalRef,
+        { provide: TranslatePipe, useClass: TranslatePipeMock }
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -7,7 +7,7 @@
     <app-ui-icon class="marker" icon="marker"></app-ui-icon>
     <h1 class="card-heading">{{f.properties['n']}}</h1>
     <h2 class="card-subheading">{{f.properties['pl']}}</h2>
-    <app-ui-close-button class="card-dismiss" [attr.aria-label]="'DATA.REMOVE_LOCATION' | translate:{'name':f.properties.n}" (onPress)="dismissedCard.emit(f)"></app-ui-close-button>
+    <app-ui-close-button class="card-dismiss" [ariaLabel]="'DATA.REMOVE_LOCATION' | translate:{'name':f.properties.n}" (onPress)="dismissedCard.emit(f)"></app-ui-close-button>
   </div>
   <div class="card-content">
     <ul class="card-stats">

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -30,7 +30,7 @@
       [bottomLabel]="selectDataLevels.length < layerOptions.length ? ('MAP.ZOOM_HINT' | translate) : false"
       (change)="setGroupVisibility($event, 'dropdown')">
     </app-ui-select>
-    <button class="btn btn-icon overview z1" (click)="helpClick.emit()">
+    <button class="btn btn-icon overview z1" (click)="helpClick.emit()" [attr.aria-label]="'MAP.FEATURE_OVERVIEW_LABEL' | translate">
       <app-ui-icon icon="help"></app-ui-icon>
     </button>
   </div>

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -8,12 +8,24 @@
   </nav>
   <ul class="social-media-links">
     <li>
-      <a [attr.tabindex]="expanded ? null : -1" class="btn btn-border" href="#" target="_blank">
+      <a 
+        [attr.tabindex]="expanded ? null : -1" 
+        [attr.aria-label]="'NAV.FACEBOOK' | translate" 
+        class="btn btn-border" 
+        href="https://www.facebook.com/evictionlab/" 
+        target="_blank"
+      >
         <app-ui-icon icon="facebook"></app-ui-icon>
       </a>
     </li>
     <li>
-      <a [attr.tabindex]="expanded ? null : -1" class="btn btn-border" href="#" target="_blank">
+      <a 
+        [attr.tabindex]="expanded ? null : -1" 
+        [attr.aria-label]="'NAV.TWITTER' | translate" 
+        class="btn btn-border" 
+        href="https://twitter.com/evictionlab" 
+        target="_blank"
+      >
           <app-ui-icon icon="twitter"></app-ui-icon>
       </a>
     </li>

--- a/src/app/ranking/ranking-list/ranking-list.component.html
+++ b/src/app/ranking/ranking-list/ranking-list.component.html
@@ -5,18 +5,18 @@
   <li 
     *ngFor="let listItem of list; let i = index" 
     [class.active]="selectedIndex === i"
-    
   >
     <button
       (click)="locationSelected.emit(i)"
+      [attr.aria-label]="getAriaLabel(i+1, listItem)"
     >
       <span class="ranking-number">{{ i + 1 }}</span>
-      <div class="ranking-bar" [style.width]="''+(100*(listItem[dataProperty]/maxValue))+'%'"></div>
+      <div class="ranking-bar" [style.width]="''+(100*(listItem[dataProperty.value]/maxValue))+'%'"></div>
       <div class="ranking-content">
         <span class="ranking-name">{{ listItem[propertyMap.primary] }}</span><span class="place-separator">,</span>
         <span class="ranking-parent">{{listItem[propertyMap.secondary]}}</span>
-        <span *ngIf="listItem[dataProperty] >= 0" class="ranking-value">{{listItem[dataProperty]}}{{ dataProperty.includes('Rate') ? '%' : '' }}</span>
-        <span *ngIf="listItem[dataProperty] < 0" class="ranking-value unavailable">{{ 'DATA.UNAVAILABLE' | translate }}</span>
+        <span *ngIf="listItem[dataProperty.value] >= 0" class="ranking-value">{{listItem[dataProperty.value]}}{{ isRate ? '%' : '' }}</span>
+        <span *ngIf="listItem[dataProperty.value] < 0" class="ranking-value unavailable">{{ 'DATA.UNAVAILABLE' | translate }}</span>
       </div>
     </button>
   </li>

--- a/src/app/ranking/ranking-list/ranking-list.component.spec.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.spec.ts
@@ -1,7 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule } from '@ngx-translate/core';
 import { RankingListComponent } from './ranking-list.component';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
+import { Pipe, PipeTransform } from '@angular/core';
 
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 describe('RankingListComponent', () => {
   let component: RankingListComponent;
   let fixture: ComponentFixture<RankingListComponent>;
@@ -9,7 +16,8 @@ describe('RankingListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ TranslateModule.forRoot() ],
-      declarations: [ RankingListComponent ]
+      declarations: [ RankingListComponent ],
+      providers: [ { provide: TranslatePipe, useClass: TranslatePipeMock }]
     })
     .compileComponents();
   }));

--- a/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -23,8 +23,8 @@ export class RankingListComponent {
 
   /**
    * Gets a readable string for the provided list item
-   * @param rank 
-   * @param listItem 
+   * @param rank
+   * @param listItem
    */
   getAriaLabel(rank, listItem) {
     if (this.propertyMap.primary === 'name') {

--- a/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, ElementRef } from '@angular/core';
 import { RankingLocation } from '../ranking-location';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-ranking-list',
@@ -8,7 +9,7 @@ import { RankingLocation } from '../ranking-location';
 })
 export class RankingListComponent {
   @Input() list: Array<RankingLocation>;
-  @Input() dataProperty: string;
+  @Input() dataProperty: { value: string, name: string };
   @Input() maxValue: number;
   @Input() selectedIndex: number;
   @Input() propertyMap = {
@@ -16,6 +17,25 @@ export class RankingListComponent {
     'secondary': 'displayParentLocation'
   };
   @Output() locationSelected = new EventEmitter<number>();
+  get isRate() { return this.dataProperty.value.indexOf('Rate') > -1; }
 
-  constructor(public el: ElementRef) {}
+  constructor(public el: ElementRef, private translatePipe: TranslatePipe) {}
+
+  /**
+   * Gets a readable string for the provided list item
+   * @param rank 
+   * @param listItem 
+   */
+  getAriaLabel(rank, listItem) {
+    if (this.propertyMap.primary === 'name') {
+      // location ranking
+      return this.translatePipe.transform('RANKINGS.LOCATION_DESCRIPTION', {
+        rank: rank,
+        location: listItem[this.propertyMap['primary']] + ', '
+                + listItem[this.propertyMap['secondary']],
+        dataType: this.dataProperty.name,
+        value: listItem[this.dataProperty.value] + (this.isRate ? '%' : '')
+      });
+    }
+  }
 }

--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -1,8 +1,15 @@
-<button *ngIf="location" class="btn btn-icon close-button z1" (click)="close.emit(true)">
+<button class="btn btn-icon close-button z1" 
+  *ngIf="location"
+  [attr.aria-label]="'DATA.CLOSE_BUTTON' | translate"
+  (click)="close.emit(true)"
+>
   <app-ui-icon icon="close"></app-ui-icon>
 </button>
 <div *ngIf="location && rank && dataProperty" class="content-inner">
-  <button class="btn btn-icon panel-arrow panel-prev" (click)="goToPrevious.emit(true)">
+  <button class="btn btn-icon panel-arrow panel-prev"
+    [attr.aria-label]="'RANKINGS.PREV_LOCATION' | translate"
+    (click)="goToPrevious.emit(true)"
+  >
     <app-ui-icon icon="arrow-left"></app-ui-icon>
   </button>
   <div class="panel-summary">
@@ -16,14 +23,19 @@
           {{ location.name }} <span>{{ location.displayParentLocation }}</span>
         </h2>
         <span class="rank-value">{{dataProperty.name}} {{location[dataProperty.value]}}{{dataProperty.value.includes('Rate') ? '%' : '' }}</span>
-        <a href="#" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
+        <!-- COMING SOON
+          <a href="#" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
+        -->
       </div>
     </div>
     <div class="panel-summary-content">
       <p>{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
     </div>
   </div>
-  <button class="btn btn-icon panel-arrow panel-next" (click)="goToNext.emit(true)">
+  <button class="btn btn-icon panel-arrow panel-next"
+    [attr.aria-label]="'RANKINGS.NEXT_LOCATION' | translate"
+    (click)="goToNext.emit(true)"
+  >
     <app-ui-icon icon="arrow-right"></app-ui-icon>
   </button>
 </div>

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.html
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.html
@@ -37,7 +37,7 @@
     <app-ranking-list *ngIf="areaType && dataProperty"
       [class]="'area-'+areaType.value"
       [list]="truncatedList"
-      [dataProperty]="dataProperty.value"
+      [dataProperty]="dataProperty"
       [maxValue]="dataMax"
       [selectedIndex]="selectedIndex"
       (locationSelected)="onClickLocation($event)"

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -31,6 +31,7 @@
   </div>
   <button 
     class="btn btn-icon scroll-to-top-button z1"
+    [attr.aria-label]="'NAV.SCROLL_TO_TOP' | translate"
     [class.visible]="showScrollButton"
     [class.panel-open]="selectedIndex && activeTab === 'evictions'"
     (click)="scrollToTop()"

--- a/src/app/ranking/ranking-ui/ranking-ui.component.html
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.html
@@ -39,6 +39,6 @@
   <div class="ranking-ui-actions">
     <button class="btn btn-primary" (click)="applyFilters.emit()">Apply</button>
   </div>
-  <button class="btn btn-close" (click)="closePanel.emit()"></button>
+  <app-ui-close-button (click)="closePanel.emit()"></app-ui-close-button>
   <ng-content></ng-content>
 </div>

--- a/src/app/ranking/ranking-ui/ranking-ui.component.scss
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.scss
@@ -7,20 +7,43 @@
   height:100%;
 }
 
-.btn.btn-close {
+app-ui-close-button {
   position:absolute;
-  top:0;
-  right:0;
+  top:grid(1);
+  right:grid(2);
   width: grid(5);
   height: grid(5);
 }
 
+@media(min-width: $gtMobile) {
+  app-ui-close-button {
+    top:0;
+    right:0;
+  }
+}
+@media(min-width: $gtTablet) {
+  app-ui-close-button {
+    display:none;
+  }
+}
+
 .ranking-ui-wrapper {
+  padding-top: grid(5);
   h2 {
     @include altSmallCapsText(12px);
     line-height:1;
     margin:grid(2) 0 grid(2) 0;
     color: $grey1a;
+  }
+}
+@media(min-width: $gtMobile) {
+  .ranking-ui-wrapper {
+    padding-top: grid(4);
+  }
+}
+@media(min-width: $gtTablet) {
+  .ranking-ui-wrapper {
+    padding-top: 0;
   }
 }
 

--- a/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
+++ b/src/app/ranking/ranking-ui/ranking-ui.component.spec.ts
@@ -1,9 +1,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
 import { UiModule } from '../../ui/ui.module';
 import { RankingUiComponent } from './ranking-ui.component';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { UiSelectComponent } from '../../ui/ui-select/ui-select.component';
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 describe('RankingUiComponent', () => {
   let component: RankingUiComponent;
@@ -12,7 +21,8 @@ describe('RankingUiComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ RankingUiComponent ],
-      imports: [ BsDropdownModule.forRoot(), UiModule, TranslateModule.forRoot() ]
+      imports: [ BsDropdownModule.forRoot(), UiModule, TranslateModule.forRoot() ],
+      providers: [ { provide: TranslatePipe, useClass: TranslatePipeMock }]
     })
     .compileComponents();
   }));

--- a/src/app/ui/location-search/location-search.component.spec.ts
+++ b/src/app/ui/location-search/location-search.component.spec.ts
@@ -4,9 +4,17 @@ import { LocationSearchComponent } from './location-search.component';
 import { PredictiveSearchComponent } from '../predictive-search/predictive-search.component';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { UiModule } from '../../ui/ui.module';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
 
 import { SearchService } from '../../services/search.service';
+import { Pipe, PipeTransform } from '@angular/core';
 
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 describe('LocationSearchComponent', () => {
   let component: LocationSearchComponent;
   let fixture: ComponentFixture<LocationSearchComponent>;
@@ -21,7 +29,11 @@ describe('LocationSearchComponent', () => {
     });
     TestBed.overrideComponent(LocationSearchComponent, {
       set: {
-        providers: [ {provide: SearchService, useValue: searchServiceStub } ],
+        providers: [
+          {provide: SearchService, useValue: searchServiceStub },
+          { provide: TranslatePipe, useClass: TranslatePipeMock }
+        ]
+
       }
     })
     .compileComponents();

--- a/src/app/ui/predictive-search/predictive-search.component.html
+++ b/src/app/ui/predictive-search/predictive-search.component.html
@@ -6,10 +6,20 @@
          [typeaheadOptionField]="optionField ? optionField : null"
          [typeaheadOptionsLimit]="optionsLimit"
          (typeaheadOnSelect)="updateSelection($event)"
+         (typeaheadOnBlur)="clearSelection($event)"
          [typeaheadWaitMs]="waitMs"
          [placeholder]="placeholder"
+         [attr.aria-owns]="ariaOwns"
+         [attr.aria-expanded]="ariaExpanded"
+         [attr.aria-activedescendant]="ariaActiveDescendant"
+         autocomplete="off"
+         aria-describedby="initInstr"
+         aria-autocomplete="both"
          class="form-control">
-  <span class="clear"
-        [style.display]="selected ? 'block' : 'none'"
-        (click)="updateSelection()">&times;</span>
+  <app-ui-close-button class="clear"
+    [ariaLabel]="'HEADER.SEARCH_CLEAR' | translate"
+    [style.display]="selected ? 'block' : 'none'"
+    (click)="clearSelection()">
+  </app-ui-close-button>
+  <span id="initInstr" style="display: none;">When autocomplete results are available use up and down arrows to review and enter to select.</span>
 </div>

--- a/src/app/ui/predictive-search/predictive-search.component.html
+++ b/src/app/ui/predictive-search/predictive-search.component.html
@@ -21,5 +21,5 @@
     [style.display]="selected ? 'block' : 'none'"
     (click)="clearSelection()">
   </app-ui-close-button>
-  <span id="initInstr" style="display: none;">When autocomplete results are available use up and down arrows to review and enter to select.</span>
+  <span id="initInstr" style="display: none;">{{ 'DATA.AUTOCOMPLETE_HINT' | translate }}</span>
 </div>

--- a/src/app/ui/predictive-search/predictive-search.component.scss
+++ b/src/app/ui/predictive-search/predictive-search.component.scss
@@ -45,3 +45,10 @@
     right: 0;
   }
 }
+
+// ::ng-deep .dropdown-menu li.active a {
+//   background: none;
+// }
+// ::ng-deep .dropdown-menu li.active-override a {
+//   background: $shadingColor;
+// }

--- a/src/app/ui/predictive-search/predictive-search.component.spec.ts
+++ b/src/app/ui/predictive-search/predictive-search.component.spec.ts
@@ -6,6 +6,15 @@ import { FormsModule } from '@angular/forms';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { PredictiveSearchComponent } from './predictive-search.component';
 import { UiModule } from '../../ui/ui.module';
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 describe('PredictiveSearchComponent', () => {
   let component: PredictiveSearchComponent;
@@ -26,7 +35,8 @@ describe('PredictiveSearchComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ],
-      imports: [ FormsModule, TypeaheadModule.forRoot(), UiModule ]
+      imports: [ FormsModule, TypeaheadModule.forRoot(), UiModule ],
+      providers: [ { provide: TranslatePipe, useClass: TranslatePipeMock }]
     })
     .compileComponents();
   }));

--- a/src/app/ui/predictive-search/predictive-search.component.ts
+++ b/src/app/ui/predictive-search/predictive-search.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import {
+  Component, OnInit, Input, Output, EventEmitter, ElementRef, HostListener 
+} from '@angular/core';
 import { NgModel } from '@angular/forms';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 
@@ -16,11 +18,90 @@ export class PredictiveSearchComponent implements OnInit {
   @Input() placeholder;
   @Output() selectedChange = new EventEmitter();
   @Output() selectionChange: EventEmitter<Object> = new EventEmitter<Object>();
+  ariaOwns = 'results';
+  ariaActiveDescendant: string;
+  ariaExpanded = false;
   private typedValue: string;
+  private selectedIndex = 0;
+  private _enteredText;
+  private _keyboardSelected;
 
-  constructor() { }
+  constructor(public el: ElementRef) { }
 
   ngOnInit() { }
+
+  @HostListener('keydown', [ '$event' ]) onkeypress(e) {
+    const keys = { 'SPACE': 32, 'ENTER': 13, 'UP': 38, 'DOWN': 40, 'ESC': 27, 'TAB': 9 };
+    const items = this.el.nativeElement.querySelectorAll('.dropdown-menu li');
+    if (!items) { return; }
+    if (e.keyCode === keys['DOWN']) {
+      this.selectedIndex++;
+      if (this.selectedIndex === this.optionsLimit) { this.selectedIndex = 0; }
+      this.selected = this.stripWhitespace(items[this.selectedIndex].textContent);
+    } else if (e.keyCode === keys['UP'] && this.selectedIndex > -1) {
+      this.selectedIndex--;
+      if (this.selectedIndex === -1) { this.selectedIndex = this.optionsLimit - 1; }
+      this.selected = this.stripWhitespace(items[this.selectedIndex].textContent);
+    } else if (e.keyCode === keys['ESC']) {
+      this.clearSelection();
+    } else {
+      this.selectedIndex = 0;
+    }
+    this.updateAria();
+  }
+
+  @HostListener('click', [ '$event' ]) onClick(e) {
+    // clear keyboard selection on click
+    this.selectedIndex = 0;
+  }
+
+  updateAria() {
+    const menu = this.el.nativeElement.querySelector('.dropdown-menu');
+    if (menu) {
+      this.ariaExpanded = true;
+      menu.setAttribute('id', this.ariaOwns);
+      menu.setAttribute('role', 'listbox');
+      const items = this.el.nativeElement.querySelectorAll('.dropdown-menu li');
+      if (items && items.length > 0 && items.length > this.selectedIndex) {
+        this.ariaActiveDescendant = 'selectedOption';
+        items.forEach(i => {
+          i.removeAttribute('id');
+          i.setAttribute('aria-selected', 'false');
+          i.setAttribute('role', 'option');
+        });
+        items[this.selectedIndex].setAttribute('id', this.ariaActiveDescendant);
+        items[this.selectedIndex].setAttribute('aria-selected', 'true');
+      } else {
+        this.ariaActiveDescendant = null;
+      }
+    } else {
+      this.ariaExpanded = false;
+    }
+  }
+
+  /**
+   * ngx-bootstrap typeahead automatically sets the "active" class on the first
+   * item, but we only want it selected if the user goes to it specifically.  In
+   * this component, we maintain a `selectedIndex` property that indicates which
+   * item should be active.
+   */
+  overrideActiveItem(items) {
+    items.forEach(el => { el.className = ''; });
+    if (this.selectedIndex > -1 && items[this.selectedIndex]) {
+      items[this.selectedIndex].className = 'active-override';
+    }
+  }
+
+  /** Strip any whitespace characters from text */
+  stripWhitespace(text: string) {
+    return text.replace(/[\n\r]+|[\s]{2,}/g, ' ').trim();
+  }
+
+  /** Reset the selected index and value on blur */
+  clearSelection(e?) {
+    this.selectedIndex = 0;
+    this.selected = null;
+  }
 
   /**
    * Updates the ngModel value and emits it for parent components
@@ -40,11 +121,18 @@ export class PredictiveSearchComponent implements OnInit {
    * @param selection object returned from selection
    */
   updateSelection(selection: TypeaheadMatch = null) {
-    this.selected = selection;
+    this.selected = selection.value;
     this.selectionChange.emit({
       selection: selection ? selection.item : selection,
       queryTerm: this.typedValue
     });
+    // clear the selection after selected and emitted
+    setTimeout(() => { this.selected = null; }, 1000);
+  }
+
+  /** Gets the option that matches the item selected with the keyboard */
+  getKeyboardSelection() {
+    return this.options.find(item => item[this.optionField] === this._keyboardSelected);
   }
 
   /**

--- a/src/app/ui/predictive-search/predictive-search.component.ts
+++ b/src/app/ui/predictive-search/predictive-search.component.ts
@@ -31,7 +31,7 @@ export class PredictiveSearchComponent implements OnInit {
   ngOnInit() { }
 
   @HostListener('keydown', [ '$event' ]) onkeypress(e) {
-    const keys = { 'SPACE': 32, 'ENTER': 13, 'UP': 38, 'DOWN': 40, 'ESC': 27, 'TAB': 9 };
+    const keys = { 'UP': 38, 'DOWN': 40, 'ESC': 27 };
     const items = this.el.nativeElement.querySelectorAll('.dropdown-menu li');
     if (!items) { return; }
     if (e.keyCode === keys['DOWN']) {
@@ -55,6 +55,7 @@ export class PredictiveSearchComponent implements OnInit {
     this.selectedIndex = 0;
   }
 
+  /** Sets or updates the appropriate aria values on the predictive search */
   updateAria() {
     const menu = this.el.nativeElement.querySelector('.dropdown-menu');
     if (menu) {
@@ -121,18 +122,13 @@ export class PredictiveSearchComponent implements OnInit {
    * @param selection object returned from selection
    */
   updateSelection(selection: TypeaheadMatch = null) {
-    this.selected = selection.value;
+    this.selected = selection ? selection.value : selection;
     this.selectionChange.emit({
       selection: selection ? selection.item : selection,
       queryTerm: this.typedValue
     });
     // clear the selection after selected and emitted
-    setTimeout(() => { this.selected = null; }, 1000);
-  }
-
-  /** Gets the option that matches the item selected with the keyboard */
-  getKeyboardSelection() {
-    return this.options.find(item => item[this.optionField] === this._keyboardSelected);
+    this.selected = null;
   }
 
   /**

--- a/src/app/ui/predictive-search/predictive-search.component.ts
+++ b/src/app/ui/predictive-search/predictive-search.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, OnInit, Input, Output, EventEmitter, ElementRef, HostListener 
+  Component, OnInit, Input, Output, EventEmitter, ElementRef, HostListener
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';

--- a/src/app/ui/ui-close-button/ui-close-button.component.html
+++ b/src/app/ui/ui-close-button/ui-close-button.component.html
@@ -1,4 +1,4 @@
-<button class="btn btn-icon" (click)="onPress.emit()">
+<button class="btn btn-icon" (click)="onPress.emit()" [attr.aria-label]="ariaLabel">
   <app-ui-icon icon="close"></app-ui-icon>
   <span *ngIf="label">{{ label }}</span>
 </button>

--- a/src/app/ui/ui-close-button/ui-close-button.component.spec.ts
+++ b/src/app/ui/ui-close-button/ui-close-button.component.spec.ts
@@ -2,6 +2,15 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { UiCloseButtonComponent } from './ui-close-button.component';
 import { UiModule } from '../ui.module';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 describe('UiCloseButtonComponent', () => {
   let component: UiCloseButtonComponent;
@@ -10,7 +19,9 @@ describe('UiCloseButtonComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ ],
-      imports: [UiModule]
+      imports: [UiModule],
+      providers: [ { provide: TranslatePipe, useClass: TranslatePipeMock }]
+
     })
     .compileComponents();
   }));

--- a/src/app/ui/ui-close-button/ui-close-button.component.ts
+++ b/src/app/ui/ui-close-button/ui-close-button.component.ts
@@ -1,11 +1,21 @@
-import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { Component, EventEmitter, Output, Input, OnInit } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-ui-close-button',
   templateUrl: './ui-close-button.component.html',
   styleUrls: ['./ui-close-button.component.scss']
 })
-export class UiCloseButtonComponent {
+export class UiCloseButtonComponent implements OnInit {
   @Input() label;
+  @Input() ariaLabel;
   @Output() onPress = new EventEmitter();
+
+  constructor(private translatePipe: TranslatePipe) {}
+
+  ngOnInit() {
+    if (!this.ariaLabel) {
+      this.ariaLabel = this.translatePipe.transform('DATA.CLOSE_BUTTON');
+    }
+  }
 }

--- a/src/app/ui/ui-dialog/ui-dialog.component.spec.ts
+++ b/src/app/ui/ui-dialog/ui-dialog.component.spec.ts
@@ -5,6 +5,15 @@ import { FormsModule } from '@angular/forms';
 
 import { UiDialogComponent } from './ui-dialog.component';
 import { UiModule } from '../ui.module';
+import { TranslateModule, TranslatePipe } from '@ngx-translate/core';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'translate' })
+export class TranslatePipeMock implements PipeTransform {
+  transform(value: any): any {
+    return value;
+  }
+}
 
 describe('UiDialogComponent', () => {
   let component: UiDialogComponent;
@@ -14,7 +23,11 @@ describe('UiDialogComponent', () => {
     TestBed.configureTestingModule({
       imports: [ FormsModule, ModalModule.forRoot(), UiModule ],
       declarations: [ ],
-      providers: [ BsModalService, BsModalRef ]
+      providers: [
+        BsModalService,
+        BsModalRef,
+        { provide: TranslatePipe, useClass: TranslatePipeMock }
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/ui/ui-hint/ui-hint.component.html
+++ b/src/app/ui/ui-hint/ui-hint.component.html
@@ -1,3 +1,11 @@
-<button *ngIf="hint" class="hint-button" container="body" [tooltip]="hint" [triggers]="triggers" [placement]="placement" (onShown)="onTooltipShown($event)">
+<button class="hint-button" 
+  *ngIf="hint" 
+  container="body"
+  [attr.aria-label]="hint"
+  [tooltip]="hint" 
+  [triggers]="triggers" 
+  [placement]="placement" 
+  (onShown)="onTooltipShown($event)" 
+>
   <app-ui-icon icon="info"></app-ui-icon>
 </button>

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -48,7 +48,7 @@ import { UiSocialShareComponent } from './ui-social-share/ui-social-share.compon
     TooltipModule.forRoot(),
     PopoverModule.forRoot(),
     TypeaheadModule,
-    TranslateModule
+    TranslateModule.forRoot()
   ],
   declarations: [
     UiSelectComponent,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -55,7 +55,8 @@
     "SIGNUP_DESCRIPTION": "Enter your email address below to recieve the raw eviction data for the Unites States.",
     "SIGNUP_EMAIL_LABEL": "Email Address", 
     "NEWSLETTER_OPT_IN": "Subscribe to the Eviction Lab newsletter",
-    "SEND_DATA": "Send Data"
+    "SEND_DATA": "Send Data",
+    "AUTOCOMPLETE_HINT": "When autocomplete results are available use up and down arrows to review and enter to select."
   },
   "HEADER": {
     "HOME": "Home",
@@ -97,7 +98,8 @@
     "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
     "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
     "NO_DATA_ERROR": "Could not find data for location.",
-    "AUTO": "auto"
+    "AUTO": "auto",
+    "FEATURE_OVERVIEW_LABEL": "Show the map feature overview"
   },
   "NAV": {
     "HOME": "Home",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -107,7 +107,11 @@
     "METHODS": "Our Methodology",
     "HELP": "Help & FAQ",
     "UPDATES": "Updates",
-    "CLOSE_MENU": "Close"
+    "FACEBOOK": "Eviction Lab on Facebook",
+    "TWITTER": "Eviction Lab on Twitter",
+    "GITHUB": "Eviction Lab on Github",
+    "CLOSE_MENU": "Close",
+    "SCROLL_TO_TOP": "Scroll to top"
   },
   "OVERVIEW": {
     "SLIDE_1": "Select eviction and census data you want to view on the map",
@@ -184,7 +188,10 @@
     "LIST_SUBHEADING": "Ranked by {{dataProperty}}",
     "DATA_HINT": "Lorem ipsum",
     "AREA_HINT": "Lorem ipsum",
-    "LOCATION_DATA_UNAVAILABLE": "The data for this location is unavailable."
+    "LOCATION_DATA_UNAVAILABLE": "The data for this location is unavailable.",
+    "LOCATION_DESCRIPTION": "Rank {{rank}}: {{location}} with {{value}} {{dataType}}",
+    "NEXT_LOCATION": "Next",
+    "PREV_LOCATION": "Previous"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",
@@ -194,6 +201,8 @@
     "SHARE_EMAIL_ERROR_MESSAGE": "Please set a default mail client in your browser to use the email link.",
     "SHARE_LINK": "Share Link",
     "CONNECT": "Connect With Us",
-    "COPYRIGHT": "<p>All content &copy; 2017 Eviction Lab. All rights reserved.</p><p>Made possible by Princeton University</p>"
+    "COPYRIGHT": "<p>All content &copy; 2017 Eviction Lab. All rights reserved.</p><p>Made possible by Princeton University</p>",
+    "EMAIL_SIGNUP": "Sign up to receive news about events and new features from Eviction Lab.",
+    "EMAIL_SUBSCRIBE": "Subscribe"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -66,7 +66,8 @@
     "EN": "English",
     "ES": "Spanish",
     "SEARCH_HINT": "Search for places",
-    "MAP_HINT": "Start Here"
+    "MAP_HINT": "Start Here",
+    "SEARCH_CLEAR": "Clear entered text"
   },
   "HINTS": {
     "EVICTION_RATE": "Represents the number of evictions per 100 renter homes.",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -107,7 +107,11 @@
     "METHODS": "Our Methodology",
     "HELP": "Help & FAQ",
     "UPDATES": "Updates",
-    "CLOSE_MENU": "Close"
+    "FACEBOOK": "Eviction Lab on Facebook",
+    "TWITTER": "Eviction Lab on Twitter",
+    "GITHUB": "Eviction Lab on Github",
+    "CLOSE_MENU": "Close",
+    "SCROLL_TO_TOP": "Scroll to top"
   },
   "OVERVIEW": {
     "SLIDE_1": "Select eviction and census data you want to view on the map",
@@ -184,7 +188,10 @@
     "LIST_SUBHEADING": "Ranked by {{dataProperty}}",
     "DATA_HINT": "Lorem ipsum",
     "AREA_HINT": "Lorem ipsum",
-    "LOCATION_DATA_UNAVAILABLE": "The data for this location is unavailable."
+    "LOCATION_DATA_UNAVAILABLE": "The data for this location is unavailable.",
+    "LOCATION_DESCRIPTION": "Rank {{rank}}: {{location}} with {{value}} {{dataType}}",
+    "NEXT_LOCATION": "Next",
+    "PREV_LOCATION": "Previous"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",
@@ -192,6 +199,10 @@
     "SHARE_EMAIL": "Share via E-mail",
     "SHARE_EMAIL_ERROR": "Email Link Error",
     "SHARE_EMAIL_ERROR_MESSAGE": "Please set a default mail client in your browser to use the email link.",
-    "SHARE_LINK": "Share Link"
+    "SHARE_LINK": "Share Link",
+    "CONNECT": "Connect With Us",
+    "COPYRIGHT": "<p>All content &copy; 2017 Eviction Lab. All rights reserved.</p><p>Made possible by Princeton University</p>",
+    "EMAIL_SIGNUP": "Sign up to receive news about events and new features from Eviction Lab.",
+    "EMAIL_SUBSCRIBE": "Subscribe"
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -55,7 +55,8 @@
     "SIGNUP_DESCRIPTION": "Enter your email address below to recieve the raw eviction data for the Unites States.",
     "SIGNUP_EMAIL_LABEL": "Email Address", 
     "NEWSLETTER_OPT_IN": "Subscribe to the Eviction Lab newsletter",
-    "SEND_DATA": "Send Data"
+    "SEND_DATA": "Send Data",
+    "AUTOCOMPLETE_HINT": "When autocomplete results are available use up and down arrows to review and enter to select."
   },
   "HEADER": {
     "HOME": "Inicio",
@@ -96,7 +97,8 @@
     "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
     "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
     "NO_DATA_ERROR": "Could not find data for location.",
-    "AUTO": "auto"
+    "AUTO": "auto",
+    "FEATURE_OVERVIEW_LABEL": "Show the map feature overview"
   },
   "NAV": {
     "HOME": "Home",


### PR DESCRIPTION
Closes #620 

- Adds missing `aria` attributes on elements where it is needed
- Adds functionality to `predictive-search.component` so that items can be read by the screen reader when navigating with the keyboard.
- Adds translations for `aria` attributes
- Add proper links to social media in header / footer
- Adjust styles on `ranking-ui` so that close button doesn't overlap search for mobile / tablet