### PR TITLE
Fix Ranking Overflow

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -295,6 +295,7 @@
 }
 
 .close-button {
+  border-radius:0;
   cursor: pointer;
   text-align: center;
   padding: grid(1.25);

--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -54,11 +54,13 @@
 @media(min-width: $gtMobile) {
   .panel-summary-heading {
     text-align: left;
+    max-width: calc(100% - #{grid(20)});
   }
 }
 @media(min-width: $gtLaptop) {
   .panel-summary-heading {
     margin-top: grid(1);
+    max-width: none;
   }
 }
 
@@ -66,6 +68,8 @@
 // ---
 .panel-top {
   text-align: center;
+  width: calc(100% - 40px); // keep some space for arrows
+  margin:auto;
 }
 @media(min-width: $gtMobile) {
   .panel-top {
@@ -139,10 +143,16 @@
 @media(min-width: $gtMobile) {
   .rank-location {
     @include altSmallCapsText(26px);
+    @include ellipsis-overflow();
     text-align: left;
     span {
       @include smallCapsText(14px);
     }
+  }
+}
+@media(min-width: $gtTablet) {
+  .rank-location {
+    
   }
 }
 @media(min-width: $gtLaptop) {
@@ -234,6 +244,7 @@
       max-width: none;
       text-align: left;
       margin-top: grid(2);
+      margin-left: grid(19);
     }
   }
 }

--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -151,11 +151,6 @@
     }
   }
 }
