### PR TITLE
Fix demographic divider position

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -81,12 +81,13 @@ export class DataPanelComponent implements OnInit {
 
   /** Builds the array of card attributes from the array of data attributes */
   updateCardAttributes() {
-    const dividerIndex = 11; // index where the divider is inserted
-    const divider = { id: 'divider', langKey: 'STATS.DEMOGRAPHICS' };
     // put the props in the correct order
     const cardProps = this._dataAttributes
       .filter(d => typeof d.order === 'number')
       .sort((a, b) => a.order > b.order ? 1 : -1);
+    // index where the divider is inserted, right before "percent white" (pw)
+    const dividerIndex = cardProps.findIndex(p => p.id === 'pw');
+    const divider = { id: 'divider', langKey: 'STATS.DEMOGRAPHICS' };
     // add the divider
     this.cardAttributes = [
       ...cardProps.slice(0, dividerIndex), divider, ...cardProps.slice(dividerIndex)


### PR DESCRIPTION
Looks up the index of "percent white" instead of using a hard coded index value when determining where to put the demographic divider on location cards.