### PR TITLE
Add block group and census tract labels to cards

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -9,10 +9,10 @@
       [tooltip]="isTruncated(f['displayName']) ? f.properties['n'] : null" 
       [placement]="collapsible ? 'top' : 'bottom'"
     >
-      <small *ngIf="f.properties['layerId'] === 'tracts' || f.properties['layerId'] === 'block-groups'">
+      <span *ngIf="f.properties['layerId'] === 'tracts' || f.properties['layerId'] === 'block-groups'">
         {{ f.properties['layerId'] === 'tracts' ? ('DATA.TRACT_SINGULAR' | translate) : ''}}
         {{ f.properties['layerId'] === 'block-groups' ? ('DATA.BLOCK_GROUP_SINGULAR' | translate) : ''}}
-      </small>
+      </span>
       {{f['displayName']}}
     </h1>
     <h2 class="card-subheading">{{f.properties['pl']}}</h2>

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -9,8 +9,10 @@
       [tooltip]="isTruncated(f['displayName']) ? f.properties['n'] : null" 
       [placement]="collapsible ? 'top' : 'bottom'"
     >
-      {{ f.properties['layerId'] === 'tracts' ? ('DATA.TRACT_SINGULAR' | translate) : ''}}
-      {{ f.properties['layerId'] === 'block-groups' ? ('DATA.BLOCK_GROUP_SINGULAR' | translate) : ''}}
+      <small *ngIf="f.properties['layerId'] === 'tracts' || f.properties['layerId'] === 'block-groups'">
+        {{ f.properties['layerId'] === 'tracts' ? ('DATA.TRACT_SINGULAR' | translate) : ''}}
+        {{ f.properties['layerId'] === 'block-groups' ? ('DATA.BLOCK_GROUP_SINGULAR' | translate) : ''}}
+      </small>
       {{f['displayName']}}
     </h1>
     <h2 class="card-subheading">{{f.properties['pl']}}</h2>

--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -6,9 +6,13 @@
   <div class="card-header" [class.clickable]="clickedHeader.observers.length > 0" (click)="clickedHeader.emit(f)">
     <app-ui-icon class="marker" icon="marker"></app-ui-icon>
     <h1 class="card-heading" 
-      [tooltip]="f.properties['n'].length > maxLocationLength ? f.properties['n'] : null" 
+      [tooltip]="isTruncated(f['displayName']) ? f.properties['n'] : null" 
       [placement]="collapsible ? 'top' : 'bottom'"
-    >{{ getLocationName(f.properties['n']) }}</h1>
+    >
+      {{ f.properties['layerId'] === 'tracts' ? ('DATA.TRACT_SINGULAR' | translate) : ''}}
+      {{ f.properties['layerId'] === 'block-groups' ? ('DATA.BLOCK_GROUP_SINGULAR' | translate) : ''}}
+      {{f['displayName']}}
+    </h1>
     <h2 class="card-subheading">{{f.properties['pl']}}</h2>
     <app-ui-close-button class="card-dismiss" 
       [ariaLabel]="'DATA.REMOVE_LOCATION' | translate:{'name':f.properties.n}" 

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -27,6 +27,7 @@
   position:relative;
   width: 100%;
   z-index: 20;
+  .card-heading small { display: block; }
   &:nth-child(2) { z-index: 19; }
   &:nth-child(3) { z-index: 18; }
   &:nth-child(4) { z-index: 17; }

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -187,6 +187,10 @@
       letter-spacing: 0.5px;
       text-transform: uppercase;
     }
+    .card-stat-value {
+      margin-top: grid(0.5);
+      font-size:15px;
+    }
     li { 
       float:left; 
       padding-right: grid(2); 
@@ -302,6 +306,7 @@
       }
       .card-stat-value {
         @include numberFont($cardValueTextSize);
+        margin:0;
         &.unavailable {
           @include defaultFont($cardValueTextSize);
         }

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -143,6 +143,7 @@
   }
   // add dotted border for hints
   .card-stats li.has-hint .card-stat-label {
+    margin-bottom: -2px; // offset the border so alignment isn't changed
     border-bottom: $tooltipTriggerBorder;
   }
   // attribute values
