### PR TITLE
Fix flex issues

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -367,6 +367,7 @@
     }
     li {
       width:auto;
+      margin-right: grid(5);
       .legend-label {
         margin-right:0;
       }

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -307,6 +307,7 @@
     .card-heading { 
       @include panelCardHeading($panelCardHeadingSize);
       margin-left: grid(4);
+      width: auto;
     }
     .card-subheading { 
       font-size: $panelCardSubheadingSize;

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -188,6 +188,12 @@ app-ranking-ui.ranking-ui-panel {
     transform: translate3d(0,0,0);
   }
 }
+
+// Safari 9 doesn't specify this automatically
+.ranking-ui-container {
+  flex: 1 0 auto;
+}
+
 // panel is sticky, but still off-screen on tablet
 @media(min-width: $gtMobile) {
   .ranking-ui-container {


### PR DESCRIPTION
* Closes #848. Based off of information in [this StackOverflow post](https://stackoverflow.com/a/38231204)
* Closes #865 by setting the width of the title to `auto`
<img width="820" alt="screen shot 2018-03-22 at 11 44 05 am" src="https://user-images.githubusercontent.com/8291663/37785857-34337182-2dc9-11e8-9a92-786ee614bd1e.png">

* Closes #850 (which was an issue across browsers) by adding `margin-right` equal to the close button offset so that it's included in the `flex` calculations
<img width="859" alt="screen shot 2018-03-22 at 12 00 31 pm" src="https://user-images.githubusercontent.com/8291663/37785868-3788cd00-2dc9-11e8-95f4-cdc694419bf8.png">
