### PR TITLE
Fixes fetching tile data from search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -472,6 +472,34 @@
         }
       }
     },
+    "@turf/helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.0.1.tgz",
+      "integrity": "sha512-EQtcbwiNbkBnvxvlxcTcrwTzaq2eR4fnDVlzx/hsw5tYxDiMJfuL9goy1rDCmXxcyDnk8gCyZapYfEQWYLl1pQ=="
+    },
+    "@turf/inside": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-5.0.0.tgz",
+      "integrity": "sha1-MRk8fxQpRpv6oWxmhfVCNOWRMaA=",
+      "requires": {
+        "@turf/invariant": "5.2.0"
+      }
+    },
+    "@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        }
+      }
+    },
     "@turf/meta": {
       "version": "6.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.0-beta.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@ngx-translate/http-loader": "^2.0.0",
     "@turf/area": "^5.1.5",
     "@turf/bbox": "^4.7.3",
+    "@turf/helpers": "^6.0.1",
+    "@turf/inside": "^5.0.0",
     "@turf/meta": "^6.0.0-beta.3",
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -208,30 +208,28 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     if (feature) {
       this.loader.start('search');
       const layerId = feature.properties['layerId'] as string;
-      this.mapToolService.getTileData(
-        feature.properties['GEOID'] as string, feature.geometry['coordinates'], true
-      ).subscribe(data => {
-          if (!data.properties.n) {
-            this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
+      this.mapToolService.getSearchTileData(feature).subscribe(data => {
+        if (!data.properties.n) {
+          this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
+        } else {
+          this.mapToolService.addLocation(data);
+        }
+        const dataLevel = this.mapToolService.dataLevels.filter(l => l.id === layerId)[0];
+        if (updateMap) {
+          if (feature.hasOwnProperty('bbox')) {
+            this.mapToolService.activeMapView = feature['bbox'];
           } else {
-            this.mapToolService.addLocation(data);
+            this.map.zoomToPointFeature(feature);
           }
-          const dataLevel = this.mapToolService.dataLevels.filter(l => l.id === layerId)[0];
-          if (updateMap) {
-            if (feature.hasOwnProperty('bbox')) {
-              this.mapToolService.activeMapView = feature['bbox'];
-            } else {
-              this.map.zoomToPointFeature(feature);
-            }
-            // Wait for map to be done loading, then set data layer
-            this.map.map.isLoading$.distinctUntilChanged()
-              .debounceTime(500)
-              .filter(state => !state)
-              .first()
-              .subscribe((state) => this.map.setGroupVisibility(dataLevel));
-          }
-          this.loader.end('search');
-        });
+          // Wait for map to be done loading, then set data layer
+          this.map.map.isLoading$.distinctUntilChanged()
+            .debounceTime(500)
+            .filter(state => !state)
+            .first()
+            .subscribe((state) => this.map.setGroupVisibility(dataLevel));
+        }
+        this.loader.end('search');
+      });
     }
   }
 

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -6,6 +6,8 @@ import { TranslateService } from '@ngx-translate/core';
 import * as SphericalMercator from '@mapbox/sphericalmercator';
 import * as vt from '@mapbox/vector-tile';
 import * as Protobuf from 'pbf';
+import inside from '@turf/inside';
+import { point } from '@turf/helpers';
 import * as bbox from '@turf/bbox';
 import 'rxjs/add/observable/forkJoin';
 import * as _isEqual from 'lodash.isequal';
@@ -298,13 +300,11 @@ export class MapToolService {
    * @param lonLat array of [lon, lat]
    * @param multiYear specifies whether to merge multiple year tiles
    */
-  getTileData(
-    geoid: string, lonLat: number[], multiYear = false
-  ): Observable<MapFeature> {
+  getTileData(geoid: string, lonLat: number[], multiYear = false): Observable<MapFeature> {
     const layerId = this.geoidLayerMap[geoid.length];
     const queryZoom = this.getQueryZoom(layerId, lonLat);
     const coords = this.getXYFromLonLat(lonLat, queryZoom);
-    const parseTile = this.getParser(geoid, layerId, lonLat);
+    const parseTile = this.getParser(geoid, layerId, lonLat, queryZoom, coords);
 
     if (multiYear) {
       const tileRequests = this.tilesetYears.map((y) => {
@@ -314,6 +314,23 @@ export class MapToolService {
     } else {
       return this.requestTile(layerId, coords, queryZoom).map(parseTile);
     }
+  }
+
+  /**
+   * Takes a feature returned from search and returns associated tile data
+   * @param feat
+   */
+  getSearchTileData(feat: MapFeature): Observable<MapFeature> {
+    const layerId = feat.properties.layerId as string;
+    const lonLat = feat['center'] as number[];
+    const queryZoom = this.getQueryZoom(layerId, lonLat);
+    const coords = this.getXYFromLonLat(lonLat, queryZoom);
+
+    const parseTile = this.getSearchParser(feat, queryZoom, coords);
+    const tileRequests = this.tilesetYears.map((y) => {
+      return this.requestTile(layerId, coords, queryZoom, y).map(parseTile);
+    });
+    return Observable.forkJoin(tileRequests).map(this.mergeFeatureProperties.bind(this));
   }
 
   /**
@@ -400,10 +417,10 @@ export class MapToolService {
    * @param geoid
    * @param layerId
    * @param lonLat
+   * @param queryZoom
+   * @param coords
    */
-  private getParser(geoid, layerId, lonLat) {
-    const queryZoom = this.getQueryZoom(layerId, lonLat);
-    const coords = this.getXYFromLonLat(lonLat, queryZoom);
+  private getParser(geoid, layerId, lonLat, queryZoom, coords) {
     return (res: ArrayBuffer): MapFeature => {
       const tile = new vt.VectorTile(new Protobuf(res));
       const layer = tile.layers[layerId];
@@ -418,6 +435,68 @@ export class MapToolService {
 
       const matchFeat = features.find(f => f.properties['GEOID'] === geoid);
       const centerFeat = centerFeatures.find(f => f.properties['GEOID'] === geoid);
+
+      if (matchFeat && centerFeat) {
+        matchFeat.properties = { ...matchFeat.properties, ...centerFeat.properties };
+        return this.processMapFeature(matchFeat, layerId);
+      }
+
+      return {} as MapFeature;
+    };
+  }
+
+  /**
+   * Tile parser for MapFeature objects returned from search
+   * @param feat
+   * @param queryZoom
+   * @param coords
+   */
+  private getSearchParser(feat: MapFeature, queryZoom: number, coords: Object) {
+    const layerId = feat.properties.layerId as string;
+    const lonLat = feat['center'] as number[];
+    const pt = point(lonLat);
+
+    return (res: ArrayBuffer): MapFeature => {
+      const tile = new vt.VectorTile(new Protobuf(res));
+      const layer = tile.layers[layerId];
+      const centerLayer = tile.layers[`${layerId}-centers`];
+
+      const features = [...Array(layer.length)].fill(null).map((d, i) => {
+        return layer.feature(i).toGeoJSON(coords['x'], coords['y'], queryZoom);
+      });
+      const centerFeatures = [...Array(centerLayer.length)].fill(null).map((d, i) => {
+        return centerLayer.feature(i);
+      });
+      const containsPoint = features.filter(f => inside(pt, f));
+
+      let matchFeat, centerFeat;
+      // If looking for block groups, search only on geography
+      // otherwise search on name and geography
+      if (layerId === 'block-groups') {
+        if (containsPoint.length > 0) {
+          matchFeat = containsPoint[0];
+        } else if (features.length > 0) {
+          matchFeat = features[0];
+        }
+      } else {
+        const featName = (feat.properties['label'] as string)
+          .replace(',', '').split(' ')[0].toLowerCase();
+        const nameFilter = (f) => f.properties['n'].toLowerCase().startsWith(featName);
+
+        const containsMatchName = containsPoint.filter(nameFilter);
+        const matchesName = features.filter(nameFilter);
+
+        if (containsMatchName.length > 0) {
+          matchFeat = containsMatchName[0];
+        } else if (matchesName.length > 0) {
+          matchFeat = matchesName[0];
+        }
+      }
+
+      if (matchFeat) {
+        centerFeat = centerFeatures.find(f =>
+          f.properties['GEOID'] === matchFeat.properties['GEOID']);
+      }
 
       if (matchFeat && centerFeat) {
         matchFeat.properties = { ...matchFeat.properties, ...centerFeat.properties };


### PR DESCRIPTION
Closes #794. Search doesn't return `GEOID`, so it failed when we tried to query based on that. This splits out pulling tile data from search into separate functions `getSearchTileData` and `getSearchParser` to keep the main ones relatively simple