### PR TITLE
Remove possessive in share selection tweet

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -195,7 +195,7 @@
     "SHARE_REGION_AMOUNT": "{{amount}} renter homes {{action}} in {{region}} in {{year}}.",
     "SHARE_REGION_TOP_AREA": " {{topArea}} {{hadAmount}}.",
     "SHARE_REGION_NO_SELECTION": "{{regionAmount}}{{topArea}} Find out where your city ranks at {{link}}",
-    "SHARE_SELECTION": "{{amount}} renter homes {{action}} in {{area}} in {{year}}. That's the {{ranking}} highest {{category}} among {{region}}'s {{areaType}}. Find out where your city ranks at {{link}}",
+    "SHARE_SELECTION": "{{amount}} renter homes {{action}} in {{area}} in {{year}}. That's the {{ranking}} highest {{category}} among {{region}} {{areaType}}. Find out where your city ranks at {{link}}",
     "SHARE_FALLBACK": "Eviction Rankings: Find out how your city compares at {{link}}",
     "LIST_HEADING": "Top Evicting {{area}} in {{region}}",
     "LIST_SUBHEADING": "Ranked by {{dataProperty}}",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -195,7 +195,7 @@
     "SHARE_REGION_AMOUNT": "{{amount}} renter homes {{action}} in {{region}} in {{year}}.",
     "SHARE_REGION_TOP_AREA": " {{topArea}} {{hadAmount}}.",
     "SHARE_REGION_NO_SELECTION": "{{regionAmount}}{{topArea}} Find out where your city ranks at {{link}}",
-    "SHARE_SELECTION": "{{amount}} renter homes {{action}} in {{area}} in {{year}}. That's the {{ranking}} highest {{category}} among {{region}}'s {{areaType}}. Find out where your city ranks at {{link}}",
+    "SHARE_SELECTION": "{{amount}} renter homes {{action}} in {{area}} in {{year}}. That's the {{ranking}} highest {{category}} among {{region}} {{areaType}}. Find out where your city ranks at {{link}}",
     "SHARE_FALLBACK": "Eviction Rankings: Find out how your city compares at {{link}}",
     "LIST_HEADING": "Top Evicting {{area}} in {{region}}",
     "LIST_SUBHEADING": "Ranked by {{dataProperty}}",


### PR DESCRIPTION
This is extremely minor, but the possessive in the share selection tweet resulted in a lot of awkward sounding phrases like "among United States's large cities." It seems fine to just say "among United States large cities" which would apply to states as well. I can update the content matrix if this works, also let me know if you have any objections @james-minton 