### PR TITLE
Performance: hover + highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ngx-translate/http-loader": "^2.0.0",
     "@turf/area": "^5.1.5",
     "@turf/bbox": "^4.7.3",
-    "@turf/helpers": "^6.0.1",
+    "@turf/helpers": "6.0.1",
     "@turf/inside": "^5.0.0",
     "@turf/meta": "^6.0.0-beta.3",
     "@turf/union": "^4.7.3",

--- a/src/app/map-tool/map/map.service.spec.ts
+++ b/src/app/map-tool/map/map.service.spec.ts
@@ -28,8 +28,8 @@ describe('MapService', () => {
     } as GeoJSON.Feature<GeoJSON.Polygon>;
     mapFeatureStub = featureStub as MapFeature;
     mapboxStub = {
-      getZoom: () => { return 5; },
-      getSource: (id) => { return { setData: (...args) => {} } },
+      getZoom: () => 5,
+      getSource: (id) => ({ setData: (...args) => {} }),
       queryRenderedFeatures: (a, b) => [featureStub]
     };
   });

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -9,7 +9,7 @@ import * as union from '@turf/union';
 import * as polylabel from 'polylabel';
 import area from '@turf/area';
 import { coordAll } from '@turf/meta';
-import * as _isEqual from 'lodash.isequal';  
+import * as _isEqual from 'lodash.isequal';
 
 import { MapLayerGroup } from '../data/map-layer-group';
 import { MapFeature } from './map-feature';
