### PR TITLE
Add null check to line tooltip

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.html
@@ -51,7 +51,7 @@
           >
             <div class="tooltip-wrapper">
               <div class="tooltip-arrow"></div>
-              <div class="tooltip-inner line-tooltip-value">{{tooltipValue(tooltip.y)}}</div>
+              <div class="tooltip-inner line-tooltip-value">{{ tooltip.y >= 0 ? tooltipValue(tooltip.y) : null }}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Null data was causing issues for tooltips because I hadn't added a null check, but this fixes it