### PR TITLE
Drop resolution based classes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,9 +37,6 @@ export class AppComponent implements OnInit {
   @HostBinding('class.ios') ios = false;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
-  largerThanMobile: boolean;
-  largerThanTablet: boolean;
-  largerThanSmallDesktop: boolean;
   currentMenuItem: string;
   menuActive = false;
   siteNav = [
@@ -95,7 +92,6 @@ export class AppComponent implements OnInit {
     this.translate.onLangChange.subscribe((lang) => {
       this.updateLanguage(lang.translations);
     });
-    this.onWindowResize();
     // Add user agent-specific classes
     this.ios = this.platform.isIos;
     this.iosSafari = this.platform.isIosSafari;
@@ -187,13 +183,6 @@ export class AppComponent implements OnInit {
     }
     // forward to map component
     return this.mapComponent.onSearchSelect.apply(this.mapComponent, arguments);
-  }
-
-  /** Sets the booleans that determine the classes on the app component */
-  @HostListener('window:resize') onWindowResize() {
-    this.largerThanMobile = this.platform.isLargerThanMobile;
-    this.largerThanTablet = this.platform.isLargerThanTablet;
-    this.largerThanSmallDesktop = this.platform.isLargerThanSmallDesktop;
   }
 
   /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,12 +34,12 @@ export class AppComponent implements OnInit {
   @HostBinding('class.ranking-tool') isRankingTool: boolean;
   @HostBinding('class.map-tool') isMapTool: boolean;
   @HostBinding('class.embed') embed: boolean;
-  @HostBinding('class.gt-mobile') largerThanMobile: boolean;
-  @HostBinding('class.gt-tablet') largerThanTablet: boolean;
-  @HostBinding('class.gt-laptop') largerThanSmallDesktop: boolean;
   @HostBinding('class.ios') ios = false;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
+  largerThanMobile: boolean;
+  largerThanTablet: boolean;
+  largerThanSmallDesktop: boolean;
   currentMenuItem: string;
   menuActive = false;
   siteNav = [

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -9,11 +9,11 @@
   p { margin:0; }
 }
 // increase header spacing for devices larger than mobile
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   .data-header { padding: grid(4) 0 grid(2); }
 }
 // increase spacing for devices larger than tablet
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   .data-header { padding: grid(8) 0 grid(4); }
 }
 
@@ -57,7 +57,7 @@ app-location-cards {
   justify-content: space-around;
   margin-bottom: grid(5);
 }
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   .data-panel-footer {
     flex-direction: row;
     align-items: flex-start;

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -114,8 +114,10 @@
   }
 }
 // increase page margin for toggle on tablet+
-:host-context(.gt-mobile) .graph-type-toggle {
-  right: $pageMarginLg;
+@media(min-width: $gtMobile) { 
+  .graph-type-toggle {
+    right: $pageMarginLg;
+  }
 }
 // graph style
 .graph-area { 
@@ -231,7 +233,7 @@
   }
 }
 
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   .graph-header {
     height: grid(11);
     .graph-header-inner {
@@ -281,7 +283,7 @@
     }
   }
 }
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   .graph-container {
     position:relative;
     padding-top: grid(11);
@@ -318,8 +320,8 @@
     }
   }
 }
