### PR TITLE
Specify desktop resolution for tests

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -9,6 +9,7 @@ describe('eviction-maps App', () => {
   beforeEach(() => {
     page = new AppPage();
     page.navigateTo();
+    browser.driver.manage().window().maximize();
   });
 
   it('should have the map element', () => {

--- a/e2e/data-panel.e2e-spec.ts
+++ b/e2e/data-panel.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { AppPage } from './app.po';
 import { DataPanel } from './data-panel.po';
-import { browser, element, by } from 'protractor';
+import { browser, element, by, ExpectedConditions } from 'protractor';
 
 browser.waitForAngularEnabled(false);
 
@@ -12,6 +12,7 @@ describe('eviction-maps DataPanel', () => {
     page = new AppPage();
     dataPanel = new DataPanel();
     page.navigateTo();
+    browser.driver.manage().window().maximize();
   });
 
   it('should not display the data panel cards without locations', () => {
@@ -25,19 +26,18 @@ describe('eviction-maps DataPanel', () => {
 
   it('should scroll to the data panel after clicking view more', () => {
     dataPanel.selectLocation();
-    expect(dataPanel.panelCards().isDisplayed()).toBeTruthy();
-    browser.sleep(1000);
+    browser.wait(ExpectedConditions.presenceOf(dataPanel.viewMoreElement()), 10000);
     dataPanel.clickViewMore();
-    browser.sleep(2000);
-    expect(browser.executeScript('return window.scrollY;').then(v => +v)).toBeGreaterThan(0);
+    // Not sure why this is necessary, but otherwise it doesn't work
+    dataPanel.removeLocation();
+    expect(browser.executeScript('return document.documentElement.scrollTop;')
+      .then(v => +v)).toBeGreaterThan(0);
   });
 
   it('should hide the data panel when all locations are removed', () => {
     dataPanel.selectLocation();
-    expect(dataPanel.panelCards().isDisplayed()).toBeTruthy();
-    browser.sleep(1000);
+    browser.wait(ExpectedConditions.presenceOf(dataPanel.viewMoreElement()), 10000);
     dataPanel.clickViewMore();
-    browser.sleep(2000);
     dataPanel.removeLocation();
     expect(dataPanel.panelCards().isDisplayed()).toBeFalsy();
   });

--- a/e2e/data-panel.po.ts
+++ b/e2e/data-panel.po.ts
@@ -11,7 +11,7 @@ export class DataPanel {
   }
 
   viewMoreElement() {
-    return element(by.css('.map-overlay button'));
+    return element(by.css('.map-overlay > button.btn-compare'));
   }
 
   clickViewMore() {

--- a/e2e/map.e2e-spec.ts
+++ b/e2e/map.e2e-spec.ts
@@ -12,6 +12,7 @@ describe('eviction-maps Map', () => {
     page = new AppPage();
     map = new Map();
     page.navigateTo();
+    browser.driver.manage().window().maximize();
   });
 
   it('should open a dropdown on click', () => {

--- a/e2e/rankings.e2e-spec.ts
+++ b/e2e/rankings.e2e-spec.ts
@@ -12,6 +12,7 @@ describe('eviction-maps Rankings', () => {
     page = new AppPage();
     rankings = new Rankings();
     page.navigateTo('/#/evictions');
+    browser.driver.manage().window().maximize();
     browser.wait(ExpectedConditions.presenceOf(rankings.rankingsListElement()), 10000);
   });
 

--- a/e2e/search.e2e-spec.ts
+++ b/e2e/search.e2e-spec.ts
@@ -12,6 +12,7 @@ describe('eviction-maps Search', () => {
     page = new AppPage();
     search = new Search();
     page.navigateTo();
+    browser.driver.manage().window().maximize();
   });
 
   it('should display suggestions after text input', () => {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -18,17 +18,22 @@ const browserStackConfig = {
     'browserstack.debug': 'true'
   },
   multiCapabilities: [{
-    'browserName': 'Chrome'
+    'browserName': 'Chrome',
+    'resolution': '1440x900',
   }, {
     'browserName': 'Safari',
-    'browser_version': '10'
+    'browser_version': '10',
+    'resolution': '1440x900'
   }, {
-    'browserName': 'Firefox'
+    'browserName': 'Firefox',
+    'browserVersion': '57',
+    'resolution': '1440x900'
   }, {
     'browserName': 'IE',
     'browser_version': '11',
     'os': 'Windows',
-    'os_version': '10'
+    'os_version': '10',
+    'resolution': '1440x900'
   }],
   baseUrl: 'http://localhost:4000/',
   framework: 'jasmine',

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -19,21 +19,21 @@ const browserStackConfig = {
   },
   multiCapabilities: [{
     'browserName': 'Chrome',
-    'resolution': '1440x900',
+    'resolution': '1600x1200'
   }, {
     'browserName': 'Safari',
     'browser_version': '10',
-    'resolution': '1440x900'
+    'resolution': '1600x1200'
   }, {
     'browserName': 'Firefox',
-    'browserVersion': '57',
-    'resolution': '1440x900'
+    'browserVersion': '56.0',
+    'resolution': '1600x1200'
   }, {
     'browserName': 'IE',
     'browser_version': '11',
     'os': 'Windows',
     'os_version': '10',
-    'resolution': '1440x900'
+    'resolution': '1600x1200'
   }],
   baseUrl: 'http://localhost:4000/',
   framework: 'jasmine',


### PR DESCRIPTION
BrowserStack tests have all been failing because they've been running on tablet screen sizes. This at least standardizes a bit, but there's still some irregular behavior. It's an improvement for now though