### PR TITLE
Fix zooming on scroll to top

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -104,11 +104,13 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
   scrollToTop() {
     this.scroll.scrollTo(this.contentEl.nativeElement);
     // set focus to an element at the top of the page for keyboard nav
-    const focusableEl = this.contentEl.nativeElement.getElementsByTagName('input');
-    if (focusableEl.length) {
-      focusableEl[0].focus();
-      focusableEl[0].blur();
-    }
+    const focusableEl = this.contentEl.nativeElement.querySelector('app-ranking-list button');
+    setTimeout(() => {
+      if (focusableEl.length) {
+        focusableEl[0].focus();
+        focusableEl[0].blur();
+      }
+    }, this.scroll.defaultDuration);
   }
 
 


### PR DESCRIPTION
Closes #786. Focusing on an `input` element with a font size of less than `16px` triggers a zoom on iOS, and focusing before the scroll also causes some jumpiness. The scroll now focuses on the first item in the list instead, and waits until the scroll is completed