### PR TITLE
Fix zoom hint display

### DIFF
--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -27,7 +27,7 @@
       labelProperty="name"
       [selectedValue]="selectedLayer"
       [values]="selectDataLevels" 
-      [bottomLabel]="selectDataLevels.length < layerOptions.length ? ('MAP.ZOOM_HINT' | translate) : false"
+      [bottomLabel]="selectDataLevels.length < (layerOptions.length + 1) ? ('MAP.ZOOM_HINT' | translate) : false"
       (change)="setGroupVisibility($event, 'dropdown')">
     </app-ui-select>
     <button class="btn btn-icon overview z1" (click)="helpClick.emit()" [attr.aria-label]="'MAP.FEATURE_OVERVIEW_LABEL' | translate">


### PR DESCRIPTION
Because "Auto" gets added to `selectDataLevels`, we need to add 1 to the length check to determine whether to show the zoom hint. It looks like we were getting away with it before because we were showing 2 layers at the same time with tracts and block groups

Fixes this behavior:
<img width="361" alt="screen shot 2018-04-02 at 2 26 19 pm" src="https://user-images.githubusercontent.com/8291663/38212047-08b9d958-3682-11e8-9708-fde22056019f.png">