@@ -167,7 +168,7 @@
   box-shadow: $z1shadow;
   // location cards fill most of the viewport width
   .location-card {
-    min-width: 75vw;
+    min-width:grid(37);
   }
   // align location text at top of card header
   .card-header {
@@ -181,10 +182,16 @@
     left:0;
     width:100%;
     padding: grid(1) 0 grid(1) grid(2);
+    .card-stat-label {
+      font-family: $boldFontStack;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
     li { 
       float:left; 
       padding-right: grid(2); 
       max-width: 50%;
+      
       > span {
         display:block;
         width:100%;
@@ -207,7 +214,16 @@
 @media(min-width: 540px) {
   :host-context(.map-ui-wrapper) {
     .card-content { 
-      li { max-width: 40%; }
+      /* two items */
+      li:first-child:nth-last-child(2),
+      li:first-child:nth-last-child(2) ~ li {
+          max-width: 50%;
+      }
+      /* three items */
+      li:first-child:nth-last-child(3),
+      li:first-child:nth-last-child(3) ~ li {
+          max-width: 33.3333%;
+      }
       li:nth-child(2) { display: block; }
       li:nth-child(2):last-child, li:nth-child(3) { float: left; }
     }
@@ -218,10 +234,6 @@
   :host-context(.map-ui-wrapper) {
     .location-card { 
       width: 100%; 
-      min-width: grid(42);
-    }
-    .card-content li { 
-      max-width: 30%;
     }
   }
 } 
@@ -259,13 +271,16 @@
       line-height: 17px;
       width:100%;
     }
+    // increase specificity to override max width and floats
+    .location-card .card-content ul li {
+      max-width:none;
+      float: none;
+    }
     // stacked statistics
     .card-content {
       position: static;
       padding: $defaultPadding;
       li {
-        max-width: none;
-        float: none;
         margin-right: 0;
         padding-right: 0;
         &:nth-child(2):last-child,
@@ -277,6 +292,9 @@
       }
       .card-stat-label {
         font-size: $cardLabelTextSize;
+        font-family: $fontStack;
+        letter-spacing: 0;
+        text-transform: none;
         // align hint button with text
         .attribute-hint ::ng-deep .hint-button svg {
           margin-top:2px;

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -86,7 +86,7 @@
 .card-heading { 
   width: 100%;
   margin: 0; 
-  @include cardHeading(18px);
+  @include cardHeading(15px);
   letter-spacing: 0.7px;
 }
 .card-subheading {

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -27,7 +27,6 @@
   position:relative;
   width: 100%;
   z-index: 20;
-  .card-heading small { display: block; }
   &:nth-child(2) { z-index: 19; }
   &:nth-child(3) { z-index: 18; }
   &:nth-child(4) { z-index: 17; }
@@ -87,11 +86,13 @@
 .card-heading { 
   width: 100%;
   margin: 0; 
-  @include cardHeading(16px);
+  @include cardHeading(18px);
+  letter-spacing: 0.7px;
 }
 .card-subheading {
   margin: grid(0.5) 0 0 0;     
-  @include smallCapsText(12px);
+  @include smallCapsText(13px);
+  letter-spacing: 0.3px;
 }
 .card-dismiss { 
   position:absolute;
@@ -217,7 +218,7 @@
   :host-context(.map-ui-wrapper) {
     .location-card { 
       width: 100%; 
-      min-width: grid(35);
+      min-width: grid(42);
     }
     .card-content li { 
       max-width: 30%;
@@ -235,15 +236,27 @@
     }
     // align header text at the bottom of the header
     .card-header {
-      justify-content: flex-end; 
+      height: grid(15.5);
+      justify-content: flex-end;
+      padding: grid(1.5) grid(2); // 1.5 padding to account for line height
+      span {
+        display: block;
+        margin: 0 0 grid(1) 0; 
+        @include smallCapsText($cardSubheadingSize);
+        letter-spacing: 0.3px;
+        width:100%;
+      }
     }
     // increase font sizes
     .card-heading { 
       @include cardHeading($cardHeadingSize);
+      letter-spacing: 0.7px;
     }
     .card-subheading {
       margin: grid(1) 0 0 0;     
       @include smallCapsText($cardSubheadingSize);
+      letter-spacing: 0.3px;
+      line-height: 17px;
       width:100%;
     }
     // stacked statistics

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -253,7 +253,7 @@
       letter-spacing: 0.7px;
     }
     .card-subheading {
-      margin: grid(1) 0 0 0;     
+      margin: (grid(1)-2px) 0 0 0; // offset subheading margin by 2px to account for line height  
       @include smallCapsText($cardSubheadingSize);
       letter-spacing: 0.3px;
       line-height: 17px;

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -10,8 +10,6 @@ import { MapDataAttribute } from '../../map-tool/data/map-data-attribute';
 import { MapFeature } from '../../map-tool/map/map-feature';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { PlatformService } from '../../services/platform.service';
-import { TranslateService } from '@ngx-translate/core';
-import { Subject } from 'rxjs/Subject';
 
 @Component({
   selector: 'app-location-cards',
@@ -141,9 +139,7 @@ export class LocationCardsComponent implements OnInit {
   private percentProps;
   /** Stores which properties should be $ formatted */
   private dollarProps;
-  /** Subject that emits value on destroy */
-  private destroy = new Subject<boolean>();
-  
+
   constructor(
     public el: ElementRef,
     private decimal: DecimalPipe,

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -10,6 +10,8 @@ import { MapDataAttribute } from '../../map-tool/data/map-data-attribute';
 import { MapFeature } from '../../map-tool/map/map-feature';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { PlatformService } from '../../services/platform.service';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs/Subject';
 
 @Component({
   selector: 'app-location-cards',
@@ -134,13 +136,14 @@ export class LocationCardsComponent implements OnInit {
   @ViewChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
   /** determines if cards are expanded (map view) */
   private expanded = true;
-  /** Maximum number of characters for location name */
-  maxLocationLength = 24;
+
   /** Stores which properties should be % formatted */
   private percentProps;
   /** Stores which properties should be $ formatted */
   private dollarProps;
-
+  /** Subject that emits value on destroy */
+  private destroy = new Subject<boolean>();
+  
   constructor(
     public el: ElementRef,
     private decimal: DecimalPipe,
@@ -189,12 +192,9 @@ export class LocationCardsComponent implements OnInit {
     return this.year.toString().slice(-2);
   }
 
-  /** Get location name and truncate if it's too long */
-  getLocationName(name: string) {
-    const max = this.maxLocationLength;
-    return name.length > max ? name.substring(0, max) + '...' : name;
+  isTruncated(value: string) {
+    return value.substr(value.length - 3) === '...';
   }
-
 
   /** gets an animation state for the card number */
   getCardState(cardNum: number) {

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -446,7 +446,7 @@ export class MapToolService {
 
   /** Get location name and truncate if it's too long */
   private addDisplayName(feature: MapFeature) {
-    const max = 24;
+    const max = 21;
     const layerId = feature['properties']['layerId'];
     const name = feature['properties']['n'] as string;
     const displayName = name.length > max ? name.substring(0, max) + '...' : name;

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -446,7 +446,7 @@ export class MapToolService {
 
   /** Get location name and truncate if it's too long */
   private addDisplayName(feature: MapFeature) {
-    const max = 21;
+    const max = 24;
     const layerId = feature['properties']['layerId'];
     const name = feature['properties']['n'] as string;
     const displayName = name.length > max ? name.substring(0, max) + '...' : name;

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -257,6 +257,7 @@ export class MapToolService {
     const maxLocations = (this.activeFeatures.length >= 3);
     if (!maxLocations) {
       // Add flag properties
+      this.addDisplayName(feature);
       this.addFlaggedProps(feature);
       this.activeFeatures = [...this.activeFeatures, feature];
       // track comparissons added
@@ -441,6 +442,15 @@ export class MapToolService {
     });
     feature['lowProps'] = Object.keys(this.lowFlags)
       .filter((p: string) => this.lowFlags[p].indexOf(feature.properties['GEOID']) > -1);
+  }
+
+  /** Get location name and truncate if it's too long */
+  private addDisplayName(feature: MapFeature) {
+    const max = 24;
+    const layerId = feature['properties']['layerId'];
+    const name = feature['properties']['n'] as string;
+    const displayName = name.length > max ? name.substring(0, max) + '...' : name;
+    feature['displayName'] = displayName;
   }
 
   /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -62,7 +62,9 @@
     "NEWSLETTER_OPT_IN": "Subscribe to the Eviction Lab newsletter",
     "SEND_DATA": "Send Data",
     "AUTOCOMPLETE_HINT": "When available, use up and down arrows to review and enter to select.",
-    "LOADING": "Loading"
+    "LOADING": "Loading",
+    "TRACT_SINGULAR": "Census Tract",
+    "BLOCK_GROUP_SINGULAR": "Block Group"
   },
   "HEADER": {
     "HOME": "Home",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -62,7 +62,9 @@
     "NEWSLETTER_OPT_IN": "Subscribirse al boletín de Eviction Lab",
     "SEND_DATA": "Enviar datos",
     "AUTOCOMPLETE_HINT": "Cuando esté disponible, use las flechas hacia arriba y hacia abajo para revisar e ingresar para seleccionar.",
-    "LOADING": "Cargando"
+    "LOADING": "Cargando",
+    "TRACT_SINGULAR": "Sección Censales",
+    "BLOCK_GROUP_SINGULAR": "Grupo de Cuadras"
   },
   "HEADER": {
     "HOME": "Inicio",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -63,7 +63,7 @@
     "SEND_DATA": "Enviar datos",
     "AUTOCOMPLETE_HINT": "Cuando esté disponible, use las flechas hacia arriba y hacia abajo para revisar e ingresar para seleccionar.",
     "LOADING": "Cargando",
-    "TRACT_SINGULAR": "Sección Censales",
+    "TRACT_SINGULAR": "Sección Censal",
     "BLOCK_GROUP_SINGULAR": "Grupo de Cuadras"
   },
   "HEADER": {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -274,7 +274,7 @@ $panelCardLabelText: $black;;
 $panelCardValueText: #434878;
 $panelCardBorder: $shadingColor;
 // font sizes
-$cardHeadingSize: 19px;
+$cardHeadingSize: 18px;
 $cardSubheadingSize: 13px;
 $cardLabelTextSize: 15px;
 $cardValueTextSize: 24px;

--- a/src/theme/base/normalize.scss
+++ b/src/theme/base/normalize.scss
@@ -231,7 +231,6 @@ h5 small,
 h6 small {
   font-weight: normal;
   line-height: 1;
-  color: #777;
 }
 h1,
 h2,


### PR DESCRIPTION
  - Moves the truncating for location name to map service.  Putting it here makes sure the truncation function is only called once instead of every change detection cycle.
  - Adds Block Group / Census Tract labels to the card when one is selected.

Seems to work okay for English, but with Spanish certain tracts / block groups will overflow the card.  Not sure the best way to handle this.

![image](https://user-images.githubusercontent.com/21034/38570224-96e60f70-3caa-11e8-8891-1d1b9d8e48a8.png)
