### PR TITLE
Fix rankings null data handling, states zoom

### DIFF
--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -17,6 +17,10 @@ export class AppPage {
     return browser.getCurrentUrl();
   }
 
+  toastElement() {
+    return element(by.css('#toast-container .toast'));
+  }
+
   updateLanguage(langIdx: number) {
     element(by.css('.language-select')).click();
     element(by.css(`.language-select li:nth-child(${langIdx})`)).click();
@@ -28,5 +32,9 @@ export class AppPage {
 
   toggleSpanish() {
     this.updateLanguage(2);
+  }
+
+  scrollToPosition(top = 0) {
+    return browser.executeScript(`window.scrollTo(0,${top});`);
   }
 }

--- a/e2e/data-panel.e2e-spec.ts
+++ b/e2e/data-panel.e2e-spec.ts
@@ -28,13 +28,14 @@ describe('eviction-maps DataPanel', () => {
     expect(dataPanel.panelCards().isDisplayed()).toBeTruthy();
     browser.sleep(1000);
     dataPanel.clickViewMore();
-    browser.sleep(1000);
+    browser.sleep(2000);
     expect(browser.executeScript('return window.scrollY;').then(v => +v)).toBeGreaterThan(0);
   });
 
   it('should hide the data panel when all locations are removed', () => {
     dataPanel.selectLocation();
     expect(dataPanel.panelCards().isDisplayed()).toBeTruthy();
+    browser.sleep(1000);
     dataPanel.clickViewMore();
     browser.sleep(2000);
     dataPanel.removeLocation();

--- a/e2e/rankings.e2e-spec.ts
+++ b/e2e/rankings.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { AppPage } from './app.po';
 import { Rankings } from './rankings.po';
-import { browser, element, by } from 'protractor';
+import { browser, element, by, ExpectedConditions } from 'protractor';
 
 browser.waitForAngularEnabled(false);
 
@@ -12,10 +12,10 @@ describe('eviction-maps Rankings', () => {
     page = new AppPage();
     rankings = new Rankings();
     page.navigateTo('/#/evictions');
-    browser.sleep(2000);
+    browser.wait(ExpectedConditions.presenceOf(rankings.rankingsListElement()), 10000);
   });
 
-  it('should display the list but not the rankings panel on load', () => {
+  it('should display the list but not the ranking?s panel on load', () => {
     expect(rankings.rankingsListElement().isPresent()).toBeTruthy();
     expect(rankings.rankingsPanelContent().isPresent()).toBeFalsy();
   });
@@ -48,5 +48,46 @@ describe('eviction-maps Rankings', () => {
   it('should display the ranking panel on search select', () => {
     rankings.searchRankings();
     expect(rankings.rankingsPanelContent().isPresent()).toBeTruthy();
+  });
+
+  it('should show a toast and not update when trying to search for a location without data', () => {
+    page.scrollToPosition(100);
+    rankings.searchRankings('springdale, ar', 1);
+    browser.sleep(1000);
+    expect(page.toastElement().isPresent()).toBeTruthy();
+    expect(rankings.rankingsPanelContent().isPresent()).toBeFalsy();
+  });
+
+  it('should show a toast and not update when trying to select a location without data', () => {
+    page.scrollToPosition(200);
+    browser.sleep(500);
+    rankings.updateFilter(rankings.regionFilterSelect(), 5);
+    rankings.updateFilter(rankings.areaFilterSelect(), 2);
+    browser.sleep(500);
+    rankings.selectLocation(3);
+    rankings.selectLocation(10);
+    rankings.selectLocation(15);
+    const locationText = rankings.rankingsPanelLocationName().getText();
+    browser.sleep(1000);
+    rankings.selectLocation(21);
+    browser.sleep(500);
+    expect(page.toastElement().isPresent()).toBeTruthy();
+    expect(rankings.rankingsPanelLocationName().getText()).toBe(locationText);
+  });
+
+  it('should show a toast and not update when clicking next to a location without data', () => {
+    page.scrollToPosition(200);
+    browser.sleep(500);
+    rankings.updateFilter(rankings.regionFilterSelect(), 5);
+    rankings.updateFilter(rankings.areaFilterSelect(), 2);
+    rankings.selectLocation(3);
+    rankings.selectLocation(10);
+    rankings.selectLocation(15);
+    rankings.selectLocation(20);
+    browser.sleep(1000);
+    const locationText = rankings.rankingsPanelLocationName().getText();
+    rankings.rankingsPanelNextButton().click();
+    expect(page.toastElement().isPresent()).toBeTruthy();
+    expect(rankings.rankingsPanelLocationName().getText()).toBe(locationText);
   });
 });

--- a/e2e/rankings.po.ts
+++ b/e2e/rankings.po.ts
@@ -14,7 +14,7 @@ export class Rankings {
   }
 
   rankingsListElement() {
-    return element(by.css('app-ranking-list'));
+    return element(by.css('ul.ranking-list'));
   }
 
   closePanelButton() {
@@ -23,6 +23,14 @@ export class Rankings {
 
   rankingsPanelContent() {
     return this.rankingsPanelElement().element(by.css('.content-inner'));
+  }
+
+  rankingsPanelLocationName() {
+    return this.rankingsPanelContent().element(by.css('h2.rank-location'));
+  }
+
+  rankingsPanelNextButton() {
+    return this.rankingsPanelContent().element(by.css('button.panel-next'));
   }
 
   searchInputElement() {
@@ -34,7 +42,7 @@ export class Rankings {
   }
 
   searchResult(index = 2) {
-    return this.typeaheadContainer().element(by.css(`li:nth-child(${index}`));
+    return this.typeaheadContainer().element(by.css(`li:nth-of-type(${index})`));
   }
 
   regionFilterSelect() {
@@ -55,18 +63,18 @@ export class Rankings {
 
   updateFilter(el, index = 1) {
     el.click();
-    el.element(by.css(`.dropdown-menu li:nth-child(${index})`)).click();
+    el.element(by.css(`.dropdown-menu li:nth-of-type(${index})`)).click();
   }
 
-  searchRankings(searchText = 'detr') {
+  searchRankings(searchText = 'detr', index = 2) {
     const searchInput = this.searchInputElement();
     searchInput.sendKeys(searchText);
-    browser.wait(() => this.searchResult().isPresent(), 2000);
-    this.searchResult().click();
+    browser.wait(() => this.searchResult(index).isPresent(), 3000);
+    this.searchResult(index).click();
   }
 
   selectLocation(index = 1) {
-    const loc = element(by.css(`app-ranking-list li:nth-child(${index})`));
+    const loc = element(by.css(`app-ranking-list li:nth-of-type(${index})`));
     loc.click();
     return loc;
   }

--- a/e2e/search.e2e-spec.ts
+++ b/e2e/search.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('eviction-maps Search', () => {
 
   it('should display a toast message if a location is not found', () => {
     search.searchLocation('long island');
-    expect(search.toastElement().isPresent()).toBeTruthy();
+    expect(page.toastElement().isPresent()).toBeTruthy();
   });
 
   it('should display a toast message if 3 locations are already selected', () => {
@@ -37,6 +37,6 @@ describe('eviction-maps Search', () => {
     search.searchLocation('florida');
     search.searchLocation('minnesota');
     browser.sleep(1000);
-    expect(search.toastElement().isPresent()).toBeTruthy();
+    expect(page.toastElement().isPresent()).toBeTruthy();
   });
 });

--- a/e2e/search.po.ts
+++ b/e2e/search.po.ts
@@ -17,10 +17,6 @@ export class Search {
     return element(by.css('.map-ui-wrapper app-location-cards .card'));
   }
 
-  toastElement() {
-    return element(by.css('#toast-container .toast'));
-  }
-
   searchLocation(searchText = 'detr') {
     const searchInput = this.searchInputElement();
     searchInput.sendKeys(searchText);

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -574,7 +574,7 @@ export class MapToolService {
     }
     switch (layerId) {
       case 'states':
-        return 4;
+        return 2;
       case 'counties':
         return 7;
       case 'cities':

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.ts
@@ -201,9 +201,13 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
     this.updateQueryParam('dataProperty', dataProp.value);
   }
 
-  /** Update current location */
+  /** Update current location, shows toast if data unavailable */
   setCurrentLocation(locationIndex: number) {
     if (this.selectedIndex === locationIndex) { return; }
+    if (this.listData[locationIndex][this.dataProperty.value] < 0) {
+      this.showUnavailableToast();
+      return;
+    }
     const value = (locationIndex || locationIndex === 0) ? locationIndex : null;
     this.updateQueryParam('selectedIndex', value);
   }
@@ -230,13 +234,9 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  /** handles the click on a specific location, shows a toast message if data is unavailable */
+  /** handles the click on a specific location */
   onClickLocation(index: number) {
-    if (this.listData[index][this.dataProperty.value] < 0) {
-      this.showUnavailableToast();
-    } else {
-      this.setCurrentLocation(index);
-    }
+    this.setCurrentLocation(index);
   }
 
   /** Switch the selected location to the next one in the list */


### PR DESCRIPTION
Closes #780. Handles null data in `setCurrentLocation` rather than on a case-by-case basis, displaying the toast message and not updating the index if it has null data. We might still need to handle cases where eviction data is null, but eviction filing data is supplied since eviction data is displayed (unless we want to add that to the conditional). Adds tests to verify this as well

Also, changes the state data query zoom to 2, since New York wasn't getting picked up