### PR TITLE
Fix Twitter web intent

### DIFF
--- a/src/app/ui/ui-social-share/ui-social-share.component.ts
+++ b/src/app/ui/ui-social-share/ui-social-share.component.ts
@@ -49,7 +49,7 @@ export class UiSocialShareComponent {
 
   shareTwitter() {
     this.trackShare('twitter');
-    const href = 'http://twitter.com/intent/tweet?status=' + this.platform.urlEncode(this.tweet);
+    const href = 'https://twitter.com/intent/tweet?text=' + this.platform.urlEncode(this.tweet);
     this.openWindow(href);
   }
 


### PR DESCRIPTION
Closes #993. It looks like we were using the wrong web intent parameter and an HTTP URL (not sure if that was related. Updated and it's working on my iPhone