### PR TITLE
Rankings Spanish Updates

### DIFF
--- a/src/app/ranking/ranking-tool/ranking-tool.component.scss
+++ b/src/app/ranking/ranking-tool/ranking-tool.component.scss
@@ -92,17 +92,7 @@ $panelHeightLg: 194px;
     }
   }
 }
-@media(min-width: 413px) {
-  .nav-bar {
-    ul { 
-      padding: 0; 
-      flex-direction: row; 
-      justify-content:center; 
-      align-items: center;
-    }
-    ul li { padding: 0 grid(1); }
-  }
-}
+
 // nav bar is sticky on tablet+
 @media(min-width: $gtMobile) {
   .nav-bar {
@@ -110,6 +100,12 @@ $panelHeightLg: 194px;
     z-index:998;
     top: 0;
     height: grid(8);
+    ul { 
+      padding: 0; 
+      flex-direction: row; 
+      justify-content:center; 
+      align-items: center;
+    }
     ul li { 
       @include altFont(16px);
       text-transform: none;

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -182,6 +182,7 @@
     "REGION": "Región",
     "AREA": "Área",
     "RANKING_BY": "Clasificar por",
+    "EVICTION_RANKINGS": "Rankings de desalojos",
     "TOP_EVICTING_AREAS": "Áreas principales de desalojo",
     "TOP_EVICTORS": "Desalojadores principales",
     "COMING_SOON": "Próximamente",


### PR DESCRIPTION
  - Updates translation for heading on rankings page (Closes #1071 )
  - Doesn't place nav items side by side until tablet, to accommodate spanish translations (closes #1072 )

![image](https://user-images.githubusercontent.com/21034/38458597-42cf1fb6-3a5d-11e8-8422-7fd8ac710ca6.png)
