### PR TITLE
Add center to counties for search

### DIFF
--- a/e2e/search.e2e-spec.ts
+++ b/e2e/search.e2e-spec.ts
@@ -27,6 +27,11 @@ describe('eviction-maps Search', () => {
     expect(search.locationCard().isPresent()).toBeTruthy();
   });
 
+  it('should add a location when searching for a county', () => {
+    search.searchLocation('wayne county');
+    expect(search.locationCard().isPresent()).toBeTruthy();
+  });
+
   it('should display a toast message if a location is not found', () => {
     search.searchLocation('long island');
     expect(page.toastElement().isPresent()).toBeTruthy();

--- a/src/app/services/search-sources.ts
+++ b/src/app/services/search-sources.ts
@@ -62,7 +62,7 @@ export const MapboxSource: SearchSource = {
 
         const countyFeatures = this.featureList.filter(f => {
             return f.properties.label.toLowerCase().startsWith(text.toLowerCase());
-        });
+        }).map(f => { f.center = f.geometry.coordinates; return f; });
 
         return countyFeatures.concat(results['features'].map(r => {
             r.properties.label = r.place_name;


### PR DESCRIPTION
Closes #833. Adds `center` property to county objects since it's a more convenient shorthand than checking the feature geometry type, and required by the current setup. Also adds an e2e test for it