### PR TITLE
Undo change to transition vh reset

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -334,7 +334,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   private resetVhTransition() {
     this.map.el.nativeElement.style.transition = 'none';
-    this.map.el.nativeElement.style.height = this.map.el.nativeElement.offsetHeight;
+    this.map.el.nativeElement.style.height = '100vh';
     setTimeout(() => {
       this.map.el.nativeElement.style.height = null;
       setTimeout(() => this.map.el.nativeElement.style.transition = null);


### PR DESCRIPTION
Undoes #791. Because we have this set up different than the website in a lot of ways, it ended up making scroll more jump on iOS Chrome and Firefox. Not sure why, because in theory it shouldn't be getting triggered, but changing this back seems to fix it