### PR TITLE
Fix Windows, IE scroll bar issues

### DIFF
--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -26,8 +26,8 @@ export class ScrollService {
       !val && this.document.documentElement.scrollTop === 0 &&
       !this.document.documentElement.classList.contains('embedded')
     );
-    this.document.body.style.position = changeScroll ? 'fixed' : '';
-    this.document.body.style.overflowY = changeScroll ? 'scroll' : '';
+    this.document.documentElement.style.position = changeScroll ? 'fixed' : '';
+    this.document.documentElement.style.overflowY = changeScroll ? 'scroll' : '';
   }
   verticalOffset$: Observable<number>;
   scrolledToTop$: Observable<boolean>;

--- a/src/theme/base/hacks.scss
+++ b/src/theme/base/hacks.scss
@@ -1,4 +1,11 @@
 /*
+  ngx-bootstrap checks if the body is overflowing, and adds padding if so. Since
+  we have the html overflow-x hidden, this ends up just adding extra padding. Ignoring
+  this padding is more straightforward than trying to toggle the overflow on and off
+*/
+body { padding-right: 0 !important; }
+
+/*
   Something about the production deployment is causing SVG linear gradients to fail on iOS browsers.
   This replaces the fill of any element using a linear gradient with a flat color.
 */


### PR DESCRIPTION
* Closes #828 by setting the scroll disabling CSS on the `html` element rather than `body`. Found a [StackOverflow post](https://stackoverflow.com/questions/1417934/how-to-prevent-scrollbar-from-repositioning-web-page) that mentions IE will duplicate the scroll bar if you set it on `body`.
* Closes #852 with a bit of a hack disabling `padding-right` on the `body` element. `ngx-bootstrap` tries to be smart about adding padding to prevent the scroll bar issue from above, but since we already have `overflow-x: hidden` it messes up our setup on Windows