### PR TITLE
Hide all tooltips on touchstart, prevent overflow

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -30,12 +30,13 @@
         <span class="card-stat-label"
           *ngIf="prop.id !== 'divider'"
           [tooltip]="prop.hintKey ? (prop.hintKey | translate) : null"
-          [attr.tabindex]="prop.hintKey ? 0 : -1"
-           placement="right"
-           container="body"
-           triggers="hover touchend focus"
-           (focus)="expanded = true"
-           (blur)="expanded = false"
+          [attr.tabindex]="prop.hintKey ? 0 : null"
+          placement="right"
+          container="body"
+          triggers="hover touchend focus"
+          (focus)="expanded = true"
+          (blur)="expanded = false"
+          (onShown)="onTooltipShown($event)"
         >
           {{ prop.name }}
         </span>

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -1,10 +1,14 @@
 import {
-  Component, OnInit, Input, Output, EventEmitter, HostBinding, HostListener
+  Component, OnInit, Input, Output, EventEmitter, HostBinding, HostListener, ViewChildren,
+  QueryList, Inject
 } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { DOCUMENT } from '@angular/common';
 import { trigger, transition, style, animate, state } from '@angular/animations';
 import { DecimalPipe } from '@angular/common';
 import { MapDataAttribute } from '../../map-tool/data/map-data-attribute';
 import { MapFeature } from '../../map-tool/map/map-feature';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   selector: 'app-location-cards',
@@ -115,6 +119,8 @@ export class LocationCardsComponent implements OnInit {
   @HostBinding('class.no-cards') get noCards() {
     return this.features.length === 0;
   }
+  /** Used for hiding all tooltips on touchstart */
+  @ViewChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
   /** determines if cards are expanded (map view) */
   expanded = true;
   /** Maximum number of characters for location name */
@@ -124,7 +130,7 @@ export class LocationCardsComponent implements OnInit {
   /** Stores which properties should be $ formatted */
   private dollarProps;
 
-  constructor(private decimal: DecimalPipe) {}
+  constructor(private decimal: DecimalPipe, @Inject(DOCUMENT) private document: any) {}
 
   ngOnInit() {
     if (this.collapsible) { this.expanded = false; }
@@ -209,6 +215,16 @@ export class LocationCardsComponent implements OnInit {
       return '>100';
     }
     return this.decimal.transform(feat.properties[prop.yearAttr], '1.0-2');
+  }
+
+  /**
+   * Hide all tooltips on touchstart
+   * @param event
+   */
+  onTooltipShown(event: any) {
+    Observable.fromEvent(this.document, 'touchstart')
+      .take(1)
+      .subscribe(e => this.tooltips.forEach(t => t.hide()));
   }
 
   /** Add a reference to the current year property name for each data attribute */


### PR DESCRIPTION
Closes #985, may fix #986. I pulled the functionality from `ui-hint` into the location cards so that `touchstart` events close tooltips so that they don't linger on mobile. I mentioned in the issue, but I think it may have been the tooltips getting moved around that caused the map overflow, and I haven't been able to reproduce it with this update.

Also uses `null` instead of -1 on the `tabindex` property, otherwise tapping on items without tooltips triggers the active state