### PR TITLE
Location Card Updates

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -5,7 +5,10 @@
 >
   <div class="card-header" [class.clickable]="clickedHeader.observers.length > 0" (click)="clickedHeader.emit(f)">
     <app-ui-icon class="marker" icon="marker"></app-ui-icon>
-    <h1 class="card-heading">{{f.properties['n']}}</h1>
+    <h1 class="card-heading" 
+      [tooltip]="f.properties['n'].length > maxLocationLength ? f.properties['n'] : null" 
+      [placement]="collapsible ? 'top' : 'bottom'"
+    >{{ getLocationName(f.properties['n']) }}</h1>
     <h2 class="card-subheading">{{f.properties['pl']}}</h2>
     <app-ui-close-button class="card-dismiss" [ariaLabel]="'DATA.REMOVE_LOCATION' | translate:{'name':f.properties.n}" (onPress)="dismissedCard.emit(f)"></app-ui-close-button>
   </div>

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -41,7 +41,7 @@
     color: $cardHeaderBg1;
     border-bottom: $cardBarHeight solid transparent;
     height: $cardHeaderHeight;
-    padding-right: grid(6);
+    padding-right: grid(5);
     &.clickable { cursor: pointer; }
     &.clickable:hover { 
       background: $cardHoverBg; 

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -40,7 +40,7 @@
     padding: $defaultPadding;
     color: $cardHeaderBg1;
     border-bottom: $cardBarHeight solid transparent;
-    height: $cardHeaderHeight;
+    height: $cardHeaderHeight + 20px; // boost height for data panel cards to allow 3 lines
     padding-right: grid(5);
     &.clickable { cursor: pointer; }
     &.clickable:hover { 
@@ -153,6 +153,7 @@
     min-width: 75vw;
     // align location text at top of card header
     .card-header {
+      height: $cardHeaderHeight;
       justify-content: flex-start;
     }
     // overlay the card content at the bottom of the header

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -37,6 +37,8 @@ import { MapFeature } from '../../map-tool/map/map-feature';
       transition('card-e-2-2 => void', [
         animate('0.4s ease-out', style({ opacity: '0', transform: 'translate3d(100%, 50%, 0)' }))
       ]),
+      transition('void => card', []),
+      transition('card => void', []),
       transition(':enter', [
         style({ opacity: '0', transform: 'translate3d(-100%,0,0)' }),
         animate('0.2s ease-in', style({ opacity: '1', transform: 'translate3d(0,0,0)' }))
@@ -113,14 +115,16 @@ export class LocationCardsComponent implements OnInit {
   @HostBinding('class.no-cards') get noCards() {
     return this.features.length === 0;
   }
+  /** determines if cards are expanded (map view) */
   expanded = true;
-  clickHeader = false;
+  /** Maximum number of characters for location name */
+  maxLocationLength = 24;
+  /** Stores which properties should be % formatted */
   private percentProps;
+  /** Stores which properties should be $ formatted */
   private dollarProps;
 
-  constructor(private decimal: DecimalPipe) {
-
-  }
+  constructor(private decimal: DecimalPipe) {}
 
   ngOnInit() {
     if (this.collapsible) { this.expanded = false; }
@@ -139,6 +143,12 @@ export class LocationCardsComponent implements OnInit {
   getAbbrYear() {
     if (!this.year) { return; }
     return this.year.toString().slice(-2);
+  }
+
+  /** Get location name and truncate if it's too long */
+  getLocationName(name: string) {
+    const max = this.maxLocationLength;
+    return name.length > max ? name.substring(0, max) + '...' : name;
   }
 
 

--- a/src/app/map-tool/location-cards/location-cards.module.ts
+++ b/src/app/map-tool/location-cards/location-cards.module.ts
@@ -6,6 +6,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { UiModule } from '../../ui/ui.module';
 import { LocationCardsComponent } from './location-cards.component';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @NgModule({
   exports: [ LocationCardsComponent ],
@@ -13,7 +14,8 @@ import { LocationCardsComponent } from './location-cards.component';
     CommonModule,
     FormsModule,
     UiModule,
-    TranslateModule
+    TranslateModule,
+    TooltipModule
   ],
   declarations: [ LocationCardsComponent ],
   entryComponents: [ LocationCardsComponent ]

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -169,6 +169,10 @@ a:focus {
   border-radius:0;
 }
 
+.card-header .tooltip {
+  max-width:grid(21);
+}
+
 .feature-overview-dialog {
   margin:grid(2);
   width: grid(36);
@@ -205,3 +209,4 @@ a:focus {
 ::-ms-clear {
   display: none;
 }
+


### PR DESCRIPTION
  - Fix location name overflow by truncating and adding tooltip for long names (closes #936 )
  - Drop transitions for data panel cards (closes #918 )

![image](http://g.recordit.co/skp3gDUiyI.gif)