### PR TITLE
Set tooltip position dynamically to keep visible

### DIFF
--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -52,6 +52,14 @@ html.embedded {
   // fix disappearing legend
   .map-ui-wrapper { height: 100vh!important; }
 }
+
+// Shrink legend tooltip to make sure it fits
+.tooltip-inner {
+  padding: 4px;
+  font-size: 11px;
+  max-width: 360px;
+}
+
 @media(min-width: $gtMobile) {
   .embed app-ui-map-legend { bottom: $pageMarginLg!important; }
 }

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -1,7 +1,7 @@
 <div 
-  [@cards]="getCardState(i+1)" 
-  *ngFor="let f of features; let i = index; trackBy: trackCards" 
-  [class]="'location-card card card-' + i"
+  [@cards]="getCardState(idx+1)" 
+  *ngFor="let f of features; let idx = index; trackBy: trackCards" 
+  [class]="'location-card card card-' + idx"
 >
   <div class="card-header" [class.clickable]="clickedHeader.observers.length > 0" (click)="clickedHeader.emit(f)">
     <app-ui-icon class="marker" icon="marker"></app-ui-icon>
@@ -31,7 +31,7 @@
           *ngIf="prop.id !== 'divider'"
           [tooltip]="prop.hintKey ? (prop.hintKey | translate) : null"
           [attr.tabindex]="prop.hintKey ? 0 : null"
-          placement="right"
+          [placement]="tooltipPos(idx, i)"
           container="body"
           triggers="hover touchend focus"
           (focus)="expanded = true"

--- a/src/app/map-tool/location-cards/location-cards.component.spec.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.spec.ts
@@ -4,6 +4,7 @@ import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { LocationCardsComponent } from './location-cards.component';
 import { UiModule } from '../../ui/ui.module';
 import { LocationCardsModule } from './location-cards.module';
+import { PlatformService } from '../../services/platform.service';
 
 describe('LocationCardsComponent', () => {
   let component: LocationCardsComponent;
@@ -11,7 +12,8 @@ describe('LocationCardsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ FormsModule, TypeaheadModule.forRoot(), UiModule, LocationCardsModule ]
+      imports: [ FormsModule, TypeaheadModule.forRoot(), UiModule, LocationCardsModule ],
+      providers: [ PlatformService ]
     })
     .compileComponents();
   }));

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -9,6 +9,7 @@ import { DecimalPipe } from '@angular/common';
 import { MapDataAttribute } from '../../map-tool/data/map-data-attribute';
 import { MapFeature } from '../../map-tool/map/map-feature';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
+import { PlatformService } from '../../services/platform.service';
 
 @Component({
   selector: 'app-location-cards',
@@ -133,6 +134,7 @@ export class LocationCardsComponent implements OnInit {
   constructor(
     public el: ElementRef,
     private decimal: DecimalPipe,
+    private platform: PlatformService,
     @Inject(DOCUMENT) private document: any
   ) {}
 
@@ -224,6 +226,25 @@ export class LocationCardsComponent implements OnInit {
       return '>100';
     }
     return this.decimal.transform(feat.properties[prop.yearAttr], '1.0-2');
+  }
+
+  /**
+   * Sets the tooltip position based on the card and property index, screen size,
+   * and the number of properties for the location cards.
+   * @param cardIdx
+   * @param propIdx
+   */
+  tooltipPos(cardIdx: number, propIdx: number): string {
+    if (this.platform.isLargerThanTablet) {
+      return 'right';
+    }
+    // If there are fewer than 4 props, it's the map cards
+    if (this._cardProps.length < 4) {
+      // The last displayed property should have position top
+      return propIdx < this._cardProps.length - 1 ? 'right' : 'top';
+    }
+    // If it's the data panel, return top for all items on the 3rd card
+    return cardIdx < 2 ? 'right' : 'top';
   }
 
   /**


### PR DESCRIPTION
Closes #1045. Trying to be extra careful with this one. Sets the tooltip position to `top` instead of `right` if the screen size is smaller than tablet and either the card is the 3rd card, or the property is the last property within a card. There will still be situations when the tooltip will go out of view, but people will be able to scroll to bring it in view instead of it being totally inaccessible.

Also fixes an issue for the embed where longer legend tooltip descriptions could go out of view. This might not account for everything, but it shrinks it so most will fit.

<img width="484" alt="screen shot 2018-04-05 at 7 27 57 am" src="https://user-images.githubusercontent.com/8291663/38365881-94806f38-38a3-11e8-9e71-f7095e9fb91c.png">
<img width="408" alt="screen shot 2018-04-05 at 7 28 05 am" src="https://user-images.githubusercontent.com/8291663/38365886-9666b424-38a3-11e8-8424-f3ab52480a9d.png">
<img width="650" alt="screen shot 2018-04-05 at 7 27 39 am" src="https://user-images.githubusercontent.com/8291663/38365879-9326c7b8-38a3-11e8-9303-e271a2e97cf8.png">
<img width="564" alt="screen shot 2018-04-05 at 7 33 19 am" src="https://user-images.githubusercontent.com/8291663/38365899-a32f832a-38a3-11e8-9c64-e17cad28ad59.png">


<img width="683" alt="screen shot 2018-04-05 at 9 14 45 am" src="https://user-images.githubusercontent.com/8291663/38371431-02bca76a-38b2-11e8-926a-0e721ef2a4f3.png">
<img width="681" alt="screen shot 2018-04-05 at 9 14 26 am" src="https://user-images.githubusercontent.com/8291663/38371432-04042f8a-38b2-11e8-8afb-b4c802de9a04.png">
