### PR TITLE
Interpolate array instead of outputs

### DIFF
--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
@@ -159,12 +159,20 @@ export class UiMapLegendComponent implements OnChanges {
    */
   private bubbleValue(radius: number, zoom: number, steps: any[]) {
     const minZoom = steps[0];
-    const minVal = this.interpolateSteps(radius, steps[1].slice(5, -2));
     const maxZoom = steps[steps.length - 2];
-    const maxVal = this.interpolateSteps(radius, steps[steps.length - 1].slice(5, -2));
 
-    // Don't return less than 0
-    return Math.max(0, this.interpolateSteps(zoom, [minVal, minZoom, maxVal, maxZoom]));
+    const difference = maxZoom - minZoom;
+    const progress = zoom - minZoom;
+    const t = difference === 0 ? 0 : progress / difference;
+
+    const lowerSteps = steps[1].slice(5, -2);
+    const upperSteps = steps[steps.length - 1].slice(5, -2);
+    const interpSteps = lowerSteps.map((lower, i) => {
+      const upper = upperSteps[i];
+      return (lower * (1 - t)) + (upper * t);
+    });
+
+    return Math.max(0, this.interpolateSteps(radius, interpSteps));
   }
 
   /**


### PR DESCRIPTION
Closes #946 (for real this time). The problem I kept running into is that I was interpolating the outputs of the expressions, rather than the values of the expressions. We needed to actually interpolate each one of those values in the arrays to come up with an interpolated array, and then base the value calculation on that.

The last version worked for interpolating the value expressions, but because it wasn't operating on the actual array it didn't work between the minimum and maximum zoom levels. This version does