### PR TITLE
Fix setting mobile height

### DIFF
--- a/src/app/map-tool/map-tool.component.ts
+++ b/src/app/map-tool/map-tool.component.ts
@@ -103,6 +103,7 @@ export class MapToolComponent implements OnInit, OnDestroy, AfterViewInit {
     // set map height on dimension changes
     this.platform.dimensions$
       .distinctUntilChanged((prev, next) => prev.width === next.width)
+      .skip(1)
       .subscribe(this.setMapSize.bind(this));
     this.cdRef.detectChanges();
   }

--- a/src/environments/version.ts
+++ b/src/environments/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.2';
+export const version = '1.0.3';


### PR DESCRIPTION
Closes #1109. Right now, the mobile map height is always going to be a little off after the address bar shifts because that will fire `setMapSize`, and it won't get called again until the width changes. It might be good to get this in before the next release for that reason