### PR TITLE
Download Dialog Updates

### DIFF
--- a/src/app/map-tool/data-panel/download-form/download-form.component.html
+++ b/src/app/map-tool/data-panel/download-form/download-form.component.html
@@ -16,6 +16,7 @@
     i18n="dialog|The Download button to trigger a file download@@dialogDownload" 
     type="button" 
     class="btn btn-primary" 
+    [class.disabled]="!optionChecked"
     (click)="onDownloadClick($event)"
   >{{ 'DATA.DOWNLOAD_BUTTON' | translate }}</button>
   <app-progress-bar [indeterminate]="loading"></app-progress-bar>

--- a/src/theme/base/buttons.scss
+++ b/src/theme/base/buttons.scss
@@ -55,10 +55,11 @@
 .btn-primary {
   @include altSmallCapsText($buttonTextSize);
   border: none;
-  background: $primaryButtonColor;
+  background-color: $primaryButtonColor;
   color: $white;
   height: grid(7);
   padding: 0 grid(7);
+  transition: background-color 0.4s ease-in-out;
   &:hover {
     background: $primaryButtonHoverColor;
   }
@@ -70,6 +71,9 @@
   }
   span + .icon {
     margin: grid(0.5) auto 0;
+  }
+  &.disabled {
+    background-color: $grey3;
   }
 }
 


### PR DESCRIPTION
- Throws an error with the feature GEOIDs and years when download fails, which will be captured by Google Tag Manager.  Closes #877 
- Disables the "Send Report(s)" button until the user selects an option in the dialog, closes #903 