### PR TITLE
Updates for null line style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,15 +524,15 @@
       }
     },
     "@types/d3": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.12.0.tgz",
-      "integrity": "sha512-F5lVj6c2G/WPbKFk4ZVxTS8F/6IRknWcheswQcycMjBh17iJ+bRfNUtn0yvtIHtRPQSanI9Dx2U8rSSA/I+ecQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
+      "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
       "requires": {
         "@types/d3-array": "1.2.1",
         "@types/d3-axis": "1.0.9",
         "@types/d3-brush": "1.0.7",
         "@types/d3-chord": "1.0.6",
-        "@types/d3-collection": "1.0.5",
+        "@types/d3-collection": "1.0.6",
         "@types/d3-color": "1.0.5",
         "@types/d3-dispatch": "1.0.5",
         "@types/d3-drag": "1.2.0",
@@ -540,7 +540,7 @@
         "@types/d3-ease": "1.0.7",
         "@types/d3-force": "1.1.0",
         "@types/d3-format": "1.2.1",
-        "@types/d3-geo": "1.9.4",
+        "@types/d3-geo": "1.10.0",
         "@types/d3-hierarchy": "1.1.0",
         "@types/d3-interpolate": "1.1.6",
         "@types/d3-path": "1.0.6",
@@ -549,9 +549,9 @@
         "@types/d3-queue": "3.0.5",
         "@types/d3-random": "1.1.0",
         "@types/d3-request": "1.0.2",
-        "@types/d3-scale": "1.0.11",
-        "@types/d3-selection": "1.2.0",
-        "@types/d3-shape": "1.2.1",
+        "@types/d3-scale": "1.0.12",
+        "@types/d3-selection": "1.3.0",
+        "@types/d3-shape": "1.2.2",
         "@types/d3-time": "1.0.7",
         "@types/d3-time-format": "2.1.0",
         "@types/d3-timer": "1.0.6",
@@ -570,7 +570,7 @@
       "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.9.tgz",
       "integrity": "sha512-fNUnI2a0F3xiE/nGrTdDpZG4sdcRIB4X59p9jgY8O7RQiKrVqyb433YCCYSqVID4CVyoq5v3bSFliUEk0FOMsw==",
       "requires": {
-        "@types/d3-selection": "1.2.0"
+        "@types/d3-selection": "1.3.0"
       }
     },
     "@types/d3-brush": {
@@ -578,7 +578,7 @@
       "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.7.tgz",
       "integrity": "sha1-BcMEQPTVN/0j+Xaw5sS6IjAB70U=",
       "requires": {
-        "@types/d3-selection": "1.2.0"
+        "@types/d3-selection": "1.3.0"
       }
     },
     "@types/d3-chord": {
@@ -587,9 +587,9 @@
       "integrity": "sha1-BYnrl6MZH07a8Xt73kmEYokM4ew="
     },
     "@types/d3-collection": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.5.tgz",
-      "integrity": "sha1-ux86qXzcjYgWRVQbnWz4ft/um8M="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.6.tgz",
+      "integrity": "sha512-UHBvaU2wT5GlJN6rRVQm42211uAyZtp7m0jpQFuMuX7hTuivc0tcF0cjx5Ny5eQkhIolEyKwWgvJexw4e8g4+A=="
     },
     "@types/d3-color": {
       "version": "1.0.5",
@@ -606,7 +606,7 @@
       "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.0.tgz",
       "integrity": "sha512-AePmm0sXj0Tpl0uQWvwmbAf1QR3yCy9aRhjJ9mRDDSZlHBdY0SCpUtdZC9uG9Q+pyHT/dEt1R2FT/sj+5k/bVA==",
       "requires": {
-        "@types/d3-selection": "1.2.0"
+        "@types/d3-selection": "1.3.0"
       }
     },
     "@types/d3-dsv": {
@@ -630,9 +630,9 @@
       "integrity": "sha512-dXhA9jzCbzu6Va8ZVUQ60nu6jqA5vhPhKGR4nY3lDYfjT05GyKEKuEhfwTaSTybWczY4nLEkzv9wLQCQd5+3cA=="
     },
     "@types/d3-geo": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.9.4.tgz",
