### PR TITLE
Fix button overlaying map dropdowns

### DIFF
--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -1,4 +1,4 @@
-<div class="map-ui-wrapper">
+<div class="map-ui-wrapper map-dropdowns">
   <div class="map-ui" [class.active]="activeMenuItem === 'map'">
     <app-ui-select
       class="eviction-select"

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -23,6 +23,7 @@
     left:0;
     bottom: 0;
     right: 0;
+    &.map-dropdowns { z-index: 60; } // bring dropdowns above other map UI
 }
 // Map UI maxes out at the max content width
 .map-ui {


### PR DESCRIPTION
Boosts the z-index on the map dropdowns div so that they overlap other map UI.

Closes #1013 