### PR TITLE
IE style fixes

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -471,6 +471,7 @@ $graphTooltipCircleSize: 10px;
   // shift the tooltip to the left and nudge the arrow out of the wrapper
   &.left {
     .tooltip-wrapper {
+      transform: translateX(-74px);
       transform: translateX(calc(-100% - #{grid(3)}));
       .tooltip-arrow {
         right: -1*$tooltipArrowSize;

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -228,6 +228,7 @@
       .card-subheading {
         margin: grid(1) 0 0 0;     
         @include smallCapsText($cardSubheadingSize);
+        width:100%;
       }
       // stacked statistics
       .card-content {

--- a/src/theme/base/inputs.scss
+++ b/src/theme/base/inputs.scss
@@ -4,6 +4,10 @@ $inputPlaceholderColor: $grey2a;
 $inputFontSize: 15px;
 $inputFontSize_lg: 17px;
 
+input:-ms-input-placeholder {
+  color: $inputPlaceholderColor;
+}
+
 .form-control {
   display: block;
   width: 100%;


### PR DESCRIPTION
- Set fallback transform for graph tooltips on the right side of the graph (IE doesnt support `calc()` inside of a transform).  Closes #839 
- Set `-ms-placeholder-input` color.  Cannot override checkboxes, so this is as good as well get to close #841 
- Set width on card parent location names so they don't overflow container.  Closes #574 
