### PR TITLE
Re-order `<link>` and `<meta>` tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,33 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>Eviction Lab: Map and Data</title>
-  <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Google Tag Manager -->
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-M955JVB');</script>
-
-  <!-- Favicons / mobile icons -->
-  <link rel="icon" type="image/x-icon" href="https://beta.evictionlab.org/tool/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://beta.evictionlab.org/tool/assets/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="https://beta.evictionlab.org/tool/assets/images/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://beta.evictionlab.org/tool/assets/images/favicon-16x16.png">
-  <link rel="manifest" href="https://beta.evictionlab.org/tool/assets/manifest.json">
-  <meta name="theme-color" content="#ffffff">
-
-  <!-- Custom Fonts -->
-  <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6135894/6199192/css/fonts.css" />
-  
   <!-- General metadata -->
   <meta name="description" content="We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state." />
   <meta name='author' content='Eviction Lab' />
-
   <!-- Facebook metadata -->
   <meta property="og:locale" content="en_US" />
   <meta property="og:type" content="website" />
@@ -38,14 +17,29 @@
   <meta property="og:site_name" content="Eviction Lab" />
   <meta property="og:image" content="https://beta.evictionlab.org/tool/assets/images/el-facebook-img.jpg" />
   <meta property="og:image:secure_url" content="https://beta.evictionlab.org/tool/assets/images/el-facebook-img.jpg" />
-
   <!-- Twitter metadata -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@EvictionLab" />
   <meta name="twitter:title" content="Eviction Lab: Map and Data" />
   <meta name="twitter:description" content="We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state." />
   <meta name="twitter:image" content="https://beta.evictionlab.org/tool/assets/images/el-twitter-img.jpg" />
-
+  <meta name="theme-color" content="#ffffff">
+  <link rel="manifest" href="https://beta.evictionlab.org/tool/assets/manifest.json">
+  <!-- Favicons / mobile icons: favicon.ico in the root directory -->
+  <link rel="apple-touch-icon" sizes="180x180" href="https://beta.evictionlab.org/tool/assets/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://beta.evictionlab.org/tool/assets/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://beta.evictionlab.org/tool/assets/images/favicon-16x16.png">
+  <!-- Custom Fonts -->
+  <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6135894/6199192/css/fonts.css" />
+  <base href="./">
+  <!-- Google Tag Manager -->
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M955JVB');</script>
   <style>
     .browserupgrade {
       position:absolute;


### PR DESCRIPTION
Adjusts the ordering of meta and link tags, so that meta tags come first to match structure of [HTML5 boilerplate](https://github.com/h5bp/html5-boilerplate/blob/master/src/index.html).  Also removes favicon.ico `<link>` tag, as browsers will automatically pull that from the root directory.

This clears up the multiple requests for the favicon pngs on resize and closes #635 
