### PR TITLE
Show toast on initial search input if max locations

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,6 +6,7 @@
   [languageOptions]="languageOptions"
   (activeMenuItemChange)="onMenuSelect($event)"
   (selectLocation)="onSearchSelect($event)"
+  (initialInput)="onInitialSearchInput()"
   (selectLanguage)="onLanguageSelect($event)"
 ></app-header-bar>
 <app-menu class="app-menu" tabindex="-1" 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -180,6 +180,13 @@ export class AppComponent implements OnInit {
   }
 
   /**
+   * Forward initial search event to map tool component
+   */
+  onInitialSearchInput() {
+    this.mapComponent.onInitialSearchInput.apply(this.mapComponent, arguments);
+  }
+
+  /**
    * Update the lang attribute on the html element
    * Based on https://github.com/ngx-translate/core/issues/565
    */

--- a/src/app/header-bar/header-bar.component.html
+++ b/src/app/header-bar/header-bar.component.html
@@ -11,6 +11,7 @@
         class="search"
         [placeholder]="'HEADER.SEARCH_HINT' | translate"
         (locationSelected)="selectLocation.emit($event)"
+        (initialInput)="initialInput.emit($event)"
       ></app-location-search>
     </div>
     <app-ui-select 

--- a/src/app/header-bar/header-bar.component.ts
+++ b/src/app/header-bar/header-bar.component.ts
@@ -22,6 +22,7 @@ export class HeaderBarComponent implements OnInit, AfterViewInit {
 
   @Output() activeMenuItemChange = new EventEmitter();
   @Output() selectLocation = new EventEmitter();
+  @Output() initialInput = new EventEmitter();
   @Output() selectLanguage = new EventEmitter();
   @ViewChild('pop') mapTooltip;
   tooltipEnabled = true;

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -241,6 +241,15 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
+   * Show toast message on initial search input if max locations already selected
+   */
+  onInitialSearchInput() {
+    if (this.mapToolService.activeFeatures.length >= 3) {
+      this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
+    }
+  }
+
+  /**
    * Set map layer and view from clicked location card header
    * @param feature clicked feature from card
    */

--- a/src/app/ui/location-search/location-search.component.html
+++ b/src/app/ui/location-search/location-search.component.html
@@ -3,5 +3,6 @@
   [options]="results"
   [placeholder]="placeholder"
   optionField="properties.label"
+  (initialInput)="initialInput.emit($event)"
   (selectionChange)="onSearchSelect($event)">
 </app-predictive-search>

--- a/src/app/ui/location-search/location-search.component.ts
+++ b/src/app/ui/location-search/location-search.component.ts
@@ -12,6 +12,7 @@ export class LocationSearchComponent {
   query: string;
   results: Observable<Object[]>;
   @Input() placeholder;
+  @Output() initialInput = new EventEmitter();
   /** Emits a location whenever one is selected in the search */
   @Output() locationSelected = new EventEmitter();
 

--- a/src/app/ui/predictive-search/predictive-search.component.html
+++ b/src/app/ui/predictive-search/predictive-search.component.html
@@ -17,7 +17,8 @@
          autocomplete="off"
          aria-describedby="initInstr"
          aria-autocomplete="both"
-         class="form-control">
+         class="form-control"
+         (focus)="setupInputListener()">
   <app-ui-close-button class="clear"
     [ariaLabel]="'HEADER.SEARCH_CLEAR' | translate"
     [style.display]="selected ? 'block' : 'none'"

--- a/src/app/ui/predictive-search/predictive-search.component.ts
+++ b/src/app/ui/predictive-search/predictive-search.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, OnInit, Input, Output, EventEmitter, ElementRef, HostListener
 } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { NgModel } from '@angular/forms';
 import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 
@@ -16,6 +17,7 @@ export class PredictiveSearchComponent implements OnInit {
   @Input() optionsLimit = 5;
   @Input() waitMs = 500;
   @Input() placeholder;
+  @Output() initialInput = new EventEmitter();
   @Output() selectedChange = new EventEmitter();
   @Output() selectionChange: EventEmitter<Object> = new EventEmitter<Object>();
   ariaOwns = 'results';
@@ -128,8 +130,17 @@ export class PredictiveSearchComponent implements OnInit {
       selection: selection ? selection.item : selection,
       queryTerm: this.typedValue
     });
-    // clear the selection after selected and emitted
+    // clear the selection after selected and emitted, reset input listener
     this.selected = null;
+    this.setupInputListener();
+  }
+
+  /**
+   * Take the first keydown event after setup and emit an input event
+   */
+  setupInputListener() {
+    Observable.fromEvent(this.el.nativeElement, 'keydown')
+      .take(1).subscribe(() => this.initialInput.emit());
   }
 
   /**


### PR DESCRIPTION
Closes #809. Each time the search input is focused or the selection changes, it resets a `keydown` listener that fires only on the first event. This is forwarded to the map tool, which shows a toast message if the max amount of locations are already selected.

![search-warning](https://user-images.githubusercontent.com/8291663/37490401-8b1cb50a-2868-11e8-9b31-1b36daf40cf4.gif)
