### PR TITLE
Set height with javascript instead of using `vh`

### DIFF
--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -8,10 +8,6 @@
 .app-wrapper {
   min-height:100%;
   min-width: 100%;
-  &.map-active {
-    height: 100vh;
-    overflow: hidden;
-  }
   app-map {
     position:relative;
     display:block;
@@ -19,7 +15,6 @@
     margin-top: $headerHeightSm;
     height: calc(100vh - #{$headerHeightSm});
     z-index:10;
-    transition: $mobileVhTransition;
   }
   app-data-panel {
     display:block;
@@ -45,10 +40,11 @@
 //    Adjust height of map / location cards to reflect large header.
 @media(min-width: $gtTablet) {
   .app-wrapper {
-    &.map-active { transition: none; }
-
-    app-map, app-map.legend-active, app-map.slider-active,
-    app-map.legend-active.slider-active, app-map.cards-active {
+    app-map, 
+    app-map.legend-active, 
+    app-map.slider-active,
+    app-map.legend-active.slider-active, 
+    app-map.cards-active {
       margin-top: $headerHeightLg;
       height: calc(100vh - #{$headerHeightLg});
       transition: none;

--- a/src/app/map-tool/map-tool.component.scss
+++ b/src/app/map-tool/map-tool.component.scss
@@ -36,22 +36,6 @@
   }
 }
 
-// Larger than tablet:
-//    Adjust height of map / location cards to reflect large header.
-@media(min-width: $gtTablet) {
-  .app-wrapper {
-    app-map, 
-    app-map.legend-active, 
-    app-map.slider-active,
-    app-map.legend-active.slider-active, 
-    app-map.cards-active {
-      margin-top: $headerHeightLg;
-      height: calc(100vh - #{$headerHeightLg});
-      transition: none;
-    }
-  }
-}
-
 // Map Overlay
 .map-overlay {
   @include fill-parent();

--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -100,10 +100,8 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     // Check device support for map once language has loaded
     this.translate.getTranslation(this.translate.currentLang)
       .take(1).subscribe(() => { this.checkSupport(); });
-    // Reset VH transition only on width changes
-    this.platform.dimensions$.distinctUntilChanged((prev, next) => {
-      return prev.width === next.width;
-    }).skip(1).subscribe(this.resetVhTransition.bind(this));
+    // set map height on dimension changes
+    this.platform.dimensions$.subscribe(this.setMapSize.bind(this));
     this.cdRef.detectChanges();
   }
 
@@ -117,6 +115,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   ngAfterViewInit() {
     this.panelOffset = this.dividerEl.nativeElement.getBoundingClientRect().bottom;
+    setTimeout(() => { this.setMapSize(); }, 1000);
   }
 
   /**
@@ -374,16 +373,10 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  /**
-   * Toggle mobile vh transition to force a height change on resize
-   */
-  private resetVhTransition() {
-    this.map.el.nativeElement.style.transition = 'none';
-    this.map.el.nativeElement.style.height = '100vh';
-    setTimeout(() => {
-      this.map.el.nativeElement.style.height = null;
-      setTimeout(() => this.map.el.nativeElement.style.transition = null);
-    }, 350);
+  private setMapSize() {
+    const newHeight =
+      (this.platform.nativeWindow.innerHeight - this.map.el.nativeElement.offsetTop);
+    this.map.el.nativeElement.style.height = newHeight + 'px';
   }
 
 }

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -145,7 +145,7 @@ app-location-cards {
       top:0;
       bottom: auto;
       margin:auto;
-      height: calc(100% - #{$headerHeightLg} - #{$timeSliderLg});
+      height: calc(100% - #{$timeSliderLg});
     }
   }
 }

--- a/src/app/map-tool/map/map/map.component.scss
+++ b/src/app/map-tool/map/map/map.component.scss
@@ -123,7 +123,7 @@ app-location-cards {
     background: none;
     pointer-events: none;
     align-items: center;
-    height: calc(100vh - #{$headerHeightLg});
+    height: calc(100% - #{$headerHeightLg});
     ::ng-deep {
       .location-card {
         transition: transform 0.2s ease;
@@ -145,7 +145,7 @@ app-location-cards {
       top:0;
       bottom: auto;
       margin:auto;
-      height: calc(100vh - #{$headerHeightLg} - #{$timeSliderLg});
+      height: calc(100% - #{$headerHeightLg} - #{$timeSliderLg});
     }
   }
 }
@@ -391,83 +391,3 @@ app-ui-map-legend {
   }
 }
 // - End Year Slider
-
-
-// TODO: Move device specific styles to separate overrides file
-// Device-specific adjustments
-
-// iPhones w/ safari
-@media(max-width: $gtMobile) {
-  .ios-safari :host-context(.slider-active) {
-    .year-slider-container { height: $timeSliderHeight + $iosSafariPadding; }
-  }
-  .ios-safari :host-context(.legend-active) {
-    app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderHeight; }
-  }
-  .ios-safari :host-context(.cards-active) {
-    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-    app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-    .year-slider-container {
-      height: $timeSliderHeight;
-      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
-    }
-    app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
-  }
-}
-// iPads w/ Safari
-@media(min-width: $gtMobile) and (max-width: $gtTablet) {
-  .ios-safari :host-context(.slider-active) {
-    .year-slider-container { height: $timeSliderLg + $iosSafariPadding; }
-  }
-  .ios-safari :host-context(.legend-active) {
-    app-ui-map-legend { bottom: $iosSafariPadding + $timeSliderLg; }
-  }
-  .ios-safari :host-context(.cards-active) {
-    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-    app-location-cards { bottom: $mobileScrollIndicatorHeight + $iosSafariPadding; }
-    .year-slider-container {
-      height: $timeSliderLg;
-      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding;
-    }
-    app-ui-map-legend { bottom: $timeSliderLg + $cardHeaderHeight + $mobileScrollIndicatorHeight + $iosSafariPadding; }
-  }
-}
-// Android - Mobile
-@media(max-width: $gtMobile) {
-  .android :host-context(.slider-active) {
-    .year-slider-container { height: $timeSliderHeight + $androidPadding; }
-  }
-  .android :host-context(.legend-active) {
-    app-ui-map-legend { bottom: $androidPadding + $timeSliderHeight; }
-  }
-  .android :host-context(.cards-active) {
-    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
-    app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
-    .year-slider-container {
-      height: $timeSliderHeight;
-      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
-    }
-    app-ui-map-legend { bottom: $timeSliderHeight + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
-  }
-}
-// Android - Tablet
-@media(min-width: $gtMobile) and (max-width: $gtTablet) {
-  .android :host-context(.slider-active) {
-    .year-slider-container { height: $timeSliderLg + $androidPadding; }
-  }
-  .android :host-context(.legend-active) {
-    app-ui-map-legend { bottom: $androidPadding + $timeSliderLg; }
-  }
-  .android :host-context(.cards-active) {
-    .mobile-scroll-indicator { height: $mobileScrollIndicatorHeight + $androidPadding; }
-    app-location-cards { bottom: $mobileScrollIndicatorHeight + $androidPadding; }
-    .year-slider-container {
-      height: $timeSliderLg;
-      bottom: $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding;
-    }
-    app-ui-map-legend { bottom: $timeSliderLg + $cardHeaderHeight + $mobileScrollIndicatorHeight + $androidPadding; }
-  }
-}
-
-
-// - End of device adjustments


### PR DESCRIPTION
There are a few weird things going on with using `vh` units on mobile / tablet, due to the changing size of location bar on the browsers.

This sets the height explicitly by getting the height with javascript and setting it. Also removes the need for a bunch of device specific CSS.