### PR TITLE
Only fire moveend when scroll enabled, default fills

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -359,9 +359,11 @@ export class MapComponent implements OnInit, OnChanges {
     this._store.bounds = this.mapService.getBoundsArray()
       .reduce((a, b) => a.concat(b))
       .map(v => Math.round(v * 1000) / 1000);
-    this.boundingBoxChange.emit(this._store.bounds);
-    if (this.restoreAutoSwitch) { this.autoSwitch = true; }
-    this.mapService.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
+    if (this.scrollZoom) {
+      this.boundingBoxChange.emit(this._store.bounds);
+      if (this.restoreAutoSwitch) { this.autoSwitch = true; }
+      this.mapService.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
+    }
   }
 
   /**

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -265,6 +265,9 @@
       "source-layer": "block-groups",
       "layout": {
         "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {
@@ -310,6 +313,9 @@
       "source-layer": "tracts",
       "layout": {
         "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {
@@ -355,6 +361,9 @@
       "source-layer": "counties",
       "layout": {
         "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {
@@ -402,7 +411,7 @@
         "visibility": "none"
       },
       "paint": {
-        "fill-color": "rgba(67,72,120,0.7)"
+        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {
@@ -443,6 +452,9 @@
       "source-layer": "cities",
       "layout": {
         "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(0,0,0,0)"
       }
     },
     {


### PR DESCRIPTION
Closes #810. We're delaying the height transition of the map using viewport units on mobile because of the URL bar appearing and disappearing, but the window is still changing size whenever that happens. That changes the dimensions of the map which then triggers a `moveend` event to update the `bounds` URL parameters. This may have started behaving differently when we updated routing, but updating those parameters makes the URL bar reappear and causes a jumpy scroll effect

This PR only fires the bounds update event when `scrollZoom` is enabled, so that it's not happening when someone is scrolling down the page. I'm also adding defaults for `fill-color` on the map layers, because I noticed an occasional black flicker before it's updated the first time