-@media(min-width: $gtTablet) {
-  .rank-location {
-    
-  }
-}
 @media(min-width: $gtLaptop) {
   .rank-location {
     display: block;

--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -114,6 +114,7 @@
   .rank-number {
     float:left;
     margin-top: grid(1);
+    margin-bottom: grid(3); // keeps text aligned when it wraps to 3 lines
     padding: 0 grid(2);
     min-width: grid(15);
     height: grid(15);

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.html
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.html
@@ -52,8 +52,7 @@
     class="btn btn-icon scroll-to-top-button z1"
     [attr.aria-label]="'NAV.SCROLL_TO_TOP' | translate"
     [class.visible]="showScrollButton"
-    [class.panel-open]="selectedIndex"
-    (click)="goToTop.emit()"
+    (click)="scrollToTop()"
   >
     <app-ui-icon icon="arrow-up"></app-ui-icon>
   </button>

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.html
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.html
@@ -48,6 +48,15 @@
   *ngIf="listData"
   [class.visible]="canRetrieveData && (selectedIndex || selectedIndex === 0)"
 >
+  <button 
+    class="btn btn-icon scroll-to-top-button z1"
+    [attr.aria-label]="'NAV.SCROLL_TO_TOP' | translate"
+    [class.visible]="showScrollButton"
+    [class.panel-open]="selectedIndex"
+    (click)="goToTop.emit()"
+  >
+    <app-ui-icon icon="arrow-up"></app-ui-icon>
+  </button>
   <app-ranking-panel
     [class]="'area-'+areaType.value"
     [topCount]="topCount"

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, OnInit, Input, OnDestroy, ViewChild, Inject, AfterViewInit, ChangeDetectorRef,
-  HostListener
+  HostListener, Output
 } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
@@ -19,6 +19,7 @@ import { AnalyticsService } from '../../../services/analytics.service';
 import { RankingUiComponent } from '../../ranking-ui/ranking-ui.component';
 import { RankingListComponent } from '../../ranking-list/ranking-list.component';
 import { RankingPanelComponent } from '../../ranking-panel/ranking-panel.component';
+import { EventEmitter } from 'protractor';
 
 
 @Component({
@@ -75,6 +76,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
     if (panelOpened) { this.focusPanel(); }
     this.updateTweet();
   }
+  @Output() goToTop = new EventEmitter();
   get selectedIndex(): number { return this.store.selectedIndex; }
   /** Reference to the ranking list component */
   @ViewChild(RankingListComponent) rankingList: RankingListComponent;

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -22,7 +22,6 @@
       [areaType]="areaType"
       [dataProperty]="dataProperty"
       [selectedIndex]="selectedIndex"
-      (goToTop)="scrollToTop()"
     ></app-evictions>
     <app-evictors
       class="ranking-component"

--- a/src/app/ranking/ranking-tool/ranking-tool.component.html
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.html
@@ -22,6 +22,7 @@
       [areaType]="areaType"
       [dataProperty]="dataProperty"
       [selectedIndex]="selectedIndex"
+      (goToTop)="scrollToTop()"
     ></app-evictions>
     <app-evictors
       class="ranking-component"
@@ -29,15 +30,6 @@
       [dataProperty]="dataProperty"
     ></app-evictors>
   </div>
-  <button 
-    class="btn btn-icon scroll-to-top-button z1"
-    [attr.aria-label]="'NAV.SCROLL_TO_TOP' | translate"
-    [class.visible]="showScrollButton"
-    [class.panel-open]="selectedIndex && activeTab === 'evictions'"
-    (click)="scrollToTop()"
-  >
-    <app-ui-icon icon="arrow-up"></app-ui-icon>
-</button>
 </div>
 
 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -39,7 +39,7 @@ $panelHeightLg: 194px;
 }
 
 .content-evictions {
-  margin-bottom: -1*$panelHeightSm;
+  margin-bottom: 0;
   &.panel-open { margin-bottom: 0; }
 }
 
@@ -349,7 +349,8 @@ app-ranking-ui.ranking-ui-panel {
   margin:  0 0 grid(2) auto;
   z-index: 20;
   border-radius:0;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease-in-out;
+  transform: translate3d(250%, 0, 0);
   .icon {
     width: 13px;
     height: 13px;
@@ -365,7 +366,7 @@ app-ranking-ui.ranking-ui-panel {
   }
 }
 // shift to the left of the close button when panel is open
-.visible .btn.btn-icon.scroll-to-top-button {
+.visible .btn.btn-icon.scroll-to-top-button.visible {
   transform: translate3d((-1*grid(6)), 0, 0);
 }
 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -40,7 +40,6 @@ $panelHeightLg: 194px;
 
 .content-evictions {
   margin-bottom: 0;
-  &.panel-open { margin-bottom: 0; }
 }
 
 .hero {

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -253,6 +253,7 @@ app-ranking-ui.ranking-ui-panel {
 // Rankings Page Body
 // ---
 .ranking-body {
+  min-height: 100vh;
   & > h2 {
     margin: grid(2) 0 grid(1);
     @include altFont(16px);
@@ -322,7 +323,6 @@ app-ranking-ui.ranking-ui-panel {
   bottom:0;
   left:0;
   right:0;
-  height: $panelHeightSm;
   background: $white;
   z-index:21;
   box-shadow: $z1shadow;
@@ -336,69 +336,43 @@ app-ranking-ui.ranking-ui-panel {
   }
 }
 
-@media(min-width: $gtMobile) {
-  .page-fixed-bottom {
-    height: $panelHeightMd;
-  }
-}
-@media(min-width: $gtLaptop) {
-  .page-fixed-bottom {
-    height: $panelHeightLg;
-  }
-}
-
 .btn.btn-icon.scroll-to-top-button {
-  position: sticky;
+  position:absolute;
+  top: -1*grid(7);
+  right: $pageMargin;
   cursor: pointer;
   text-align: center;
   padding: grid(1.25);
   width: grid(5);
   height: grid(5);
   background: $white;
-  right: $pageMargin;
-  bottom: $pageMargin;
-  margin:  -1*grid(7) 0 grid(2) auto;
+  margin:  0 0 grid(2) auto;
   z-index: 20;
-  transition: transform 0.4s ease;
-  transform: translate3d(0, 250%, 0);
-  &.visible {
-    transform: translate3d(0, 0, 0);
-  }
-  // &.panel-open {
-  //   transform: translate3d(-100%, 0, 0);
-  //   right: $pageMargin + grid(2);
-  // }
-  &.visible.panel-open {
-    transform: translate3d(-100%, -1*$panelHeightSm, 0);
-  }
+  border-radius:0;
+  transition: transform 0.2s ease;
   .icon {
     width: 13px;
     height: 13px;
     margin:auto;
     fill: $color1;
   }
+  &.visible {
+    transform: translate3d(0, 0, 0);
+  }
   &:hover, &:active {
     background-color: $color1;
     .icon { fill: $white; }
   }
 }
+// shift to the left of the close button when panel is open
+.visible .btn.btn-icon.scroll-to-top-button {
+  transform: translate3d((-1*grid(6)), 0, 0);
+}
 
 @media(min-width: $gtMobile) {
   .btn.btn-icon.scroll-to-top-button {
+    top: -1*grid(8);
     right: $pageMarginLg;
-    bottom: $pageMarginLg;
-    margin:  -1*grid(8) 0 grid(3) auto;
-    &.panel-open {
-      right: $pageMarginLg + grid(2);
-    }
-    &.visible.panel-open {
-      transform: translate3d(-100%, -1*$panelHeightMd, 0);
-    }
-  }
-}
-@media(min-width: $gtLaptop) {
-  .btn.btn-icon.scroll-to-top-button.visible.panel-open {
-    transform: translate3d(-100%, -1*($panelHeightLg), 0);
   }
 }
 

--- a/src/app/ranking/ranking-tool/ranking-tool.component.ts
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, OnInit, OnDestroy, ViewChild, Inject, ViewEncapsulation, ElementRef, AfterViewInit
+  Component, OnInit, OnDestroy, ViewChild, Inject, ViewEncapsulation, ElementRef
 } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, RouterLink } from '@angular/router';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
@@ -22,9 +22,8 @@ import { RankingUiComponent } from '../ranking-ui/ranking-ui.component';
   providers: [TranslatePipe, DecimalPipe],
   encapsulation: ViewEncapsulation.None
 })
-export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
-  /** page content element */
-  @ViewChild('content') contentEl: ElementRef;
+export class RankingToolComponent implements OnInit, OnDestroy {
+
   /** identifier for the component so AppComponent can detect type */
   id = 'ranking-tool';
   /** tab ID for the active tab */
@@ -33,8 +32,6 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
   areaType;
   dataProperty;
   selectedIndex;
-  /** Boolean of whether to show scroll to top button */
-  showScrollButton = false;
 
   private ngUnsubscribe: Subject<any> = new Subject();
 
@@ -58,10 +55,6 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe(this.onRouteChange.bind(this));
     this.route.queryParams.takeUntil(this.ngUnsubscribe)
       .subscribe(this.onQueryParamChange.bind(this));
-  }
-
-  ngAfterViewInit() {
-    this.setupPageScroll();
   }
 
   switchTab(id: string) {
@@ -100,28 +93,5 @@ export class RankingToolComponent implements OnInit, OnDestroy, AfterViewInit {
       this.activeTab = url[0].path;
     }
   }
-
-  scrollToTop() {
-    this.scroll.scrollTo(this.contentEl.nativeElement);
-    // set focus to an element at the top of the page for keyboard nav
-    const focusableEl = this.contentEl.nativeElement.querySelector('app-ranking-list button');
-    setTimeout(() => {
-      if (focusableEl.length) {
-        focusableEl[0].focus();
-        focusableEl[0].blur();
-      }
-    }, this.scroll.defaultDuration);
-  }
-
-
-  private setupPageScroll() {
-    this.scroll.defaultScrollOffset = 175;
-    const listYOffset = this.contentEl.nativeElement.getBoundingClientRect().top;
-    this.scroll.verticalOffset$.debounceTime(100)
-      .subscribe(offset => {
-        this.showScrollButton = offset > listYOffset;
-      });
-  }
-
 
 }


### PR DESCRIPTION
Closes #932   
  - Adjustments so that the ranking panel does not need a fixed height 
  - Limiting long titles to one line
  - Moves scroll to top button inside of `evictions.component`
  - Set offset to show scroll to top button to a fixed number (we were detecting dynamically, but it's not really needed and this is better for performance)

Mobile: 
![image](https://user-images.githubusercontent.com/21034/38059391-7ffc3a5c-32a3-11e8-923e-718557ad6882.png)

Tablet portrait:
![image](https://user-images.githubusercontent.com/21034/38059556-12ca709c-32a4-11e8-84b9-f445e89b2956.png)