-      "integrity": "sha512-DoigJorMGGIG9K4n980zz5g1XnvhDhNy7rk/0O8KCpFPpUZ9hyAgN0ZHXhbtIelxhJhMZxwMRe2soxx/Fhx4Hg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.0.tgz",
+      "integrity": "sha512-cUdeIcK2scvFBAwysPV6Y9ioflhD3RYjZw41m9vEDvFCZWuRI0Xax5LR/Vz0ohet0JbAfF/r69R8HoN3hv5IJg==",
       "requires": {
         "@types/geojson": "1.0.6"
       }
@@ -684,22 +684,22 @@
       }
     },
     "@types/d3-scale": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.11.tgz",
-      "integrity": "sha512-W7Rir91wwuVYDFesVqlFdwmbsr4QYk+Ens7oEoMruX2zx2GB5BS71g1EDQ90doJgyWRmlglptEd0nPjwRkpgfg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.12.tgz",
+      "integrity": "sha512-2Z3YsHdWRBuUiqKHcnWVF1ffuALFn+k74QEECUCpzabD/5Olxvs/aJM4eG3QTe5n9yiWK432kOEpinGvO1wDfA==",
       "requires": {
         "@types/d3-time": "1.0.7"
       }
     },
     "@types/d3-selection": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.2.0.tgz",
-      "integrity": "sha512-QPmtQnzJA8dtKEd1+FbtirI6ENncf52I754Jidnvnozo+bqJpl3oaZADth7gDamQWx0bJmFrajvxkPxfh88+Ow=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-1SJhi3kTk/SHHIE6XkHuHU2REYkbSOjkQuo3HT71FOTs8/tjeGcvtXMsX4N3kU1UE1nVG+A5pg7TSjuJ4zUN3A=="
     },
     "@types/d3-shape": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.1.tgz",
-      "integrity": "sha512-y0QmQtKns0IHBoG80yGLo6rmznHjZs/JODxc9kOgQgkCUe2e07X9DPghXE1KbTTAIr9U85Xm8YSbSzx/ytxyYg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.2.tgz",
+      "integrity": "sha512-Ydksrces8J5WP/NXhZ/CcDx/XZZ8b7MDX+u6WGQXwEWfmimJn9eYHiD7QR4BLe3zBiAOQmmiGAwRBKUDp5zb1g==",
       "requires": {
         "@types/d3-path": "1.0.6"
       }
@@ -724,7 +724,7 @@
       "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
       "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
       "requires": {
-        "@types/d3-selection": "1.2.0"
+        "@types/d3-selection": "1.3.0"
       }
     },
     "@types/d3-voronoi": {
@@ -738,7 +738,7 @@
       "integrity": "sha512-eIivt2ehMUXqS0guuVzRSMr5RGhO958g9EKxIJv3Z23suPnX4VQI9k1TC/bLuwKq0IWp9a1bEEcIy+PNJv9BtA==",
       "requires": {
         "@types/d3-interpolate": "1.1.6",
-        "@types/d3-selection": "1.2.0"
+        "@types/d3-selection": "1.3.0"
       }
     },
     "@types/geojson": {
@@ -931,9 +931,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "angular-d3-graph": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.12.tgz",
-      "integrity": "sha512-dM+dMvlpu49I9j/2Xgv1ZlSqca8VMI6+zBNEalS9WGUhs0Coy+2yZWAqQnwWZ2xTfDQdOQ83uZN4ZwpkKHI5OQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.13.tgz",
+      "integrity": "sha512-g4Exp2/+Hu5h4CUDq2r3gqjl2heG7tIblXchjy6bpMesc8f56aJ6wI3PB/uhh9jYVvDl66aDXTsA2uJq/KOr4A==",
       "requires": {
         "@angular/animations": "5.0.3",
         "@angular/common": "5.0.3",
@@ -946,7 +946,7 @@
         "@angular/platform-browser-dynamic": "5.0.3",
         "@angular/platform-server": "5.0.3",
         "@angular/router": "5.0.3",
-        "@types/d3": "4.12.0",
+        "@types/d3": "4.13.0",
         "core-js": "2.5.1",
         "d3-array": "1.2.1",
         "d3-axis": "1.0.8",
@@ -954,11 +954,11 @@
         "d3-format": "1.2.2",
         "d3-line-chunked": "1.4.1",
         "d3-scale": "1.0.7",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-shape": "1.2.0",
         "d3-zoom": "1.7.1",
         "lodash.isequal": "4.5.0",
-        "lodash.merge": "4.6.0",
+        "lodash.merge": "4.6.1",
         "rxjs": "5.5.2",
         "uuid": "3.1.0",
         "zone.js": "0.8.18"
@@ -2584,7 +2584,7 @@
       "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
       "requires": {
         "d3-dispatch": "1.0.3",
-        "d3-selection": "1.2.0"
+        "d3-selection": "1.3.0"
       }
     },
     "d3-dsv": {
@@ -2631,7 +2631,7 @@
         "d3-array": "1.2.1",
         "d3-interpolate": "1.1.6",
         "d3-interpolate-path": "1.1.1",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-shape": "1.2.0",
         "d3-transition": "1.1.1"
       }
@@ -2656,9 +2656,9 @@
       }
     },
     "d3-selection": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.2.0.tgz",
