### PR TITLE
Use Mapbox GL built-in support function

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -121,7 +121,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
 
   /** Checks if the map features are supported (currently just WebGL) and shows a dialog if not */
   checkSupport() {
-    if (!this.platform.hasWebGLSupport) {
+    if (!mapboxgl.supported()) {
       const title = this.translatePipe.transform('MAP.UNSUPPORTED_TITLE');
       const data = this.translatePipe.transform('MAP.UNSUPPORTED_MESSAGE');
       return this.dialogService.showDialog({

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -91,17 +91,6 @@ export class PlatformService {
       !this.userAgent.includes('firefox');
   }
 
-  /** Returns if the device has WebGL support */
-  get hasWebGLSupport(): boolean {
-    // Create canvas element. The canvas is not added to the
-    // document itself, so it is never displayed in the
-    // browser window.
-    const canvas = this.nativeWindow.document.createElement('canvas');
-    // Get WebGLRenderingContext from canvas element.
-    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-    return (gl && gl instanceof WebGLRenderingContext);
-  }
-
   constructor() {
     this.userAgent = this.nativeWindow.navigator.userAgent.toLowerCase();
     // store viewport width / height


### PR DESCRIPTION
Closes #136. I think the WebGL check wasn't detecting support for some of the other standards like web workers that Mapbox GL JS is using. From tests on BrowserStack, this seems to pick up the difference in the IE 11 sub-versions