### PR TITLE
fix rankings overflow

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -10,6 +10,7 @@ $panelHeightLg: 194px;
 .ranking-page {
   margin-top: $headerHeightSm;
   margin-bottom: 0;
+  overflow:hidden;
 }
 
 @media(min-width: $gtMobile) {


### PR DESCRIPTION
Was able to replicate overflow issue on rankings page in #986, this should fix that.

Still not sure what is causing overflow on maps.