### PR TITLE
Increase tract, bg tile zoom

### DIFF
--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -580,7 +580,7 @@ export class MapToolService {
       case 'cities':
         return 8;
       default:
-        return 10;
+        return 9;
     }
   }
 


### PR DESCRIPTION
This is a small fix, but for some of the larger census tracts and block groups it seems safer to search zoom 9 instead of zoom 10 tiles for additional data