### PR TITLE
add default value for graph attribute

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -7,7 +7,7 @@
           class="graph-eviction-toggle"
           [leftLabel]="'DATA.JUDGMENTS'| translate" 
           [rightLabel]="'DATA.FILINGS' | translate" 
-          [on]="this.graphAttribute && this.graphAttribute.id === this.dataAttributes[1].id"
+          [on]="this.graphAttribute && this.dataAttributes.length > 0 && this.graphAttribute.id === this.dataAttributes[1].id"
           (switched)="changeGraphProperty($event)"
         ></app-ui-switch>
         <app-ui-toggle

--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -28,7 +28,7 @@ export class EvictionGraphsComponent implements OnInit {
   @Output() barYearChange = new EventEmitter();
 
   /** Allow double-binding of graph attribute */
-  private _graphAttribute;
+  private _graphAttribute = { id: '', langKey: ''};
   @Input() set graphAttribute(attr: MapDataAttribute) {
     if (!attr || !this._graphAttribute) { return; }
     if (attr.id !== this._graphAttribute.id) {


### PR DESCRIPTION
Sets a default value so errors aren't thrown when trying to access `graphAttribute` properties.