### PR TITLE
Fix Safari Detection

### DIFF
--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -78,7 +78,7 @@ export class PlatformService {
 
   /** Returns true if browser is Safari */
   get isSafari(): boolean {
-    return this.userAgent.includes('safari');
+    return this.userAgent.includes('safari') && !this.userAgent.includes('chrome');
   }
 
   /** Returns true if device is iOS */


### PR DESCRIPTION
Checks if `chrome` is in the user agent when detecting Safari to prevent false positives.

Closes #1019 