### PR TITLE
Only propagate graph toggle when map bubble is not none

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -27,13 +27,18 @@ export class EvictionGraphsComponent implements OnInit {
   get barYear() { return this._barYear; }
   @Output() barYearChange = new EventEmitter();
 
+  /** Store currently selected map graph attribute */
+  private _mapGraphAttribute = { id: '', langKey: '' };
   /** Allow double-binding of graph attribute */
   private _graphAttribute = { id: '', langKey: ''};
   @Input() set graphAttribute(attr: MapDataAttribute) {
     if (!attr || !this._graphAttribute) { return; }
+    this._mapGraphAttribute = attr;
     if (attr.id !== this._graphAttribute.id) {
       this._graphAttribute = attr.id === 'none' ? this.dataAttributes[0] : attr;
-      this.graphAttributeChange.emit(this._graphAttribute);
+      if (attr.id !== 'none') {
+        this.graphAttributeChange.emit(this._graphAttribute);
+      }
       this.setGraphData();
     }
   }
@@ -193,8 +198,13 @@ export class EvictionGraphsComponent implements OnInit {
    * Toggles the graph between judgments / filings
    */
   changeGraphProperty(filings: boolean) {
-    this.graphAttribute = filings ? this.dataAttributes[1] : this.dataAttributes[0];
-    this.setGraphData();
+    const attr = filings ? this.dataAttributes[1] : this.dataAttributes[0];
+    if (this._mapGraphAttribute.id !== 'none') {
+      this.graphAttribute = attr;
+    } else {
+      this._graphAttribute = attr;
+      this.setGraphData();
+    }
   }
 
   /** Gets config for bar graph */


### PR DESCRIPTION
Closes #959, fixes the issue of not allowing "None" to be selected for the bubbles because of the toggle double-binding. Instead of a one-way binding, this only emits a change event to the map tool service if the new `graphAttribute` is not None.

It also doesn't emit changes when None is the currently selected bubble layer. This made the most sense to me because we only have a toggle on the graph without the option of None, and adding a layer to the map while toggling something on the graph seemed odd. If you have Eviction Rate selected on the map, and then toggle for Eviction Filing Rate, it will update the map which seemed to make more sense. Let me know what you think! A one-way binding might also make sense here