### PR TITLE
Merge features finds first with geography

### DIFF
--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -512,7 +512,7 @@ export class MapToolService {
    * @param features an array of features
    */
   private mergeFeatureProperties(features: any[]) {
-    const feat = features[0];
+    const feat = features.find(f => f.hasOwnProperty('geometry'));
     for (let i = 1; i < this.tilesetYears.length; ++i) {
       feat['properties'] = { ...feat['properties'], ...features[i]['properties']};
     }


### PR DESCRIPTION
Closes #846. From looking around the census site and in our data, it looks like Valle, AZ doesn't actually have information earlier than 2010. The reason this caused errors is that the merge feature code defaulted to using the first feature rather than checking that it wasn't effectively null. Adding a check for that now which handles the issue gracefully, even if it looks odd.

We shouldn't need to address this in the data pipeline, because it's already being handled as null data here, and if we end up having eviction data it will get added to the tiles