### PR TITLE
Hide scroll top button on y instead of x

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.scss
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.scss
@@ -313,6 +313,8 @@
   right: $pageMargin;
   top: -1*$pageMargin;
   transform: translate3d(0,-100%,0);
+  // So it shows on top of scroll to top button
+  z-index: 20;
   .icon {
     height: grid(2.5);
     width: grid(2.5);

--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -10,7 +10,6 @@ $panelHeightLg: 194px;
 .ranking-page {
   margin-top: $headerHeightSm;
   margin-bottom: 0;
-  overflow:hidden;
 }
 
 @media(min-width: $gtMobile) {
@@ -356,7 +355,8 @@ app-ranking-ui.ranking-ui-panel {
   z-index: 20;
   border-radius:0;
   transition: transform 0.2s ease-in-out;
-  transform: translate3d(250%, 0, 0);
+  // Disappear vertically instead of horizontally
+  transform: translate3d(0, 150%, 0);
   .icon {
     width: 13px;
     height: 13px;
@@ -371,9 +371,13 @@ app-ranking-ui.ranking-ui-panel {
     .icon { fill: $white; }
   }
 }
+
 // shift to the left of the close button when panel is open
-.visible .btn.btn-icon.scroll-to-top-button.visible {
-  transform: translate3d((-1*grid(6)), 0, 0);
+.visible .btn.btn-icon.scroll-to-top-button {
+  transform: translate3d(0, 0, 0);
+  &.visible {
+    transform: translate3d((-1*grid(6)), 0, 0);
+  }
 }
 
 @media(min-width: $gtMobile) {


### PR DESCRIPTION
This should fix the horizontal overflow on rankings and also keep the rankings panel in view. Since we can't use `overflow: hidden` without breaking `position: sticky`, I'm moving the scroll to top button down instead of to the right and hiding it behind the close button when it shouldn't be visible

![hide-scroll-button-vertical](https://user-images.githubusercontent.com/8291663/38253058-4e7ab96e-371b-11e8-81f3-ccb8f63507f1.gif)
