### PR TITLE
Cap Y axis at 100%, display >100% above

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,9 +931,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "angular-d3-graph": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.13.tgz",
-      "integrity": "sha512-g4Exp2/+Hu5h4CUDq2r3gqjl2heG7tIblXchjy6bpMesc8f56aJ6wI3PB/uhh9jYVvDl66aDXTsA2uJq/KOr4A==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/angular-d3-graph/-/angular-d3-graph-2.0.14.tgz",
+      "integrity": "sha512-v1kP36Po8FXFWDfAhh00XpHdsLso9DWnmXiLOQ/IC+rwvv6EbN1JhnEVan6fPLPa9Of5cCVhqMimfdirO5bizQ==",
       "requires": {
         "@angular/animations": "5.0.3",
         "@angular/common": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@turf/union": "^4.7.3",
     "@types/geojson": "^1.0.3",
     "@types/mapbox-gl": "^0.41.0",
-    "angular-d3-graph": "^2.0.13",
+    "angular-d3-graph": "^2.0.14",
     "clipboard": "^1.7.1",
     "core-js": "^2.4.1",
     "d3-dsv": "^1.0.8",

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -55,7 +55,7 @@
           </div>
         </div>
         <div class="bar-tooltips" *ngIf="graphType === 'bar'">
-          <div class="tooltip tooltip-number top" role="tooltip" *ngFor="let tooltip of tooltips" [style.transform]="'translate('+ (tooltip.left + tooltip.width/2) +'px, ' + tooltip.top + 'px)'">
+          <div class="tooltip tooltip-number top" role="tooltip" *ngFor="let tooltip of tooltips" [style.transform]="'translate('+ (tooltip.left + tooltip.width/2) +'px, ' + barTopValue(tooltip.top) + 'px)'">
             <div class="tooltip-arrow"></div>
             <div class="tooltip-inner" *ngIf="tooltip.data && tooltip.data.length">{{ tooltip.data[0].y >= 0 ? tooltipValue(tooltip.data[0].y) : ('DATA.UNAVAILABLE' | translate) }}</div>
           </div>

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -50,14 +50,14 @@
           >
             <div class="tooltip-wrapper">
               <div class="tooltip-arrow"></div>
-              <div class="tooltip-inner line-tooltip-value">{{tooltip.y}}{{graphAttribute.format === 'percent' ? '%' : ''}}</div>
+              <div class="tooltip-inner line-tooltip-value">{{tooltipValue(tooltip.y)}}</div>
             </div>
           </div>
         </div>
         <div class="bar-tooltips" *ngIf="graphType === 'bar'">
           <div class="tooltip tooltip-number top" role="tooltip" *ngFor="let tooltip of tooltips" [style.transform]="'translate('+ (tooltip.left + tooltip.width/2) +'px, ' + tooltip.top + 'px)'">
             <div class="tooltip-arrow"></div>
-            <div class="tooltip-inner" *ngIf="tooltip.data && tooltip.data.length">{{ tooltip.data[0].y >= 0 ? tooltip.data[0].y : ('DATA.UNAVAILABLE' | translate) }}{{graphAttribute.format === 'percent' && tooltip.data[0].y >= 0 ? '%' : ''}}</div>
+            <div class="tooltip-inner" *ngIf="tooltip.data && tooltip.data.length">{{ tooltip.data[0].y >= 0 ? tooltipValue(tooltip.data[0].y) : ('DATA.UNAVAILABLE' | translate) }}</div>
           </div>
         </div>
       </app-graph>

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -306,6 +306,10 @@ export class EvictionGraphsComponent implements OnInit {
     return `${valStr}${this.graphAttribute.format === 'percent' ? '%' : ''}`;
   }
 
+  barTopValue(top: number): number {
+    return Math.max(this.graphSettings.margin.top, top);
+  }
+
   /** Returns the Y axis label name with % added if they are percent values */
   private getAxisLabel() {
     return this.graphAttribute.name +

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -162,14 +162,14 @@ export class EvictionGraphsComponent implements OnInit {
     if (this.graphType === 'bar') {
       const value = l.properties[this.attrYear(this.barYear)];
       return value >= 0 ?
-        this.barYear + ': ' + value + '%' :
+        this.barYear + ': ' + this.tooltipValue(value) :
         this.translatePipe.transform('DATA.UNAVAILABLE');
     } else if (this.graphType === 'line') {
       const tooltip = this.tooltips[locationIndex];
       if (!tooltip) { return ''; }
       const value = l.properties[this.attrYear(tooltip.x)];
       return value >= 0 ?
-        tooltip.x + ': ' + value + '%' :
+        tooltip.x + ': ' + this.tooltipValue(value) :
         this.translatePipe.transform('DATA.UNAVAILABLE');
     }
     return '';
@@ -208,7 +208,8 @@ export class EvictionGraphsComponent implements OnInit {
           label: this.getAxisLabel(),
           tickSize: '-100%',
           ticks: 5,
-          tickPadding: 5
+          tickPadding: 5,
+          maxVal: 100
         }
       },
       margin: { left: 65, right: 16, bottom: 32, top: 16 }
@@ -238,7 +239,8 @@ export class EvictionGraphsComponent implements OnInit {
           label: this.getAxisLabel(),
           tickSize: '-100%',
           ticks: 5,
-          tickPadding: 5
+          tickPadding: 5,
+          maxVal: 100
         }
       },
       margin: { left: 65, right: 16, bottom: 48, top: 16 }
@@ -294,6 +296,14 @@ export class EvictionGraphsComponent implements OnInit {
       }
     }
     return null;
+  }
+
+  tooltipValue(val: number): string {
+    let valStr = val.toString();
+    if (this.graphSettings.axis.y.maxVal > 0 && val > this.graphSettings.axis.y.maxVal) {
+      valStr = '>' + this.graphSettings.axis.y.maxVal;
+    }
+    return `${valStr}${this.graphAttribute.format === 'percent' ? '%' : ''}`;
   }
 
   /** Returns the Y axis label name with % added if they are percent values */


### PR DESCRIPTION
Closes #944, dependent on https://github.com/EvictionLab/angular-d3-graph/pull/16. Caps the Y axis at 100%, displays any values above at the top of the axis with ">100%"

![cap-axis](https://user-images.githubusercontent.com/8291663/38156269-4a1a1f6c-3442-11e8-8fff-9fac3ff50d7f.gif)

Fixed on the bar chart (set the max value to 50% to make it more obvious)

<img width="820" alt="screen shot 2018-03-30 at 9 06 11 pm" src="https://user-images.githubusercontent.com/8291663/38158647-6b718d46-345e-11e8-8142-5954cf0c0653.png">

