### PR TITLE
Adds tooltips to Hispanic, demographic label

### DIFF
--- a/src/app/map-tool/data/data-attributes.ts
+++ b/src/app/map-tool/data/data-attributes.ts
@@ -145,6 +145,7 @@ export const DataAttributes: Array<MapDataAttribute> = [
     'id': 'ph',
     'type': 'choropleth',
     'langKey': 'STATS.PCT_HISPANIC',
+    'hintKey': 'HINTS.HISPANIC',
     'order': 14,
     'default': 'rgba(0, 0, 0, 0)',
     'format': 'percent',

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -46,7 +46,17 @@
           <app-ui-hint *ngIf="isHighProp(f, prop.yearAttr)" placement="right" container="body" [hint]="'MAP.FLAG_99TH' | translate"></app-ui-hint>
           <app-ui-hint *ngIf="isLowProp(f, prop.id)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_LOW' | translate"></app-ui-hint>
         </div>
-        <span *ngIf="prop.id === 'divider'" class="card-stat-label">{{ 'STATS.DEMOGRAPHICS' | translate }}</span>
+        <span *ngIf="prop.id === 'divider'"
+          class="card-stat-label"
+          [tooltip]="'HINTS.DEMOGRAPHICS' | translate"
+          [attr.tabindex]="0"
+          placement="top"
+          container="body"
+          triggers="hover touchend focus"
+          (onShown)="onTooltipShown($event)"
+        >
+          {{ 'STATS.DEMOGRAPHICS' | translate }}
+        </span>
       </li>
     </ul>
   </div>

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -419,9 +419,10 @@
       padding: grid(3) 0 grid(2) 0;
       @include smallCapsText(12px);
       .card-stat-label { 
-        width:100%; 
+        margin: auto;
         color: $grey2; 
         text-align:center; 
+        border-bottom: $tooltipTriggerBorder;
       }
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -77,7 +77,7 @@
     "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
     "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more.",
     "HISPANIC": "Represents the % of the population of Hispanic or Latino origin and any race according to the Census.",
-    "DEMOGRAPHICS": "Race/ethnicity breakdown of the area's overall population."
+    "DEMOGRAPHICS": "Population estimates of the area's overall population."
   },
   "LAYERS": {
     "STATES": "States",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -75,7 +75,9 @@
   "HINTS": {
     "EVICTION_RATE": "Represents the number of evictions per 100 renter homes.",
     "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
-    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more."
+    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more.",
+    "HISPANIC": "Represents the % of the population of Hispanic or Latino origin and any race according to the Census.",
+    "DEMOGRAPHICS": "Race/ethnicity breakdown of the area's overall population."
   },
   "LAYERS": {
     "STATES": "States",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -78,7 +78,9 @@
   "HINTS": {
     "EVICTION_RATE": "Represents the number of evictions per 100 renter homes.",
     "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
-    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more."
+    "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more.",
+    "HISPANIC": "Represents the % of the population of Hispanic or Latino origin and any race according to the Census.",
+    "DEMOGRAPHICS": "Race/ethnicity breakdown of the area's overall population."
   },
   "LAYERS": {
     "STATES": "Estados",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -80,7 +80,7 @@
     "EVICTION_FILING_RATE": "Represents the number of eviction filings per 100 renter homes.",
     "RENT_BURDEN": "The percentage of household income spent on rent. The maximum value is 50%, representing 50% or more.",
     "HISPANIC": "Represents the % of the population of Hispanic or Latino origin and any race according to the Census.",
-    "DEMOGRAPHICS": "Race/ethnicity breakdown of the area's overall population."
+    "DEMOGRAPHICS": "Population estimates of the area's overall population."
   },
   "LAYERS": {
     "STATES": "Estados",


### PR DESCRIPTION
Closes #1041 and closes #1042. Adds a `hintKey` prop to Hispanic/Latinx, also adds one to Demographic Breakdown, and makes the Demographic Breakdown center-aligned instead of full width so that the border doesn't go further than the text

<img width="977" alt="screen shot 2018-04-04 at 7 00 30 pm" src="https://user-images.githubusercontent.com/8291663/38340783-c93137bc-383a-11e8-8c83-48b2656bcfb0.png">
