### PR TITLE
Split eviction and census data

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -84,8 +84,8 @@ export class DataPanelComponent implements OnInit {
     const cardProps = this._dataAttributes
       .filter(d => typeof d.order === 'number')
       .sort((a, b) => a.order > b.order ? 1 : -1);
-    // index where the divider is inserted, right before "percent white" (pw)
-    const dividerIndex = cardProps.findIndex(p => p.id === 'pw');
+    // index where the divider is inserted, right before "poverty rate" (pr)
+    const dividerIndex = cardProps.findIndex(p => p.id === 'pr');
     const divider = { id: 'divider', langKey: 'STATS.DEMOGRAPHICS' };
     // add the divider
     this.cardAttributes = [

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -142,7 +142,7 @@
     "PREV": "Previous"
   },
   "STATS": {
-    "DEMOGRAPHICS": "Demographic Breakdown",
+    "DEMOGRAPHICS": "Census Demographics",
     "NO_DATA": "No data",
     "NONE": "None",
     "JUDGMENTS_PER_DAY": "Evictions Per Day",


### PR DESCRIPTION
Closes #1088. Changes the name of the demographic divider, and moves it between the eviction numbers and census numbers on location cards in the data panel. It doesn't seem as necessary to put it in the map location cards, given we don't have a lot of space, and the map lists "Census Data" for the choropleth dropdown

<img width="396" alt="screen shot 2018-04-10 at 11 28 36 am" src="https://user-images.githubusercontent.com/8291663/38570117-ac2013b0-3cb2-11e8-94c4-99b977ef7d08.png">
