### PR TITLE
WIP: Increase input size to prevent zoom on iOS

### DIFF
--- a/src/theme/base/inputs.scss
+++ b/src/theme/base/inputs.scss
@@ -1,7 +1,7 @@
 
 $inputTextColor: $black;
 $inputPlaceholderColor: $grey2a;
-$inputFontSize: 15px;
+$inputFontSize: 16px;
 $inputFontSize_lg: 17px;
 
 .form-control {


### PR DESCRIPTION
iOS automatically zooms into any `input` element with a font size of less than 16px (https://forum.webflow.com/t/prevent-zoom-in-on-form-focus-state-for-mobile/33867), which is annoying on the map tool search since it's already almost the full width. We'll need to make sure this works for the design, but this updates the default input font size to 16px, and I can confirm that it fixes the issue on my iPhone