### PR TITLE
Cap displayed rate value at >100%, format rankings numbers

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -161,7 +161,7 @@ export class DataPanelComponent implements OnInit {
       tweetParams['place1'] = feat.n;
       tweetParams['perDay'] = feat[`epd-${yearSuffix}`];
       tweetParams['total'] = this.decimal.transform(feat[`${action.slice(0, -1)}-${yearSuffix}`]);
-      tweetParams['rate'] = this.decimal.transform(feat[`${action}-${yearSuffix}`]);
+      tweetParams['rate'] = this.cappedRateValue(feat[`${action}-${yearSuffix}`]);
 
       if (featLength === 1) {
         actionTrans = action === 'efr' ? 'DATA.TWEET_EVICTION_FILINGS' : 'DATA.TWEET_EVICTIONS';
@@ -203,5 +203,10 @@ export class DataPanelComponent implements OnInit {
       const splitUrl = url.split('/map/');
       return [splitUrl[0], '/map/embed/', ...splitUrl.slice(1)].join('');
     }
+  }
+
+  /** Returns the formatted rate number, with >100 instead of values over */
+  private cappedRateValue(val: number): string {
+    return val > 100 ? '>100' : this.decimal.transform(val, '1.1-2');
   }
 }

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -24,7 +24,7 @@
           <app-ui-hint *ngIf="prop.hintKey" class="attribute-hint" [hint]="prop.hintKey | translate" placement="right" triggers="hover touchend focus"></app-ui-hint>
         </span>
         <span *ngIf="prop.id !== 'divider'" class="card-stat-value" [class.unavailable]="!(f.properties[prop.yearAttr] >= 0)">
-          <span *ngIf="f.properties[prop.yearAttr] >= 0">{{ prefix(prop.id) }}{{ (f.properties[prop.yearAttr] | number) }}{{ suffix(prop.id) }}</span>
+          <span *ngIf="f.properties[prop.yearAttr] >= 0">{{ prefix(prop.id) }}{{ processValue(f, prop) }}{{ suffix(prop.id) }}</span>
           <span *ngIf="!(f.properties[prop.yearAttr] >= 0)">{{ 'DATA.UNAVAILABLE' | translate }}</span>
         </span>
         <span *ngIf="prop.id === 'divider'" class="card-stat-label">{{ 'STATS.DEMOGRAPHICS' | translate }}</span>

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -181,6 +181,14 @@ export class LocationCardsComponent implements OnInit {
     return (this.percentProps.indexOf(prop) !== -1) ? '%' : null;
   }
 
