### PR TITLE
Only initialize search header on map tool

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
   [class.condensed]="!isAtTop"
   [activeMenuItem]="currentMenuItem"
   [languageOptions]="languageOptions"
+  [activeComponentId]="activeComponentId"
   (activeMenuItemChange)="onMenuSelect($event)"
   (selectLocation)="onSearchSelect($event)"
   (initialInput)="onInitialSearchInput()"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -49,6 +49,7 @@ export class AppComponent implements OnInit {
   ];
   selectedLanguage;
   isAtTop = true;
+  activeComponentId: string;
   private activeMenuItem;
 
   constructor(
@@ -101,6 +102,7 @@ export class AppComponent implements OnInit {
 
   /** Fired when a route is activated */
   onActivate(component: any) {
+    this.activeComponentId = component.id;
     let title;
     if (component.id === 'map-tool') {
       this.mapComponent = component;

--- a/src/app/header-bar/header-bar.component.html
+++ b/src/app/header-bar/header-bar.component.html
@@ -7,6 +7,7 @@
     </div>
     <div [class.active]="activeMenuItem === 'search'" class="header-search">
       <app-location-search
+        *ngIf="activeComponentId === 'map-tool'"
         role="search"
         class="search"
         [placeholder]="'HEADER.SEARCH_HINT' | translate"

--- a/src/app/header-bar/header-bar.component.ts
+++ b/src/app/header-bar/header-bar.component.ts
@@ -19,6 +19,7 @@ export class HeaderBarComponent implements OnInit, AfterViewInit {
   }
   get activeMenuItem() { return this.state.menuItem; }
   @Input() languageOptions = [];
+  @Input() activeComponentId: string;
 
   @Output() activeMenuItemChange = new EventEmitter();
   @Output() selectLocation = new EventEmitter();


### PR DESCRIPTION
Closes #1001. `app-location-search` was getting initialized in `app-header-bar` even though it wasn't visible on rankings, and this was triggering counties.csv to load. Adding `ngIf` to check if it's on the map tool before creating the component fixes it