### PR TITLE
Sticky fallbacks on ranking nav

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -93,9 +93,9 @@ $panelHeightLg: 194px;
 // nav bar is sticky on tablet+
 @media(min-width: $gtMobile) {
   .nav-bar {
-    position: sticky;
+    position: relative;
     z-index:998;
-    top: $headerHeightSm - 1px; // fix 1px showing through
+    top: 0; // fix 1px showing through
     height: grid(8);
     ul {
       flex-direction: row;
@@ -117,6 +117,12 @@ $panelHeightLg: 194px;
           border-bottom: grid(0.5) solid $color1;
         }
       }
+    }
+  }
+  @supports(position: sticky) {
+    .nav-bar {
+      position: sticky;
+      top: $headerHeightSm - 1px; // fix 1px showing through
     }
   }
 }

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -95,7 +95,7 @@ $panelHeightLg: 194px;
   .nav-bar {
     position: relative;
     z-index:998;
-    top: 0; // fix 1px showing through
+    top: 0;
     height: grid(8);
     ul {
       flex-direction: row;


### PR DESCRIPTION
Adds fallback styles for sticky nav bar when `position: sticky` is not supported (Edge below v16, Chrome below v56).