### PR TITLE
Caps bubble sizes, fixes radius

### DIFF
--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -249,16 +249,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 2,
             0, 2.5,
-            30, 60
+            30, 60,
+            500, 60
           ],
           6, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 3,
             0, 2.5,
-            30, 120
+            30, 90,
+            500, 90
           ]
         ]
       ],
@@ -267,16 +269,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1.5,
             0, 1,
-            30, 10
+            30, 7.5,
+            500, 7.5
           ],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 4,
             0, 2,
-            30, 30
+            30, 30,
+            500, 30
           ]
         ]
       ],
@@ -284,17 +288,19 @@ export const DataAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['get', 'PROP'],
         [
           'interpolate', ['linear'], ['zoom'],
-          2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+          3, [
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1,
             0, 1,
-            30, 7.5
+            60, 7.5,
+            500, 7.5
           ],
           10, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 3,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 2,
             0, 1,
-            30, 20
+            60, 15,
+            500, 15
           ]
         ]
       ],
@@ -303,16 +309,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1.5,
             0, 1,
-            30, 10
+            50, 12.5,
+            500, 12.5
           ],
           12, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 4,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 3,
             0, 2,
-            30, 45
+            30, 30,
+            500, 30
           ]
         ]
       ],
@@ -321,16 +329,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 2,
             0, 1,
-            30, 7.5
+            30, 7.5,
+            500, 7.5
           ],
           12, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 4,
             0, 2,
-            30, 30
+            30, 30,
+            500, 30
           ]
         ]
       ]
@@ -357,16 +367,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 2,
             0, 2.5,
-            45, 60
+            40, 40,
+            500, 40
           ],
           6, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 3,
             0, 2.5,
-            45, 120
+            40, 80,
+            500, 80
           ]
         ]
       ],
@@ -375,16 +387,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1.5,
             0, 1,
-            45, 10
+            60, 7.5,
+            500, 7.5
           ],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 4,
             0, 2,
-            45, 30
+            60, 30,
+            500, 30
           ]
         ]
       ],
@@ -392,17 +406,19 @@ export const DataAttributes: Array<MapDataAttribute> = [
         'let', 'data_prop', ['get', 'PROP'],
         [
           'interpolate', ['linear'], ['zoom'],
-          2, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+          3, [
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1,
             0, 1,
-            45, 7.5
+            100, 7.5,
+            500, 7.5
           ],
           10, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 3,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 2,
             0, 1,
-            45, 20
+            100, 15,
+            500, 15
           ]
         ]
       ],
@@ -411,16 +427,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 2,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 1.5,
             0, 1,
-            45, 10
+            50, 12.5,
+            500, 12.5
           ],
           12, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
-            -1, 4,
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
+            -1, 3,
             0, 2,
-            45, 45
+            60, 30,
+            500, 30
           ]
         ]
       ],
@@ -429,16 +447,18 @@ export const DataAttributes: Array<MapDataAttribute> = [
         [
           'interpolate', ['linear'], ['zoom'],
           8, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 2,
             0, 1,
-            45, 7.5
+            60, 7.5,
+            500, 7.5
           ],
           12, [
-            'interpolate', ['exponential', 1], ['number', ['var', 'data_prop']],
+            'interpolate', ['linear'], ['number', ['var', 'data_prop']],
             -1, 4,
             0, 2,
-            45, 30
+            60, 30,
+            500, 30
           ]
         ]
       ]

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
@@ -21,8 +21,8 @@ export class UiMapLegendComponent implements OnChanges {
   /** Gets the fill stops based on the selected choropleth */
   stops;
   /** Radius and values for bubble legend. Max value changes with screen size */
-  minBubbleRadius = 4;
-  get maxBubbleRadius() { return this.platform.isLargerThanMobile ? 12 : 8; }
+  minBubbleRadius = 2;
+  get maxBubbleRadius() { return this.platform.isLargerThanMobile ? 8 : 4; }
   minBubbleValue: number;
   maxBubbleValue: number;
   hasBubbles = false;
@@ -159,13 +159,14 @@ export class UiMapLegendComponent implements OnChanges {
    */
   private bubbleValue(radius: number, mapZoom: number, steps: any[]) {
     const minZoom = steps[0];
-    const minVal = this.interpolateValue(radius, steps[1].slice(5));
+    const minVal = this.interpolateValue(radius, steps[1].slice(5, -2));
     const maxZoom = steps[steps.length - 2];
-    const maxVal = this.interpolateValue(radius, steps[steps.length - 1].slice(5));
+    const maxVal = this.interpolateValue(radius, steps[steps.length - 1].slice(5, -2));
     // Clamp zoom to range
     const zoom = Math.max(minZoom, Math.min(mapZoom, maxZoom));
 
-    return this.interpolateValue(zoom, [minVal, minZoom, maxVal, maxZoom]);
+    // Don't return less than 0
+    return Math.max(0, this.interpolateValue(zoom, [minVal, minZoom, maxVal, maxZoom]));
   }
 
   /**


### PR DESCRIPTION
Closes #922. Caps the max bubble size and fixes the radius numbers (previously it was returning double the expected value)

Maryland is still significantly bigger, but less overwhelming now
<img width="1055" alt="screen shot 2018-03-28 at 9 45 37 am" src="https://user-images.githubusercontent.com/8291663/38036719-f1b48abe-326c-11e8-8d03-eaaa99cf381e.png">
