### PR TITLE
Add singular version of robotext in ranking panel

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -29,7 +29,8 @@
       </div>
     </div>
     <div class="panel-summary-content">
-      <p>{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
+      <p *ngIf="location.evictions !== 1">{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
+      <p *ngIf="location.evictions === 1">{{ 'RANKINGS.PANEL_SUMMARY_SINGULAR' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
     </div>
   </div>
   <button class="btn btn-icon panel-arrow panel-next"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -166,6 +166,7 @@
     "COMING_SOON": "Coming Soon",
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} evictions in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
+    "PANEL_SUMMARY_SINGULAR": "There was {{evictions}} eviction in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",
     "SEARCH_FILTER": "Search & Filter",
     "TOP_EVICTORS_LINK": "View Top Evictors",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -169,6 +169,7 @@
     "COMING_SOON": "Coming Soon",
     "HIGHEST": "Highest",
     "PANEL_SUMMARY": "There were {{evictions}} in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
+    "PANEL_SUMMARY_SINGULAR": "There was {{evictions}} eviction in the {{name}} area last year.  That amounts to {{evictionsPerDay}} people evicted every day.  {{evictionRate}} in 100 renter homes are evicted each year.",
     "LIST_INTRO": "View {{year}} eviction rankings for locations across America. To refine your selection, choose either a city, mid-sized areas, or rural areas, and data type (eviction rate or raw eviction number).",
     "SEARCH_FILTER": "Search & Filter",
     "TOP_EVICTORS_LINK": "View Top Evictors",


### PR DESCRIPTION
Adds singular version of robotext when there is one eviction.  Closes #747 

![image](https://user-images.githubusercontent.com/21034/37616673-4e401a58-2b76-11e8-8a71-610b3bd3890c.png)
