### PR TITLE
Add filing rate hint and update rent burden hint

### DIFF
--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -348,6 +348,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'type': 'bubble',
     'order': 3,
     'langKey': 'STATS.FILING_RATE',
+    'hintKey': 'HINTS.EVICTION_FILING_RATE',
     'format': 'percent',
     'default': 0,
     'expressions': {

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -72,7 +72,6 @@
       [collapsible]="gtTablet"
       [class.cards-2]="activeFeatures.length === 2"
       [class.cards-3]="activeFeatures.length === 3"
-      [class.no-census-data]="!selectedChoropleth || selectedChoropleth.id.includes('none')"
       [features]="activeFeatures"
       [cardProperties]="cardProps"
       [year]="year"

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -118,9 +118,6 @@ app-location-cards {
     pointer-events: none;
     align-items: center;
     height: calc(100vh - #{$headerHeightLg});
-    &.no-census-data ::ng-deep .location-card {
-      height: grid(34);
-    }
     ::ng-deep {
       .location-card {
         transition: transform 0.2s ease;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -72,7 +72,8 @@
   },
   "HINTS": {
     "EVICTION_RATE": "Represents the number of evictions per 100 renter homes.",
-    "RENT_BURDEN": "The percentage of household income spent on rent (max 50% or more)."
+    "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
+    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more."
   },
   "LAYERS": {
     "STATES": "States",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -75,7 +75,8 @@
   },
   "HINTS": {
     "EVICTION_RATE": "Represents the number of evictions per 100 renter homes.",
-    "RENT_BURDEN": "The percentage of household income spent on rent (max 50% or more)."
+    "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
+    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more."
   },
   "LAYERS": {
     "STATES": "Estados",


### PR DESCRIPTION
Progress on #787. Add eviction filing rate hint, and update the text for rent burden based on Slack conversations. Also, it might reintroduce and issue that was fixed a bit ago with padding on the cards:

<img width="277" alt="screen shot 2018-03-22 at 12 46 30 pm" src="https://user-images.githubusercontent.com/8291663/37788379-458accfe-2dcf-11e8-817a-6e6fda722da4.png">
