### PR TITLE
Prevent safari overscroll

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -322,7 +322,10 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
       .throttleTime(50)
       // only fire when wheel event hasn't been triggered yet
       .filter(() => !this.wheelEvent)
-      .subscribe(e => this.wheelEvent = true);
+      .subscribe(e => {
+        // only set wheel scroll flag when we're scrolling from a non-top position
+        if (this.verticalOffset > 0) { this.wheelEvent = true; }
+      });
     this.scroll.verticalOffset$.subscribe(this.onScroll.bind(this));
   }
 
@@ -334,7 +337,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   private onWheel() {
     this.verticalOffset = this.scroll.getVerticalOffset();
     this.wheelEvent = false;
-    this.enableZoom = (this.verticalOffset === 0);
+    this.enableZoom = (this.verticalOffset <= 0);
   }
 
   /**
@@ -344,7 +347,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
   private onScroll(yOffset: number) {
     this.verticalOffset = yOffset;
     if (!this.wheelEvent) {
-      this.enableZoom = (this.verticalOffset === 0);
+      this.enableZoom = (this.verticalOffset <= 0);
     } else {
       this.enableZoom = false;
     }

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -38,11 +38,21 @@ export class ScrollService {
     @Inject(DOCUMENT) private document: any,
     private platform: PlatformService
   ) {
-    // provide observable with top / bottom vertical offset
+    // kill overscroll, primarily for safari so the map is zoomable with
+    // mousewheel / trackpad.
+    this.platform.nativeWindow.addEventListener('mousewheel', (e) => {
+      if (e && e.deltaY < 0) {
+        if (this.getVerticalOffset() === 0) {
+          e.preventDefault();
+          return false;
+        }
+      }
+    });
+    // provide observable with top vertical offset
     this.verticalOffset$ = Observable
       .fromEvent(this.platform.nativeWindow, 'scroll')
       .throttleTime(10, undefined, { trailing: true, leading: true })
-      .map(e => this.getVerticalOffset());
+      .map((e: any) => this.getVerticalOffset());
     this.scrolledToTop$ = this.verticalOffset$
       .map(offset => offset < this.topOffset)
       .distinctUntilChanged();


### PR DESCRIPTION
Adds a mousewheel listener in the scroll service that prevents the browser default when the user tries to scroll up, but their already at the top of the page.

This is as good of a fix as I can get for #831.  The map still won't zoom, the first time they try to zoom in but it works on the second try so it's better than nothing.  Tried to debug and find a way to get it to zoom on the first try, but it looks like the browser is just eating those events and not passing them on to the DOM.