### PR TITLE
Fix Spanish average overflow, closes #1053

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -378,12 +378,13 @@
         }
       }
       .card-stat-comparison {
-        font-size: 13px;
+        font-size: 11px;
         display: block;
         position: absolute;
         bottom: grid(1.5);
         right: 0;
         left: 0;
+        white-space: nowrap;
       }
     }
     &:nth-child(2) {
@@ -495,6 +496,7 @@
         height: grid(15);
         .card-stat-label { font-size: $panelCardLabelTextLg_t; }
         .card-stat-value { font-size: $panelCardLabelValueLg_t; }
+        .card-stat-comparison { font-size: 13px; }
       }
       li:nth-child(n+3) { 
         padding: grid(1.5) $defaultPadding; 

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -55,7 +55,7 @@
     "UNAVAILABLE": "No disponible",
     "ADD_LOCATION": "Añadir {{name}}",
     "REMOVE_LOCATION": "Eliminar {{name}}",
-    "US_AVERAGE": "Promedio de EE. UU.",
+    "US_AVERAGE": "prom. de EE. UU.",
     "SIGNUP_TITLE": "Acceder datos no procesados",
     "SIGNUP_DESCRIPTION": "Introducir su dirección de correo electrónico a continuación para recibir los datos de desalojo sin procesar de los Estados Unidos.",
     "SIGNUP_EMAIL_LABEL": "Correo electrónico", 


### PR DESCRIPTION
Closes #1053. Changes the text for the US average in Spanish, shrinks the font a bit on tablet and below, and sets `white-space: nowrap` for the most extreme cases:

<img width="286" alt="screen shot 2018-04-06 at 11 26 53 am" src="https://user-images.githubusercontent.com/8291663/38432752-2c328ace-398e-11e8-944e-54852c1c0b43.png">
