### PR TITLE
Fix rankings aria-label, unavailable data

### DIFF
--- a/src/app/ranking/ranking-list/ranking-list.component.html
+++ b/src/app/ranking/ranking-list/ranking-list.component.html
@@ -13,7 +13,7 @@
       (click)="locationSelected.emit(i)"
       [attr.aria-label]="getAriaLabel(i+1, listItem)"
     >
-      <span class="ranking-number">{{ i + 1 }}</span>
+      <span class="ranking-number">{{ listItem[dataProperty.value] >= 0 ? i + 1 : ('RANKINGS.NA_RANK' | translate) }}</span>
       <div class="ranking-bar" [style.width]="''+(100*(listItem[dataProperty.value]/maxValue))+'%'"></div>
       <div class="ranking-content">
         <span class="ranking-name">{{ listItem[propertyMap.primary] }}</span><span class="place-separator">,</span>

--- a/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -30,11 +30,14 @@ export class RankingListComponent {
     if (this.propertyMap.primary === 'name') {
       // location ranking
       return this.translatePipe.transform('RANKINGS.LOCATION_DESCRIPTION', {
-        rank: rank,
+        rank: listItem[this.dataProperty.value] >= 0 ?
+          rank : this.translatePipe.transform('RANKINGS.NA_RANK'),
         location: listItem[this.propertyMap['primary']] + ', '
                 + listItem[this.propertyMap['secondary']],
         dataType: this.dataProperty.name,
-        value: listItem[this.dataProperty.value] + (this.isRate ? '%' : '')
+        value: listItem[this.dataProperty.value] >= 0 ?
+          listItem[this.dataProperty.value] + (this.isRate ? '%' : '') :
+          this.translatePipe.transform('DATA.UNAVAILABLE')
       });
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -203,7 +203,8 @@
     "LOCATION_DESCRIPTION": "Rank {{rank}}: {{location}} with {{value}} {{dataType}}",
     "NEXT_LOCATION": "Next",
     "PREV_LOCATION": "Previous",
-    "NO_RANKINGS": "There are no rankings available for the area and region you have selected."
+    "NO_RANKINGS": "There are no rankings available for the area and region you have selected.",
+    "NA_RANK": "N/A"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -203,7 +203,8 @@
     "LOCATION_DESCRIPTION": "Rank {{rank}}: {{location}} with {{value}} {{dataType}}",
     "NEXT_LOCATION": "Next",
     "PREV_LOCATION": "Previous",
-    "NO_RANKINGS": "There are no rankings available for the area and region you have selected."
+    "NO_RANKINGS": "There are no rankings available for the area and region you have selected.",
+    "NA_RANK": "N/A"
   },
   "FOOTER": {
     "SHARE_TWITTER": "Share on Twitter",


### PR DESCRIPTION
Closes #998 and closes #999. Updates the `aria-label`, and displays N/A instead of the rank for any location with null data. "Unavailable" takes too much space, and when I tried it with blanks it looked pretty empty. Marked as WIP since I'm not sure about the language, but if the text is alright this should be good to go

<img width="552" alt="screen shot 2018-04-03 at 9 51 01 am" src="https://user-images.githubusercontent.com/8291663/38256843-cfaa2cc8-3724-11e8-8620-780c94963474.png">

<img width="670" alt="screen shot 2018-04-03 at 9 47 21 am" src="https://user-images.githubusercontent.com/8291663/38256849-d28822a6-3724-11e8-8db6-768b6dbea78a.png">
