### PR TITLE
Lower zoom for cities search tile data

### DIFF
--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -577,6 +577,8 @@ export class MapToolService {
         return 4;
       case 'counties':
         return 7;
+      case 'cities':
+        return 8;
       default:
         return 10;
     }


### PR DESCRIPTION
Re-fixes #794. It looks like the issue was actually specific to New York. Because it's so large, fetching tile data from zoom 10 didn't contain the data for the centers layer. Reducing that to 8 seems to fix it for NY, and so this shouldn't be a problem for other cities