### PR TITLE
Fix SVG Animation Detection

### DIFF
--- a/src/app/map-tool/feature-overview/feature-overview.component.ts
+++ b/src/app/map-tool/feature-overview/feature-overview.component.ts
@@ -99,7 +99,7 @@ export class FeatureOverviewComponent implements OnInit, AfterViewInit, AppDialo
     Object.assign(svg.style, {
       position: 'absolute', top: 0, left: 0, width: '8px', height: '8px', zIndex: 99999
     });
-    svg.innerHTML = 
+    svg.innerHTML =
       '<rect width="4" height="4" fill="#fff" style="transform: translate(4px, 4px)"/>';
     document.body.appendChild(svg);
     const result = document.elementFromPoint(6, 6) !== svg;

--- a/src/app/map-tool/feature-overview/feature-overview.component.ts
+++ b/src/app/map-tool/feature-overview/feature-overview.component.ts
@@ -30,7 +30,6 @@ export class FeatureOverviewComponent implements OnInit, AfterViewInit, AppDialo
   ngOnInit() {
     this.animationSupport = this.supportsSVGTransforms();
     this.slideIndex = 0;
-    console.log('supports animation:', this.animationSupport);
     this.carousel = {
       grid: {xs: 1, sm: 1, md: 1, lg: 1, all: 0},
       slide: 1,
@@ -96,13 +95,14 @@ export class FeatureOverviewComponent implements OnInit, AfterViewInit, AppDialo
   // pulled from: http://eprev.org/2017/01/05/how-to-detect-if-css-transforms-are-supported-on-svg
   private supportsSVGTransforms() {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('viewBox', '0 0 2 2');
+    svg.setAttribute('viewBox', '0 0 8 8');
     Object.assign(svg.style, {
-      position: 'absolute', top: 0, left: 0, width: '2px', height: '2px', zIndex: 99999
+      position: 'absolute', top: 0, left: 0, width: '8px', height: '8px', zIndex: 99999
     });
-    svg.innerHTML = '<rect width="1" height="1" style="transform: translate(1px, 1px)"/>';
+    svg.innerHTML = 
+      '<rect width="4" height="4" fill="#fff" style="transform: translate(4px, 4px)"/>';
     document.body.appendChild(svg);
-    const result = document.elementFromPoint(1, 1) !== svg;
+    const result = document.elementFromPoint(6, 6) !== svg;
     svg.parentNode.removeChild(svg);
     return result;
   }


### PR DESCRIPTION
Adjusts the `<rect>` element so it is a little bigger.  It was previously detecting a one pixel space, and on chrome it was off a bit.   Increased the hit area on the transformed rect so that chrome returns true when SVG transforms via CSS are supported.

Closes #949  