### PR TITLE
Safari fixes

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.html
+++ b/src/app/map-tool/data-panel/data-panel.component.html
@@ -62,7 +62,7 @@
           <h2>{{ 'DATA.DOWNLOAD_HEADING' | translate }}</h2>
           <span>{{ 'DATA.DOWNLOAD_HINT' | translate }}</span>
           <button
-            [disabled]="displayLocations.length === 0"
+            [class.disabled]="displayLocations.length === 0"
             tooltip="{{ 'DATA.DOWNLOAD_DISABLED' | translate }}"
             [isDisabled]="displayLocations.length > 0"
             class="btn btn-border"

--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -166,8 +166,8 @@ app-location-cards {
 
 // Disabled download button
 .action-wrapper {
-  .btn.btn-border[disabled],
-  .btn.btn-border[disabled]:hover {
+  .btn.btn-border.disabled,
+  .btn.btn-border.disabled:hover {
     opacity: inherit;
     color: $grey1a;
     cursor: inherit;

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -106,6 +106,8 @@ export class DataPanelComponent implements OnInit {
   }
 
   showDownloadDialog(e) {
+    // Don't fire if no features
+    if (this.displayLocations.length === 0) { return; }
     const config = {
       lang: this.translate.currentLang,
       year: this.year,

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -262,6 +262,8 @@ app-location-cards {
       width: 22px;
       height:22px;
       fill: $iconColor;
+      // Hack to prevent overflow on Safari
+      ::ng-deep { svg { height: inherit; } }
     }
   }
 }

--- a/src/theme/base/header.scss
+++ b/src/theme/base/header.scss
@@ -27,6 +27,7 @@
   box-shadow: $z1shadow;
   padding: grid(1) $pageMargin;
   z-index:999;
+  transform: translateZ(0);
   .header-content {
     position:relative;
     width: 100%;


### PR DESCRIPTION
:heavy_check_mark:
- Closes #832, fixes help icon display
- Closes #840, uses disabled class instead of disabled attribute so that hint hover state still active on reports when not active. Has the added benefit(?) of activating the tooltip on tab navigation rather than just skipping the button
- Closes #842, uses `translateZ(0)` to fix flickering behavior on position fixed navbar condensing

Also I don't know why I haven't used GitHub emojis until now :100: :tada: