### PR TITLE
Force query features on zoom highlight update

### DIFF
--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -348,7 +348,8 @@ export class MapComponent implements OnInit, OnChanges {
         }
       }
     }
-    this.mapService.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
+    // Update highlighted features, forcing a query of rendered features
+    this.mapService.updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures, true);
   }
 
   enableZoom() { return this.mapService.enableZoom(); }


### PR DESCRIPTION
Closes #855. The reason the geography isn't always updating is that `getUnionFeature` checks to see if the geography matches the bounding box, and only updates if it's not about the same size. That's mainly to prevent a ton of calls to `queryRenderedFeatures`.

This splits out querying the features and creating a union feature out of them into a separate function, that's called directly if the optional parameter `forceQuery` is true. Right now I'm only triggering that on zoom change, which is the main place this is an issue