### PR TITLE
Adjust "Maximum locations reached"

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ export class CustomOption extends ToastOptions {
   showCloseButton = true;
   positionClass = 'toast-bottom-left';
   maxShown = 1;
+  newestOnTop = false;
 }
 
 @NgModule({

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -13,8 +13,8 @@
     <app-ui-close-button class="card-dismiss" 
       [ariaLabel]="'DATA.REMOVE_LOCATION' | translate:{'name':f.properties.n}" 
       (onPress)="removeCard($event, f)"
-      (onFocus)="expanded = true"
-      (onBlur)="expanded = false"
+      (onFocus)="collapsed = false"
+      (onBlur)="collapsed = true"
     ></app-ui-close-button>
   </div>
   <div class="card-content">
@@ -34,8 +34,8 @@
           [placement]="tooltipPos(idx, i)"
           container="body"
           triggers="hover touchend focus"
-          (focus)="expanded = true"
-          (blur)="expanded = false"
+          (focus)="collapsed = false"
+          (blur)="collapsed = true"
           (onShown)="onTooltipShown($event)"
         >
           {{ prop.name }}

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -114,6 +114,16 @@ export class LocationCardsComponent implements OnInit {
   @Input() allowAddLocation = false;
   /** US Average data used to show how a location compares (eviction rate only) */
   @Input() usAverage: Object;
+  @Input()
+  set collapsed(isCollapsed: boolean) {
+    if (!this.collapsible) { return; }
+    if (!isCollapsed !== this.expanded) {
+      this.expanded = !isCollapsed;
+      this.collapsedChange.emit(isCollapsed);
+    }
+  }
+  get collapsed(): boolean { return !this.expanded; }
+  @Output() collapsedChange: EventEmitter<boolean> = new EventEmitter();
   @Output() dismissedCard = new EventEmitter();
   @Output() locationAdded = new EventEmitter();
   @Output() clickedHeader = new EventEmitter();
@@ -123,7 +133,7 @@ export class LocationCardsComponent implements OnInit {
   /** Used for hiding all tooltips on touchstart */
   @ViewChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
   /** determines if cards are expanded (map view) */
-  expanded = true;
+  private expanded = true;
   /** Maximum number of characters for location name */
   maxLocationLength = 24;
   /** Stores which properties should be % formatted */
@@ -139,17 +149,17 @@ export class LocationCardsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    if (this.collapsible) { this.expanded = false; }
+    this.collapsed = this.collapsible;
   }
 
   /** Expand cards on mouse enter */
   @HostListener('mouseenter', ['$event']) onmouseenter(e) {
-    this.expanded = true;
+    this.collapsed = false;
   }
 
   /** Collapse cards on mouse leave, if enabled */
   @HostListener('mouseleave', ['$event']) onmouseleave(e) {
-    this.expanded = this.collapsible ? false : true;
+    this.collapsed = this.collapsible;
   }
 
   removeCard(e, feature) {

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -154,7 +154,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     const maxLocations = this.mapToolService.addLocation(feature);
     if (maxLocations) {
       this.loader.end('feature');
-      this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
+      this.showMaxLocationsError();
     }
     // track event
     const selectEvent = {
@@ -226,7 +226,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
 
     if (feature) {
       if (maxLocations) {
-        this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
+        this.showMaxLocationsError();
         this.map.mapService.zoomToFeature(feature);
         return;
       }
@@ -264,7 +264,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   onInitialSearchInput() {
     if (this.mapToolService.activeFeatures.length >= 3) {
-      this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
+      this.showMaxLocationsError();
     }
   }
 
@@ -305,6 +305,12 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     return this.dialogService.showDialog(
       { options: { class: 'feature-overview-dialog' } }, FeatureOverviewComponent
     );
+  }
+
+  /** Show the toast for maximum locations, and expand the cards as a visual cue */
+  private showMaxLocationsError() {
+    this.toast.error(this.translatePipe.transform('MAP.MAX_LOCATIONS_ERROR'));
+    this.mapToolService.cardsCollapsed = false;
   }
 
   /**

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -37,6 +37,7 @@ export class MapToolService {
   activeLineYearStart = environment.minYear;
   activeLineYearEnd = environment.maxYear;
   activeShowGraphAvg = true;
+  cardsCollapsed = false;
   embed = false;
   activeMapView;
   mapConfig;

--- a/src/app/map-tool/map/map/map.component.html
+++ b/src/app/map-tool/map/map/map.component.html
@@ -76,6 +76,7 @@
       [features]="activeFeatures"
       [cardProperties]="cardProps"
       [year]="year"
+      [(collapsed)]="mapToolService.cardsCollapsed"
       (clickedHeader)="clickedCardHeader.emit($event)"
       (dismissedCard)="dismissedCard.emit($event)"
     ></app-location-cards>

--- a/src/app/map-tool/map/map/map.component.spec.ts
+++ b/src/app/map-tool/map/map/map.component.spec.ts
@@ -15,6 +15,7 @@ import { UiMapLegendComponent } from '../map-legend/ui-map-legend.component';
 import { LocationCardsModule } from '../../location-cards/location-cards.module';
 import { ServicesModule } from '../../../services/services.module';
 import { Pipe, PipeTransform } from '@angular/core';
+import { MapToolService } from '../../map-tool.service';
 
 @Pipe({ name: 'translate' })
 export class TranslatePipeMock implements PipeTransform {
@@ -44,6 +45,10 @@ class MapServiceStub {
   updateHighlightFeatures(...args) { return this; }
 }
 
+class MapToolServiceStub {
+  cardsCollapsed = true;
+}
+
 describe('MapComponent', () => {
   let component: MapComponent;
   let fixture: ComponentFixture<MapComponent>;
@@ -63,7 +68,8 @@ describe('MapComponent', () => {
       set: {
         providers: [
           { provide: MapService, useValue: new MapServiceStub() },
-          { provide: TranslatePipe, useClass: TranslatePipeMock }
+          { provide: TranslatePipe, useClass: TranslatePipeMock },
+          { provide: MapToolService, useValue: new MapToolServiceStub() }
         ],
       }
     })

--- a/src/app/map-tool/map/map/map.component.ts
+++ b/src/app/map-tool/map/map/map.component.ts
@@ -18,6 +18,7 @@ import { MapService } from '../map.service';
 import { LoadingService } from '../../../services/loading.service';
 import { PlatformService } from '../../../services/platform.service';
 import { AnalyticsService } from '../../../services/analytics.service';
+import { MapToolService } from '../../map-tool.service';
 
 @Component({
   selector: 'app-map',
@@ -31,7 +32,7 @@ export class MapComponent implements OnInit, OnChanges {
   maxYear = environment.maxYear;
   mapEventLayers: Array<string>;
   cardProps;
-  private zoom = 3;
+  zoom = 3;
   private autoSelect = { id: 'auto', name: 'Auto', langKey: 'LAYERS.AUTO', minzoom: 0 };
   private _store = {
     layer: null,
@@ -63,8 +64,6 @@ export class MapComponent implements OnInit, OnChanges {
   get boundingBox() { return this._store.bounds; }
   @Output() boundingBoxChange: EventEmitter<Array<number>> = new EventEmitter();
 
-
-
   /** Sets and gets the bubble attribute to display on the map */
   @Input()
   set selectedBubble(newBubble: MapDataAttribute) {
@@ -77,7 +76,6 @@ export class MapComponent implements OnInit, OnChanges {
   }
   get selectedBubble(): MapDataAttribute { return this._store.bubble; }
   @Output() selectedBubbleChange: EventEmitter<MapDataAttribute> = new EventEmitter();
-
 
   /** Sets and gets the choropleth attribute to display on the map */
   @Input()
@@ -223,6 +221,7 @@ export class MapComponent implements OnInit, OnChanges {
 
   constructor(
     public el: ElementRef,
+    public mapToolService: MapToolService,
     private mapService: MapService,
     private loader: LoadingService,
     private platform: PlatformService,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -103,7 +103,7 @@
     "DATA_LINK_MULTIPLE": "View Full Comparison",
     "SCROLL_DATA_SINGLE": "Scroll for More Data",
     "SCROLL_DATA_MULTIPLE": "Scroll for Full Comparison",
-    "MAX_LOCATIONS_ERROR": "Maximum limit reached. Please remove a location to add another.",
+    "MAX_LOCATIONS_ERROR": "Only three locations may be viewed at once. Remove one of the location cards to add another location.",
     "NO_DATA_ERROR": "Could not find data for location.",
     "AUTO": "auto",
     "UNSUPPORTED_TITLE": "Unsupported Browser",

--- a/src/theme/base/toast.scss
+++ b/src/theme/base/toast.scss
@@ -37,6 +37,10 @@
   background-color: $black;
   pointer-events: auto;
 }
+// prevent toast messages from stacking
+.toast + .toast {
+  display:none;
+}
 
 // Toast message text
 // ---


### PR DESCRIPTION
  - Update error message with more specific instructions
  - Expand the cards when trying to add a location with the maximum number of locations already selected

Test it out on the [prototype link](http://eviction-lab-prototypes.s3-website.us-east-2.amazonaws.com/issue-1076/#/2016?geography=states&bounds=-157.148,12.494,-44.648,59.458&locations=47,-86.066,35.836%2B49,-112.183,38.88%2B08,-105.557,38.999) 
  - there are three locations active, try to add another via map or search

Closes #1076 