### PR TITLE
Fix iOS map showing on scroll

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.scss
+++ b/src/app/map-tool/data-panel/data-panel.component.scss
@@ -1,5 +1,10 @@
 @import '../../../theme';
 
+:host {
+  transform: translate3d(0,0,0);
+  & > * { transform: translate3d(0,0,0); }
+}
+
 // Data panel header text
 // ----
 .data-header {
@@ -22,8 +27,10 @@
   width:100%;
   box-sizing: border-box;
   overflow:auto;
+  transform: translate3d(0,0,0);
   // padding at the bottom to leave space for "back to map" button
   padding: 0 $defaultPadding grid(15); 
+
   .data-content-inner {
     max-width: $maxContentWidth;
     padding: $defaultPadding;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -11,6 +11,7 @@
   max-width: 100%;
   height:100%;
   display:block;
+
 }
 // Map UI Wrapper spans the entire width of the viewport
 .map-ui-wrapper {


### PR DESCRIPTION
Found a fix here:
https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/

Closes #917