### PR TITLE
Add general search error handling

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -143,6 +143,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     this.loader.start('feature');
     const maxLocations = this.mapToolService.addLocation(feature);
     if (maxLocations) {
+      this.loader.end('feature');
       this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
     }
     // track event
@@ -159,6 +160,9 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
         this.mapToolService.updateLocation(data);
         this.updateRoute();
         this.loader.end('feature');
+      }, err => {
+        this.loader.end('feature');
+        console.error(err.message);
       });
   }
 
@@ -235,6 +239,9 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
             .first()
             .subscribe(() => this.map.setGroupVisibility(dataLevel));
         }
+        this.loader.end('search');
+      }, err => {
+        this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
         this.loader.end('search');
       });
     }

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -138,7 +138,7 @@ export class MapToolService {
   setLocations(locations) {
     locations.forEach(l => {
       this.getTileData(l.geoid, l.lonLat, true)
-        .subscribe((data) => { this.addLocation(data); });
+        .subscribe((data) => { this.addLocation(data); }, err => { console.error(err.message); });
     });
   }
 


### PR DESCRIPTION
Closes #868. Adds general error handling (which is really easy with observables) to calls to `getTileData` and `getSearchTileData`. Stops any loaders if there's an error, and shows a toast message if an error occurs on search. Example below (where I added a `throw new Error('test')` inside of the call back of `getSearchParser`):

![search-errors](https://user-images.githubusercontent.com/8291663/37786904-cb238a08-2dcb-11e8-8983-f5adf6b0e86b.gif)