-
-:host-context(.gt-laptop) {
+// boost legend margins on desktop+
+@media(min-width: $gtLaptop) {
   .graph-legend {
     padding-left: grid(5);
     padding-right: grid(5);

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -198,69 +198,74 @@
   }
 }
 // split cards across viewport on devices larger than mobile 
-.gt-mobile .map-ui-wrapper :host-context {
-  .location-card { 
-    width: 100%; 
-    min-width: grid(35); 
-    .card-content li { 
-      max-width: 30%;
+@media(min-width: $gtMobile) {
+  :host-context(.map-ui-wrapper) {
+    .location-card { 
+      width: 100%; 
+      min-width: grid(35); 
+      .card-content li { 
+        max-width: 30%;
+      }
     }
   }
-}
+} 
 // tablet and larger displays:
-.gt-tablet .map-ui-wrapper :host-context {
-  box-shadow:none;
-  // drop card width
-  .location-card {
-    width: $cardWidth;
-    min-width: $cardWidth;
-    // align header text at the bottom of the header
-    .card-header {
-      justify-content: flex-end; 
-    }
-    // increase font sizes
-    .card-heading { 
-      @include cardHeading($cardHeadingSize);
-    }
-    .card-subheading {
-      margin: grid(1) 0 0 0;     
-      @include smallCapsText($cardSubheadingSize);
-    }
-    // stacked statistics
-    .card-content {
-      position: static;
-      padding: $defaultPadding;
-      li {
-        max-width: none;
-        float: none;
-        margin-right: 0;
-
-        span {
-          overflow: visible;
-          white-space: normal;
-        }
+@media(min-width: $gtTablet) {
+  :host-context(.map-ui-wrapper) {
+    box-shadow:none;
+    // drop card width
+    .location-card {
+      width: $cardWidth;
+      min-width: $cardWidth;
+      // align header text at the bottom of the header
+      .card-header {
+        justify-content: flex-end; 
       }
-      .card-stat-label {
-        font-size: $cardLabelTextSize;
-        // align hint button with text
-        .attribute-hint ::ng-deep .hint-button svg {
-          margin-top:2px;
-        }
+      // increase font sizes
+      .card-heading { 
+        @include cardHeading($cardHeadingSize);
       }
-      .card-stat-value {
-        @include numberFont($cardValueTextSize);
-        &.unavailable {
-          @include defaultFont($cardValueTextSize);
-        }
+      .card-subheading {
+        margin: grid(1) 0 0 0;     
+        @include smallCapsText($cardSubheadingSize);
       }
-      // override for eviction rate to place the hint button after text
-      li.er .card-stat-label .attribute-hint {
-        width: auto;
-        right: grid(4);
+      // stacked statistics
+      .card-content {
+        position: static;
+        padding: $defaultPadding;
+        li {
+          max-width: none;
+          float: none;
+          margin-right: 0;
+  
+          span {
+            overflow: visible;
+            white-space: normal;
+          }
+        }
+        .card-stat-label {
+          font-size: $cardLabelTextSize;
+          // align hint button with text
+          .attribute-hint ::ng-deep .hint-button svg {
+            margin-top:2px;
+          }
+        }
+        .card-stat-value {
+          @include numberFont($cardValueTextSize);
+          &.unavailable {
+            @include defaultFont($cardValueTextSize);
+          }
+        }
+        // override for eviction rate to place the hint button after text
+        li.er .card-stat-label .attribute-hint {
+          width: auto;
+          right: grid(4);
+        }
       }
     }
   }
 }
+
 
 // Location cards in the data panel
 // ----
@@ -428,53 +433,52 @@
 //  - Boost font sizes
 //  - Adjust margins / padding
 //  - No horizontal overflow on wrapper
-// ----
-// Workaround for multiple host contexts below
-// https://github.com/angular/angular/issues/19199
-.gt-tablet .data-wrapper :host-context {
-  overflow:none;
-  max-width: $maxContentWidth;
-  margin: auto;
-  padding: 0 $pageMarginLg grid(6);
-  .location-card {
-    margin-right: grid(4);
-    min-width: grid(39);
-    flex:1;
-    &:last-child { margin-right: 0; }
-    .card-header .marker {
-      top:0;
-      width: 40px; 
-      height: 58px;
-    }
-    .card-heading { 
-      font-size: 26px; 
-      margin-left: grid(6);
-    }
-    .card-subheading { 
-      margin-left: grid(6); 
-    }
-    .card-dismiss {
-      bottom: grid(4.5);
-    }
-    .card-stats { 
-      padding-top: grid(15); 
-      li:nth-child(1),
-      li:nth-child(2) {
-        height: grid(15);
-        .card-stat-label { font-size: $panelCardLabelTextLg_t; }
-        .card-stat-value { font-size: $panelCardLabelValueLg_t; }
+@media(min-width: $gtTablet) {
+  :host-context(.data-wrapper) {
+    overflow:none;
+    max-width: $maxContentWidth;
+    margin: auto;
+    padding: 0 $pageMarginLg grid(6);
+    .location-card {
+      margin-right: grid(4);
+      min-width: grid(39);
+      flex:1;
+      &:last-child { margin-right: 0; }
+      .card-header .marker {
+        top:0;
+        width: 40px; 
+        height: 58px;
       }
-      li:nth-child(n+3) { 
-        padding: grid(1.5) $defaultPadding; 
-        .card-stat-label,
-        .card-stat-value { font-size: $panelCardStatTextSize_t; }
+      .card-heading { 
+        font-size: 26px; 
+        margin-left: grid(6);
       }
-      li.divider .card-stat-label {
-        font-size:14px;
+      .card-subheading { 
+        margin-left: grid(6); 
       }
-    }
-    &.location-add .card-content p {
-      font-size: $cardAddLocationTextSize_t;
+      .card-dismiss {
+        bottom: grid(4.5);
+      }
+      .card-stats { 
+        padding-top: grid(15); 
+        li:nth-child(1),
+        li:nth-child(2) {
+          height: grid(15);
+          .card-stat-label { font-size: $panelCardLabelTextLg_t; }
+          .card-stat-value { font-size: $panelCardLabelValueLg_t; }
+        }
+        li:nth-child(n+3) { 
+          padding: grid(1.5) $defaultPadding; 
+          .card-stat-label,
+          .card-stat-value { font-size: $panelCardStatTextSize_t; }
+        }
+        li.divider .card-stat-label {
+          font-size:14px;
+        }
+      }
+      &.location-add .card-content p {
+        font-size: $cardAddLocationTextSize_t;
+      }
     }
   }
 }

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -32,7 +32,7 @@
 
 // Larger than mobile:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   .app-wrapper {
     app-map {
       margin-top: $headerHeightLg;
@@ -43,7 +43,7 @@
 
 // Larger than tablet:
 //    Adjust height of map / location cards to reflect large header.
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   .app-wrapper {
     &.map-active { transition: none; }
 
@@ -122,7 +122,7 @@
   }
 }
 
-:host-context(.gt-tablet) {
+@media(min-width: $gtTablet) {
   .map-overlay .btn-compare { display:block; }
   .slider-active .map-overlay {
     height: calc(100% - #{$timeSliderLg});

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -56,7 +56,7 @@ app-ui-hint.legend-hint {
   }
 }
 
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   .map-legend {
     .legend {
       left: grid(1);

--- a/src/app/ui/ui-slider/ui-slider.component.scss
+++ b/src/app/ui/ui-slider/ui-slider.component.scss
@@ -143,7 +143,7 @@
   }
 }
 
-:host-context(.gt-mobile) {
+@media(min-width: $gtMobile) {
   .slider-label {
     @include numberFont(15px);
   }


### PR DESCRIPTION
Drops styling based on resolutions based classes on `app.component` (`.gt-*`) and uses media queries for resolution based styling instead.

The `:host-context` thing seemed like a good idea initially, but the `app.component` classes aren't updated consistently on orientation change.  Using media queries is a for sure way to make sure the correct styles are applied for the current resolution, and better performance-wise.

If any more device-specific styles are needed, use the sass variables with `@media(min-width: $gtMobile) { }` instead of `:host-context(.gt-mobile) { }`.