### PR TITLE
Drop glow on menu item focus

### DIFF
--- a/src/theme/base/menu.scss
+++ b/src/theme/base/menu.scss
@@ -86,6 +86,8 @@ $menuMargin: grid(5);
       color: $white;
       border-bottom-color: $white;
       text-decoration: none;
+      box-shadow:none;
+      outline: 0;
     }
   }
 }


### PR DESCRIPTION
- Keeps focus state consistent with the website pages (closes #1050 )

Before:
![image](https://user-images.githubusercontent.com/21034/38458737-d0e197f6-3a5e-11e8-80ad-d696ac63f135.png)

After:
![image](https://user-images.githubusercontent.com/21034/38458731-c39f8774-3a5e-11e8-89e1-129438f6bfe7.png)
