### PR TITLE
Add iOS SVG gradient hack to Safari

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,6 +35,7 @@ export class AppComponent implements OnInit {
   @HostBinding('class.map-tool') isMapTool: boolean;
   @HostBinding('class.embed') embed: boolean;
   @HostBinding('class.ios') ios = false;
+  @HostBinding('class.safari') safari = false;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
   currentMenuItem: string;
@@ -85,6 +86,7 @@ export class AppComponent implements OnInit {
     });
     // Add user agent-specific classes
     this.ios = this.platform.isIos;
+    this.safari = this.platform.isSafari;
     this.iosSafari = this.platform.isIosSafari;
     this.android = this.platform.isAndroid;
   }

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -76,6 +76,11 @@ export class PlatformService {
     return this.viewportWidth > breakpoints['largeDesktop'];
   }
 
+  /** Returns true if browser is Safari */
+  get isSafari(): boolean {
+    return this.userAgent.includes('safari');
+  }
+
   /** Returns true if device is iOS */
   get isIos(): boolean {
     return this.userAgent.includes('iphone') || this.userAgent.includes('ipad');

--- a/src/theme/base/hacks.scss
+++ b/src/theme/base/hacks.scss
@@ -2,7 +2,7 @@
   Something about the production deployment is causing SVG linear gradients to fail on iOS browsers.
   This replaces the fill of any element using a linear gradient with a flat color.
 */
-.ios {
+.ios, .safari {
   .fallback-gradient { fill: $color1 !important; }
   .app-graph {
     .bar-0 { fill: $color1 !important; }


### PR DESCRIPTION
Hadn't noticed this before, but that iOS SVG gradient problem also exists on desktop Safari. Added another class to handle it