### PR TITLE
Fix Spanish mobile overflows

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.scss
@@ -288,7 +288,7 @@
       // hide the path that creates the edge tick lines
       .axis-x path.domain { display: none; }
       .label-y {
-        @include smallCapsText(12px);
+        @include smallCapsText(10px);
         fill: $graphAxisLabels;
       }
     }
@@ -306,6 +306,15 @@
     }
   }
 }
+
+@media(min-width: $gtMobile) {
+  .graph-area app-graph {
+    ::ng-deep {
+      .label-y { font-size: 12px; }
+    }
+  }
+}
+
 .graph-legend {
   max-width: grid(40); // 320px
   margin:auto;

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -68,9 +68,12 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   text-align: center;
-  margin: grid(1) grid(4);
+  margin: grid(1);
   opacity: 1;
   transition: opacity 0.6s;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 
 :host-context(.cards-active) .mobile-scroll-indicator {


### PR DESCRIPTION
Closes #1057. I think these are the last two examples of overflowing Spanish text I could find on the map or rankings.

For the full comparison hint, I decreased the margin on the left and right, and added `text-overflow: ellipsis` when that fails for really small screens. It works a lot more often though.

<img width="299" alt="screen shot 2018-04-06 at 1 00 21 pm" src="https://user-images.githubusercontent.com/8291663/38437090-07000566-399c-11e8-9eae-ef4191823a12.png">

For the Y axis label, I shrank the font size on mobile, but kept it the current size for all screen sizes larger than mobile

<img width="315" alt="screen shot 2018-04-06 at 1 14 08 pm" src="https://user-images.githubusercontent.com/8291663/38437226-6b5bc27a-399c-11e8-8c4e-4e60b1044b53.png">

