### PR TITLE
Fix embed popup eviction props

### DIFF
--- a/src/app/map-tool/map/mapbox/mapbox.component.ts
+++ b/src/app/map-tool/map/mapbox/mapbox.component.ts
@@ -255,6 +255,17 @@ export class MapboxComponent implements AfterViewInit {
       let popupData = `<p>${feature.properties.n}, ${feature.properties.pl}</p>`;
       if (this.mapConfig['popupProps']) {
         const yearSuffix = this.mapConfig['year'].toString().slice(2);
+        // Add centers if an eviction prop is included
+        if (this.mapConfig['popupProps'].find(p => p.type === 'bubble')) {
+          const centerLayerId = `${feature['layer']['id']}_bubbles`;
+          const centerFeatures = this.map.queryRenderedFeatures(undefined, {
+            layers: [centerLayerId],
+            filter: ['==', 'GEOID', feature.properties['GEOID']]
+          });
+          const centerFeat = centerFeatures.length > 0 ? centerFeatures[0] : { properties: {} };
+          feature.properties = { ...feature.properties, ...centerFeat.properties };
+        }
+
         this.mapConfig['popupProps'].forEach(p => {
           const label = this.translate.transform(p['langKey']);
           let value;


### PR DESCRIPTION
Because of the refactor where we took the eviction data out of the shape tile layer, the embed view popup was showing "Unavailable" for every eviction property. The performance on this probably isn't amazing, but since it's only for the embed I added a call to `queryRenderedFeatures` to pull the center feature properties and combine them with the shape feature so the actual eviction rate or eviction filing rate is displayed