-      "integrity": "sha512-xW2Pfcdzh1gOaoI+LGpPsLR2VpBQxuFoxvrvguK8ZmrJbPIVvfNG6pU6GNfK41D6Qz15sj61sbW/AFYuukwaLQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
     },
     "d3-shape": {
       "version": "1.2.0",
@@ -2695,7 +2695,7 @@
         "d3-dispatch": "1.0.3",
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-timer": "1.0.7"
       }
     },
@@ -2707,7 +2707,7 @@
         "d3-dispatch": "1.0.3",
         "d3-drag": "1.2.1",
         "d3-interpolate": "1.1.6",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-transition": "1.1.1"
       }
     },
@@ -6642,9 +6642,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.41.0",
-    "angular-d3-graph": "^2.0.12",
+    "angular-d3-graph": "^2.0.13",
     "clipboard": "^1.7.1",
     "core-js": "^2.4.1",
     "d3-dsv": "^1.0.8",

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -23,10 +23,23 @@
   .g3-start { stop-color: #C6D5E0; }
   .g3-end { stop-color: #94AABD; }
   .app-graph {
-    .line-0 { stroke: $c1; stroke-width: $strokeWidth; }
-    .line-1 { stroke: $c2; stroke-width: $strokeWidth; }
-    .line-2 { stroke: $c3; stroke-width: $strokeWidth; }
-    .line-3 { stroke: $c4; stroke-width: $strokeWidth; }
+    .line-0 {
+      stroke: $c1; stroke-width: $strokeWidth;
+      circle { fill: $c1; }
+    }
+    .line-1 {
+      stroke: $c2; stroke-width: $strokeWidth;
+      circle { fill: $c2; }
+    }
+    .line-2 {
+      stroke: $c3; stroke-width: $strokeWidth;
+      circle { fill: $c3; }
+    }
+    .line-3 {
+      stroke: $c4; stroke-width: $strokeWidth;
+      circle { fill: $c4; }
+    }
+    circle { stroke-width: 0 }
   }
 
 }


### PR DESCRIPTION
Closes #888, dependent on https://github.com/EvictionLab/angular-d3-graph/pull/15. The transitions look the same, except any circles shrink and reappear. Some examples (I deleted chunks of the data rather than track down examples)

<img width="1222" alt="screen shot 2018-03-27 at 10 53 16 am" src="https://user-images.githubusercontent.com/8291663/37979626-ad0a2914-31ae-11e8-9c9f-bb40f597bd48.png">

<img width="1209" alt="screen shot 2018-03-27 at 10 58 53 am" src="https://user-images.githubusercontent.com/8291663/37979635-b09d2a4a-31ae-11e8-8f39-11f8ae9d6dc4.png">
