### PR TITLE
Set constant width for bubble legend items

### DIFF
--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -22,6 +22,7 @@ $bubbleColor: rgba(255,4,0,0.65);
   position:relative;
   margin: (grid(2)+2px) grid(1) 0;
   height: grid(2);
+  width: grid(3);
   padding:0;
   color: $legendTextColor;
   text-align:center;
@@ -113,6 +114,7 @@ $bubbleColor: rgba(255,4,0,0.65);
     @include numberFont(11px);
     margin: grid(3) grid(1) 0;
     height: grid(3);
+    width: grid(4);
     span {
       margin-top: (-1*grid(5)) - 4px; // shift text up so it is flush with top margin
     }


### PR DESCRIPTION
Closes #989. Sets widths for bubble items on legend for desktop and mobile so that they don't shift when the numbers change

![legend-fixed-desktop](https://user-images.githubusercontent.com/8291663/38248728-0d226a0e-370f-11e8-8c8c-cfdd573640f2.gif)
![legend-fixed-mobile](https://user-images.githubusercontent.com/8291663/38248731-0e55ccae-370f-11e8-8d15-2e268db6f3f8.gif)
