### PR TITLE
Switch geography on zoomend instead of load, closes #838

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -228,12 +228,12 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
         const dataLevel = this.mapToolService.dataLevels.filter(l => l.id === layerId)[0];
         if (updateMap) {
           this.map.mapService.zoomToFeature(feature);
-          // Wait for map to be done loading, then set data layer
-          this.map.mapService.isLoading$.distinctUntilChanged()
-            .debounceTime(500)
-            .filter(state => !state)
+          // Wait for map to be done zooming, then set data layer
+          this.map.mapService.zoom$
+            .distinctUntilChanged()
+            .filter(zoom => zoom !== null)
             .first()
-            .subscribe((state) => this.map.setGroupVisibility(dataLevel));
+            .subscribe(() => this.map.setGroupVisibility(dataLevel));
         }
         this.loader.end('search');
       });

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -17,7 +17,9 @@ export class MapService {
   embedded = false;
   private map: mapboxgl.Map;
   private _isLoading = new BehaviorSubject<boolean>(true);
+  private _zoom = new BehaviorSubject<number>(null);
   isLoading$ = this._isLoading.asObservable();
+  zoom$ = this._zoom.asObservable();
   private colors = ['#e24000', '#434878', '#2c897f'];
   get mapCreated() { return this.map !== undefined; }
 
@@ -46,6 +48,10 @@ export class MapService {
 
   setLoading(state: boolean) {
     this._isLoading.next(state);
+  }
+
+  setZoomEvent(zoom: number) {
+    this._zoom.next(zoom);
   }
 
   /**

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -46,7 +46,6 @@
     [selectedLayer]="selectedLayer"
     [featureCount]="activeFeatures.length"
     (ready)="onMapReady($event)"
-    (zoomEnd)="onMapZoomEnd($event)"
     (featureClick)="onFeatureClick($event)"
     (moveEnd)="onMapMoveEnd($event)"
   ></app-mapbox>

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -2,6 +2,7 @@ import { async, fakeAsync, tick, ComponentFixture, TestBed } from '@angular/core
 import { TranslateModule, TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { MapComponent } from './map.component';
 import { MapboxComponent } from '../mapbox/mapbox.component';
@@ -23,6 +24,7 @@ export class TranslatePipeMock implements PipeTransform {
 }
 
 class MapServiceStub {
+  zoom$ = new BehaviorSubject<number>(null);
   updateCensusSource() {}
   createMap(settings) { return this; }
   addControl(...args) { return this; }

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -234,6 +234,9 @@ export class MapComponent implements OnInit, OnChanges {
   ) {
     loader.start('map');
     translate.onLangChange.subscribe(l => this.updateSelectedLayerName());
+    this.mapService.zoom$.skip(1)
+      .filter(zoom => zoom !== null)
+      .subscribe((zoom) => this.onMapZoomEnd(zoom));
   }
 
   ngOnInit() {

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -33,7 +33,6 @@ export class MapboxComponent implements AfterViewInit {
   @Input() selectedLayer: MapLayerGroup;
   @Input() featureCount = 0;
   @Output() ready: EventEmitter<any> = new EventEmitter();
-  @Output() zoomEnd: EventEmitter<number> = new EventEmitter();
   @Output() moveEnd: EventEmitter<Array<number>> = new EventEmitter();
   @Output() featureClick: EventEmitter<number> = new EventEmitter();
   featureMouseMove: EventEmitter<any> = new EventEmitter();
@@ -163,11 +162,14 @@ export class MapboxComponent implements AfterViewInit {
    */
   private setupEmitters() {
     this.map.on('moveend', (e) => this.moveEnd.emit(e));
-    this.map.on('zoomstart', (e) => this.scroll.allowScroll = false);
-    // Emit feature on zoom end to account for geography details changing across zooms
+    this.map.on('zoomstart', (e) => {
+      this.scroll.allowScroll = false;
+      this.mapService.setZoomEvent(null);
+    });
+    // Update zoom observable zoom end to account for geography details changing across zooms
     this.map.on('zoomend', () => {
       this.scroll.allowScroll = true;
-      this.zoomEnd.emit(this.map.getZoom());
+      this.mapService.setZoomEvent(this.map.getZoom());
     });
     this.map.on('data', (e) =>  this.mapService.setLoading(!this.map.areTilesLoaded()));
     this.map.on('dataloading', (e) => this.mapService.setLoading(!this.map.areTilesLoaded()));


### PR DESCRIPTION
Needed to add the `zoomstart` handler to a more general `zoom$` to make it work consistently, but this should address the issue. Not sure if it'll have a huge performance payoff in IE, but definitely helpful generally