### PR TITLE
Fix layer ordering

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -33,6 +33,7 @@ export class MapService {
   private _mapHighlights = [];
   private _mapHover = [];
   private _hoverEnabled = true;
+  private addBeforeLayer = 'city_extra_small_labels';
 
   constructor(private loader: LoadingService) { }
 
@@ -315,7 +316,7 @@ export class MapService {
       })
       // add the new layer w/ updated source
       .forEach(l => {
-        this.map.addLayer(l, this.getBeforeLayer(l.id));
+        this.map.addLayer(l, this.addBeforeLayer);
       });
   }
 
@@ -372,16 +373,6 @@ export class MapService {
       [box[0], box[1]],
       [box[2], box[3]]
     ], { padding: 50 });
-  }
-
-  /**
-   * Given a layer id, this will return the layer it should be inserted before
-   * in the map style. Bubbles / text layers return null, so those layers will
-   * be added at the top level.  All others will be inserted before 'roads'.
-   */
-  private getBeforeLayer(layerId: string) {
-    if (layerId.includes('bubbles') || layerId.includes('text')) { return null; }
-    return 'roads';
   }
 
   /**

--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -33,7 +33,6 @@ export class MapService {
   private _mapHighlights = [];
   private _mapHover = [];
   private _hoverEnabled = true;
-  private addBeforeLayer = 'city_extra_small_labels';
 
   constructor(private loader: LoadingService) { }
 
@@ -316,7 +315,8 @@ export class MapService {
       })
       // add the new layer w/ updated source
       .forEach(l => {
-        this.map.addLayer(l, this.addBeforeLayer);
+        this.debug('adding layer', l);
+        this.map.addLayer(l, this.getBeforeLayer(l.id));
       });
   }
 
@@ -373,6 +373,17 @@ export class MapService {
       [box[0], box[1]],
       [box[2], box[3]]
     ], { padding: 50 });
+  }
+
+  /**
+    * Given a layer id, this will return the layer it should be inserted before
+    * in the map style. Bubbles are below labels, labels return null so they will
+    * be added at the top level.  All others will be inserted before 'roads'.
+    */
+  private getBeforeLayer(layerId: string) {
+    if (layerId.includes('text')) { return null; }
+    if (layerId.includes('bubbles')) { return 'city_extra_small_labels'; }
+    return 'roads';
   }
 
   /**

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -720,63 +720,6 @@
       }
     },
     {
-      "id": "counties_text",
-      "type": "symbol",
-      "source": "us-counties-10",
-      "source-layer": "counties-centers",
-      "layout": {
-        "text-size": {
-          "stops": [
-            [
-              4,
-              12
-            ],
-            [
-              10,
-              16
-            ]
-          ]
-        },
-        "text-field": "{n}",
-        "text-allow-overlap": false,
-        "text-ignore-placement": false,
-        "text-anchor": "center",
-        "symbol-spacing": 2500,
-        "icon-allow-overlap": false,
-        "symbol-placement": "point",
-        "text-padding": 6,
-        "text-justify": "center",
-        "text-keep-upright": true,
-        "text-line-height": 1.3,
-        "text-font": [
-          "Lato+Bold"
-        ],
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.12,
-        "text-max-width": 3,
-        "visibility": "none",
-        "text-offset": [-3, -2]
-      },
-      "paint": {
-        "icon-translate-anchor": "map",
-        "text-color": "rgba(5, 4, 3, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 2,
-        "text-opacity": {
-          "stops": [
-            [
-              8.99,
-              0
-            ],
-            [
-              9,
-              1
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id": "states_bubbles",
       "type": "circle",
       "source": "us-states-10",
@@ -1063,6 +1006,66 @@
         "text-halo-blur": 1,
         "icon-opacity": 1,
         "icon-color": "rgba(0, 0, 0, 1)"
+      }
+    },
+    {
+      "id": "counties_text",
+      "type": "symbol",
+      "source": "us-counties-10",
+      "source-layer": "counties-centers",
+      "layout": {
+        "text-size": {
+          "stops": [
+            [
+              4,
+              12
+            ],
+            [
+              10,
+              16
+            ]
+          ]
+        },
+        "text-field": "{n}",
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-anchor": "center",
+        "symbol-spacing": 2500,
+        "icon-allow-overlap": false,
+        "symbol-placement": "point",
+        "text-padding": 6,
+        "text-justify": "center",
+        "text-keep-upright": true,
+        "text-line-height": 1.3,
+        "text-font": [
+          "Lato+Bold"
+        ],
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.12,
+        "text-max-width": 3,
+        "visibility": "none",
+        "text-offset": [
+          -3,
+          -2
+        ]
+      },
+      "paint": {
+        "icon-translate-anchor": "map",
+        "text-color": "rgba(5, 4, 3, 1)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 2,
+        "text-opacity": {
+          "stops": [
+            [
+              8.99,
+              0
+            ],
+            [
+              9,
+              1
+            ]
+          ]
+        }
       }
     }
   ]


### PR DESCRIPTION
Closes #967. The currently `style.json` doesn't really require any logic to determine where to add layers, so I moved `counties_text` to the top since it rarely appears and should take precedence anyway, and set a static `addBeforeLayer` to make sure all bubble layers are added before the city labels

<img width="440" alt="screen shot 2018-04-02 at 7 55 14 am" src="https://user-images.githubusercontent.com/8291663/38196994-93577dae-364b-11e8-80a3-c40450e6611b.png">