@@ -24,8 +24,8 @@ export class MapService {
   private colors = ['#e24000', '#434878', '#2c897f'];
   get mapCreated() { return this.map !== undefined; }
   /** Returns true if highlighting features on hover is enabled */
-  get hoverEnabled() { 
-    return this._hoverEnabled && this._mapHighlights.length < this._maxLocations; 
+  get hoverEnabled() {
+    return this._hoverEnabled && this._mapHighlights.length < this._maxLocations;
   }
   private _debug = true;
   private _maxLocations = 3;
@@ -154,12 +154,12 @@ export class MapService {
 
   /**
    * Checks the bounding box of the geometry and compares it with
-   * the bounding box of the feature nwse  
+   * the bounding box of the feature nwse
    */
   isFullFeaturePresent(feature: MapFeature) {
     // if there is a cached version at a lower zoom level the geometry must be updated
     if (
-      feature.properties['geoDepth'] && 
+      feature.properties['geoDepth'] &&
       feature.properties['geoDepth'] < this.map.getZoom()
     ) { return false; }
     // check the feature bounding box to see if the whole feature is present
@@ -182,7 +182,7 @@ export class MapService {
    */
   getUnionFeature(layerId: string, feature: MapFeature): GeoJSON.Feature<GeoJSON.Polygon> | null {
     if (this.isFullFeaturePresent(feature)) {
-      return feature as GeoJSON.Feature<GeoJSON.Polygon>; 
+      return feature as GeoJSON.Feature<GeoJSON.Polygon>;
     }
     // full feature is not present, so query the map for it
     const queryFeatures = this.map.queryRenderedFeatures(undefined, {
@@ -233,11 +233,11 @@ export class MapService {
   }
 
   /** Checks if the geometry of two feature arrays are equal */
-  areFeaturesEqual(f1:MapFeature[], f2: MapFeature[]) {
+  areFeaturesEqual(f1: MapFeature[], f2: MapFeature[]) {
     if (f1.length !== f2.length) { return false; }
     if (f1.length === 0) { return true; }
     return f1
-      .map((f,i) => _isEqual(f['geometry'], f2[i]['geometry']))
+      .map((f, i) => _isEqual(f['geometry'], f2[i]['geometry']))
       .reduce((acc, curr) => acc ? curr : false);
   }
 
@@ -280,7 +280,7 @@ export class MapService {
         const geoDepth = f['properties']['geoDepth'];
         if (!geoDepth) { f['properties']['geoDepth'] = 0.1; }
         f = this.getUpdatedFeature(f);
-        f['properties']['color'] = this.colors[i]; 
+        f['properties']['color'] = this.colors[i];
         return f;
       });
     this.setHighlightedFeatures(highlightFeatures);

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -201,6 +201,7 @@ export class MapService {
       feats.properties['geoDepth'] = this.map.getZoom();
       return feats;
     } catch (e) { }
+    return null;
   }
 
   /**

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -362,19 +362,19 @@ export class MapComponent implements OnInit, OnChanges {
     }
   }
 
-  /** 
+  /**
    * Updates the active feature highlights and caches the geometry if it is at
    * a higher detail level.
    */
   private updateHighlights() {
-    const updatedFeatures = 
+    const updatedFeatures =
       this.mapService.updateHighlightFeatures(this.activeFeatures);
     // update geometries in place if higher detail
     for (let i = 0; i < this.activeFeatures.length; i++) {
       const f1 = this.activeFeatures[i];
       const f2 = updatedFeatures[i];
       if (
-        !f1.properties['geoDepth'] || 
+        !f1.properties['geoDepth'] ||
         f1.properties['geoDepth'] < f2.properties['geoDepth']
       ) {
         f1.properties['geoDepth'] = f2.properties['geoDepth'];

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -289,7 +289,7 @@ export class MapComponent implements OnInit, OnChanges {
         this.mapService.setLayerGroupVisibility(group, (group.id === layerGroup.id));
       });
       // Reset the hover layer
-      this.mapService.setSourceData('hover');
+      this.mapService.setHoveredFeature(null);
     }
   }
 
@@ -331,14 +331,6 @@ export class MapComponent implements OnInit, OnChanges {
         }
       }
     }
-    // updating the highlighted features when zoom is finished
-    this.loader.isLoading$.take(1)
-      .subscribe(loading => {
-        if (this.activeFeatures.length > 0 && !loading) {
-          this.mapService
-            .updateHighlightFeatures(this.selectedLayer.id, this.activeFeatures);
-        }
-      });
   }
 
   enableZoom() { return this.mapService.enableZoom(); }

--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -54,6 +54,8 @@ export class MapboxComponent implements AfterViewInit {
    * Create map object from mapEl ViewChild
    */
   ngAfterViewInit() {
+    // rendering hover outlines is slow on IE, so disable
+    if (this.platform.isIE) { this.mapService.setHoverEnabled(false); }
     this.embedded = this.platform.nativeWindow.document.querySelector('app-embed');
     this.mapService.embedded = this.embedded;
     this.map = this.mapService.createMap({

--- a/src/app/services/loading.service.ts
+++ b/src/app/services/loading.service.ts
@@ -41,10 +41,9 @@ export class LoadingService {
   start(id: string, done$?: Observable<any>) {
     const timeout$ = timer(this._timeout);
     const itemLoading$ = done$ ? Observable.race(done$, timeout$) : timeout$;
+    this.debug('loading start', id);
     if (this.loadingStore[id]) {
       this.subscriptionStore[id].unsubscribe();
-    } else {
-      this.debug('loading start', id);
     }
     this.loadingStore[id] = itemLoading$;
     this.subscriptionStore[id] = this.loadingStore[id].subscribe(done => this.end(id));

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -97,6 +97,11 @@ export class PlatformService {
       !this.userAgent.includes('firefox');
   }
 
+  /** Returns if the device is Internet Explorer */
+  get isIE(): boolean {
+    return this.userAgent.includes('trident');
+  }
+
   constructor() {
     this.userAgent = this.nativeWindow.navigator.userAgent.toLowerCase();
     // store viewport width / height


### PR DESCRIPTION
Did an optimization pass on hovering and highlights that includes the following updates:

- Reduce calls to `updateHighlightFeatures` and `setSourceData`
- Do not add hover outlines when 3 features are active (still shows tooltip)
- Do not add hover outlines for features that have an active outline
- Cache the highest zoom geometry in for the active map features (closes #855 and removes need for #863 (sorry!))
- Add ability to disable hover outlines via `MapService`, disable for IE... performance is better, but still not good enough (closes #830)