### PR TITLE
Fixed search data bugs

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -226,12 +226,13 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
       this.mapToolService.getSearchTileData(feature).subscribe(data => {
         if (!data.properties.n) {
           this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
+          this.map.mapService.zoomToFeature(feature);
         } else {
           this.mapToolService.addLocation(data);
         }
         const dataLevel = this.mapToolService.dataLevels.filter(l => l.id === layerId)[0];
         if (updateMap) {
-          this.map.mapService.zoomToFeature(feature);
+          this.map.mapService.zoomToFeature(data);
           // Wait for map to be done zooming, then set data layer
           this.map.mapService.zoom$
             .distinctUntilChanged()
@@ -242,6 +243,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
         this.loader.end('search');
       }, err => {
         this.toast.error(this.translatePipe.transform('MAP.NO_DATA_ERROR'));
+        this.map.mapService.zoomToFeature(feature);
         this.loader.end('search');
       });
     }

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -480,16 +480,24 @@ export class MapToolService {
         }
       } else {
         const featName = (feat.properties['label'] as string)
-          .replace(',', '').split(' ')[0].toLowerCase();
-        const nameFilter = (f) => f.properties['n'].toLowerCase().startsWith(featName);
+          .replace(',', '').toLowerCase();
+        const featFirstWord = featName.split(' ')[0];
+        const nameFilter = (f) => f.properties['n'].toLowerCase().includes(featName);
+        const firstWordFilter = (f) => f.properties['n'].toLowerCase().includes(featFirstWord);
 
-        const containsMatchName = containsPoint.filter(nameFilter);
-        const matchesName = features.filter(nameFilter);
+        const containsMatchName = containsPoint.find(nameFilter);
+        const containsMatchFirst = containsPoint.find(firstWordFilter);
+        const matchName = features.find(nameFilter);
+        const matchFirst = features.find(firstWordFilter);
 
-        if (containsMatchName.length > 0) {
-          matchFeat = containsMatchName[0];
-        } else if (matchesName.length > 0) {
-          matchFeat = matchesName[0];
+        if (containsMatchName) {
+          matchFeat = containsMatchName;
+        } else if (matchName) {
+          matchFeat = matchName;
+        } else if (containsMatchFirst) {
+          matchFeat = containsMatchFirst;
+        } else if (matchFirst) {
+          matchFeat = matchFirst;
         }
       }
 


### PR DESCRIPTION
Fixes #937

* Zooms to a searched feature regardless of whether data is found or an error is thrown in getting search data
* Updates the search tile parser to check both the full name and the first word, and to check for them anywhere in the string rather than just at the beginning. Fixes the Grosse Pointe Shores issue
* Fixes the Pittsburgh example by zooming to the returned data if getting the tile data is successful, rather than the searched feature data