+  /** Handle capping rate values at >100 */
+  processValue(feat: MapFeature, prop: MapDataAttribute) {
+    if (prop.type === 'bubble' && feat.properties[prop.yearAttr] > 100) {
+      return '>100';
+    }
+    return this.decimal.transform(feat.properties[prop.yearAttr], '1.0-2');
+  }
+
   /** Add a reference to the current year property name for each data attribute */
   private addYearAttrToProps() {
     this._cardProps = this._cardProps.map(p => {

--- a/src/app/ranking/ranking-list/ranking-list.component.html
+++ b/src/app/ranking/ranking-list/ranking-list.component.html
@@ -15,7 +15,7 @@
       <div class="ranking-content">
         <span class="ranking-name">{{ listItem[propertyMap.primary] }}</span><span class="place-separator">,</span>
         <span class="ranking-parent">{{listItem[propertyMap.secondary]}}</span>
-        <span *ngIf="listItem[dataProperty.value] >= 0" class="ranking-value">{{listItem[dataProperty.value]}}{{ isRate ? '%' : '' }}</span>
+        <span *ngIf="listItem[dataProperty.value] >= 0" class="ranking-value">{{ listItem[dataProperty.value] > 100 && isRate ? '>100' : (listItem[dataProperty.value] | number:'1.0-2') }}{{ isRate ? '%' : '' }}</span>
         <span *ngIf="listItem[dataProperty.value] < 0" class="ranking-value unavailable">{{ 'DATA.UNAVAILABLE' | translate }}</span>
       </div>
     </button>

--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -22,15 +22,15 @@
         >
           {{ location.name }} <span>{{ location.displayParentLocation }}</span>
         </h2>
-        <span class="rank-value">{{dataProperty.name}} {{location[dataProperty.value]}}{{dataProperty.value.includes('Rate') ? '%' : '' }}</span>
+        <span class="rank-value">{{dataProperty.name}} {{dataProperty.value.includes('Rate') && location[dataProperty.value] > 100 ? '>100' : (location[dataProperty.value] | number:'1.0-2') }}{{dataProperty.value.includes('Rate') ? '%' : '' }}</span>
         <!-- COMING SOON
           <a href="#" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
         -->
       </div>
     </div>
     <div class="panel-summary-content">
-      <p *ngIf="location.evictions !== 1">{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
-      <p *ngIf="location.evictions === 1">{{ 'RANKINGS.PANEL_SUMMARY_SINGULAR' | translate:{'evictions': location.evictions, 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.2-2'), 'evictionRate': location.evictionRate} }}</p>
+      <p *ngIf="location.evictions !== 1">{{ 'RANKINGS.PANEL_SUMMARY' | translate:{'evictions': (location.evictions | number: '1.0-2'), 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.0-2'), 'evictionRate': location.evictionRate} }}</p>
+      <p *ngIf="location.evictions === 1">{{ 'RANKINGS.PANEL_SUMMARY_SINGULAR' | translate:{'evictions': (location.evictions | number: '1.0-2'), 'name': location.name, 'evictionsPerDay': ((location.evictions/365) | number: '1.0-2'), 'evictionRate': location.evictionRate} }}</p>
     </div>
   </div>
   <button class="btn btn-icon panel-arrow panel-next"

--- a/src/app/ranking/ranking-tool/evictions/evictions.component.ts
+++ b/src/app/ranking/ranking-tool/evictions/evictions.component.ts
@@ -320,7 +320,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
     }, 0);
     // format number based on if it's a rate or not
     amount = this.isRateValue() ?
-      this.decimal.transform(amount / 10, '1.1-2') : this.decimal.transform(amount);
+      this.cappedRateValue(amount / 10) : this.decimal.transform(amount);
     // add average text if the number is an average rate
     amount = this.isRateValue() ?
       this.translatePipe.transform('RANKINGS.SHARE_AVERAGE', { amount }) : amount;
@@ -339,7 +339,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   private getLocationTweet() {
     const location = this.listData[this.selectedIndex];
     let amount = this.isRateValue() ?
-      this.decimal.transform(location[this.dataProperty.value], '1.1-2') :
+      this.cappedRateValue(location[this.dataProperty.value]) :
       this.decimal.transform(location[this.dataProperty.value]);
     amount = this.isRateValue() ?
       this.translatePipe.transform('RANKINGS.SHARE_PERCENT_OF', { amount }) :
@@ -374,7 +374,7 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
       this.translatePipe.transform('RANKINGS.SHARE_PASSIVE_FILING');
     const state = this.rankings.stateData.find(s => s.name === this.region);
     let amount = this.isRateValue() ?
-      this.decimal.transform(state[this.dataProperty.value], '1.1-2') :
+      this.cappedRateValue(state[this.dataProperty.value]) :
       this.decimal.transform(state[this.dataProperty.value]);
     amount = this.isRateValue() ?
       this.translatePipe.transform('RANKINGS.SHARE_PERCENT_OF', { amount }) :
@@ -440,6 +440,11 @@ export class EvictionsComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Returns true if the data property is a rate instead of a count */
   private isRateValue(): boolean {
     return this.dataProperty.value.endsWith('Rate');
+  }
+
+  /** Returns the formatted rate number, with >100 instead of values over */
+  private cappedRateValue(val: number): string {
+    return val > 100 ? '>100' : this.decimal.transform(val, '1.1-2');
   }
 
     /**


### PR DESCRIPTION
Closes #931 by updating any eviction rate or filing rate that is over 100% to display at ">100%" in the rankings, location cards, or tweet text. One thing I'm not sure of here: how do we handle this in the graph? Should we change any data passed to it that's over 100% to 100% and represent that somehow? I'm leaning toward leaving the graph as-is. Moved that to #944

Also closes #895 by passing rankings numbers to the `number` pipe