### PR TITLE
More IE fixes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,6 +38,7 @@ export class AppComponent implements OnInit {
   @HostBinding('class.safari') safari = false;
   @HostBinding('class.ios-safari') iosSafari = false;
   @HostBinding('class.android') android = false;
+  @HostBinding('class.ie') ie = false;
   currentMenuItem: string;
   menuActive = false;
   siteNav = environment.siteNav;
@@ -89,6 +90,7 @@ export class AppComponent implements OnInit {
     this.safari = this.platform.isSafari;
     this.iosSafari = this.platform.isIosSafari;
     this.android = this.platform.isAndroid;
+    this.ie = this.platform.isIE;
   }
 
   closeMenu() {

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -131,6 +131,7 @@ $bubbleColor: rgba(255,4,0,0.65);
   }
   .choropleth-legend {
     width: grid(22);
+    min-width: grid(22);
   }
   .legend-middle {
     display: block;

--- a/src/theme/base/hacks.scss
+++ b/src/theme/base/hacks.scss
@@ -18,3 +18,16 @@ body { padding-right: 0 !important; }
   }
   .graph-area app-graph.average-shown .app-graph rect.bar:last-of-type { fill: $color4 !important; }
 }
+
+
+// IE: set some alternate styles for the navbar because sticky is not supported
+@media(min-width: $gtMobile) {
+  .ie .nav-bar {
+    position: relative;
+    left:auto;right:auto;bottom:auto;top:auto;
+  }
+}
+
+.ie .content-evictions {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
- Set min-width on choropleth legend (closes #910)
- Add `.ie` class to app wrapper for hack styling that can't be fixed with feature detection
- Override IE position styles on nav bar (Closes #913 )
- Override bottom margin on content so full list is visible (closes #916 )
