### PR TITLE
Update titles for SEO

### DIFF
--- a/src/environments/metadata.js
+++ b/src/environments/metadata.js
@@ -1,7 +1,7 @@
 module.exports = {
     map: {
         base: '/map/',
-        title: 'Eviction Lab: Map and Data',
+        title: 'Eviction Map &amp; Data',
         description: 'We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state.',
         facebookImg: 'https://beta.evictionlab.org/tool/assets/images/el-facebook-img.jpg',
         twitterImg: 'https://beta.evictionlab.org/tool/assets/images/el-twitter-img.jpg',
@@ -9,7 +9,7 @@ module.exports = {
     },
     rankings: {
         base: '/rankings/',
-        title: 'Eviction Lab: Rankings',
+        title: 'Eviction Rankings',
         description: 'We’ve built the first nationwide database of evictions. Use our Rankings tool to compare your area\'s eviction rate with thousands of other places across America.',
         facebookImg: 'https://beta.evictionlab.org/tool/assets/images/el-facebook-img.jpg',
         twitterImg: 'https://beta.evictionlab.org/tool/assets/images/el-twitter-img.jpg',

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Eviction Lab: Map and Data</title>
+  <title>Eviction Map &amp; Data | Eviction Lab</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- General metadata -->
   <meta name="description" content="We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state." />
@@ -11,7 +11,7 @@
   <!-- Facebook metadata -->
   <meta property="og:locale" content="en_US" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Eviction Lab: Map and Data" />
+  <meta property="og:title" content="Eviction Map &amp; Data" />
   <meta property="og:description" content="We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state." />
   <meta property="og:url" content="https://beta.evictionlab.org/map/" />
   <meta property="og:site_name" content="Eviction Lab" />
@@ -20,7 +20,7 @@
   <!-- Twitter metadata -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@EvictionLab" />
-  <meta name="twitter:title" content="Eviction Lab: Map and Data" />
+  <meta name="twitter:title" content="Eviction Map &amp; Data" />
   <meta name="twitter:description" content="We’ve built the first nationwide database of evictions. Use our customizable map to find and compare eviction rates in your neighborhood, city, or state." />
   <meta name="twitter:image" content="https://beta.evictionlab.org/tool/assets/images/el-twitter-img.jpg" />
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
Closes #906. I'm assuming that `&amp;` will be rendered as `&` in the Facebook and Twitter metadata, and that the | delimiter is only for the actual page title and not needed for the social media metadata?