### PR TITLE
Add static geocoder for states and counties

### DIFF
--- a/src/app/services/search-sources.ts
+++ b/src/app/services/search-sources.ts
@@ -104,3 +104,27 @@ export const OSMNamesSource: SearchSource = {
         });
     }
 };
+
+export const StaticSource: SearchSource = {
+    key: '',
+    baseUrl: '',
+    csvUrl: environment.staticSearchUrl,
+    featureList: [],
+    query: function (text: string) { return ''; },
+    results: function (results: Object, text?: string): MapFeature[] {
+        return this.featureList.filter(f =>
+            f.properties.label.toLowerCase().includes(text.toLowerCase())
+        ).sort((a, b) => {
+            // Sort states before counties
+            if (a.properties.layerId === 'states' && b.properties.layerId === 'states') {
+                return 0;
+            } else if (a.properties.layerId === 'states') {
+                return -1;
+            } else if (b.properties.layerId === 'states') {
+                return 1;
+            } else {
+                return 0;
+            }
+        }).map(f => { f.center = f.geometry.coordinates; return f; });
+    }
+};

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -4,13 +4,14 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { csvParse } from 'd3-dsv';
 import 'rxjs/add/operator/do';
 
-import { SearchSource, MapboxSource } from './search-sources';
+import { SearchSource, MapboxSource, StaticSource } from './search-sources';
 import { MapFeature } from '../map-tool/map/map-feature';
 import { AnalyticsService } from './analytics.service';
+import { environment } from '../../environments/environment';
 
 @Injectable()
 export class SearchService {
-  source: SearchSource = MapboxSource;
+  source: SearchSource = environment.useMapbox ? MapboxSource : StaticSource;
 
   constructor(private http: HttpClient, private analytics: AnalyticsService) {
     if (this.source.hasOwnProperty('csvUrl')) {
@@ -25,8 +26,12 @@ export class SearchService {
    * @param query string to be sent to API
    */
   queryGeocoder(query: string): Observable<Object[]> {
-    return this.http.get(this.source.query(query))
-      .map(res => this.source.results(res, query));
+    if (environment.useMapbox) {
+      return this.http.get(this.source.query(query))
+        .map(res => this.source.results(res, query));
+    } else {
+      return Observable.from([this.source.results({}, query)]);
+    }
   }
 
   /**
@@ -38,9 +43,13 @@ export class SearchService {
     return csvParse(csv, d => {
       return {
         type: 'Feature',
-        bbox: [ +d.west, +d.south, +d.east, +d.north ],
-        properties: { label: d.name, layerId: layerId, GEOID: d.GEOID },
-        geometry: { type: 'Point',  coordinates: [+d.lon, +d.lat] }
+        bbox: [+d.west, +d.south, +d.east, +d.north],
+        properties: {
+          label: d.name,
+          layerId: 'layer' in d ? d.layer : layerId,
+          GEOID: d.GEOID
+        },
+        geometry: { type: 'Point', coordinates: [+d.lon, +d.lat] }
       } as MapFeature;
     });
   }

--- a/src/assets/style.json
+++ b/src/assets/style.json
@@ -18,7 +18,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-block-groups-00/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-block-groups-10": {
       "type": "vector",
@@ -26,7 +26,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-block-groups-10/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-tracts-00": {
       "type": "vector",
@@ -34,7 +34,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-tracts-00/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-tracts-10": {
       "type": "vector",
@@ -42,7 +42,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-tracts-10/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-cities-00": {
       "type": "vector",
@@ -50,7 +50,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-cities-00/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-cities-10": {
       "type": "vector",
@@ -58,7 +58,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-cities-10/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-counties-00": {
       "type": "vector",
@@ -66,7 +66,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-counties-00/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-counties-10": {
       "type": "vector",
@@ -74,7 +74,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-counties-10/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-states-00": {
       "type": "vector",
@@ -82,7 +82,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-states-00/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "us-states-10": {
       "type": "vector",
@@ -90,7 +90,7 @@
       "tiles": [
         "https://tiles.evictionlab.org/evictions-states-10/{z}/{x}/{y}.pbf"
       ],
-      "attribution": ""
+      "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">© Mapbox</a>"
     },
     "highlight": {
       "type": "geojson",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -15,6 +15,7 @@ export const environment = {
     'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqY20zamVpcTBwb3gzM28yb292YzM3dXoifQ.' +
     'uKgAjsMd4qkJNqEtr3XyPQ',
   mapboxCountyUrl: 'https://evictionlab.org/data/search/counties.csv',
+  staticSearchUrl: 'https://evictionlab.org/data/search/locations.csv',
   downloadBaseUrl: 'https://exports.evictionlab.org',
   minYear: 2000,
   maxYear: 2016,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -15,6 +15,7 @@ export const environment = {
         'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
         '4et5d5nstXWM5P0JG67XEQ',
     mapboxCountyUrl: 'https://staging.evictionlab.org/data/search/counties.csv',
+    staticSearchUrl: 'https://staging.evictionlab.org/data/search/locations.csv',
     downloadBaseUrl: 'https://exports-dev.evictionlab.org',
     minYear: 2000,
     maxYear: 2016,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -21,6 +21,7 @@ export const environment = {
     'eyJ1IjoiZXZpY3Rpb24tbGFiIiwiYSI6ImNqYzJoNzVxdzAwMTMzM255dmsxM2YwZWsifQ.' +
     '4et5d5nstXWM5P0JG67XEQ',
   mapboxCountyUrl: 'https://s3.amazonaws.com/eviction-lab-tool-data/data/search/counties.csv',
+  staticSearchUrl: 'https://staging.evictionlab.org/data/search/locations.csv',
   downloadBaseUrl: 'https://exports-dev.evictionlab.org',
   minYear: 2000,
   maxYear: 2016,


### PR DESCRIPTION
Closes #1081. Implements a static file location search for states and counties with `StaticSource` when `useMapbox` is false. The build step for `locations.csv` is added to the ETL repo already. I also added the Mapbox text attribution back to the OpenMapTiles `style.json` because from what I remember we still needed that since we're using Mapbox GL JS, but we needed to remove the Mapbox logo.