### PR TITLE
Update embed legend, link to map

### DIFF
--- a/src/app/map-tool/embed/embed.component.html
+++ b/src/app/map-tool/embed/embed.component.html
@@ -1,5 +1,5 @@
 <div id="embed-branding">
-  <a href="/" target="_blank">
+  <a href="{{mapUrl}}" target="_blank">
     <img src="{{deployUrl}}assets/images/eviction-lab-logo.svg" class="header-logo-img" alt="Eviction Lab Home" />
   </a>
 </div>

--- a/src/app/map-tool/embed/embed.component.scss
+++ b/src/app/map-tool/embed/embed.component.scss
@@ -41,7 +41,10 @@ html.embedded {
   app-map .map-ui-wrapper app-location-cards,
   app-map .year-slider-container { display: none !important; }
   // force legend to the bottom
-  app-ui-map-legend { bottom: 0!important; }
+  app-ui-map-legend {
+    bottom: 0!important;
+    height: grid(9) !important;
+  }
   // hide scroll indicator
   .cards-active .mobile-scroll-indicator,
   .slider-active .mobile-scroll-indicator,
@@ -61,6 +64,8 @@ html.embedded {
 }
 
 @media(min-width: $gtMobile) {
-  .embed app-ui-map-legend { bottom: $pageMarginLg!important; }
+  .embed app-ui-map-legend {
+    bottom: $pageMarginLg!important;
+  }
 }
 

--- a/src/app/map-tool/embed/embed.component.spec.ts
+++ b/src/app/map-tool/embed/embed.component.spec.ts
@@ -9,6 +9,7 @@ import { MapModule } from '../map/map.module';
 import { ServicesModule } from '../../services/services.module';
 import { ScrollService } from '../../services/scroll.service';
 import { MapToolService } from '../map-tool.service';
+import { PlatformService } from '../../services/platform.service';
 import { LocationCardsComponent } from '../location-cards/location-cards.component';
 
 describe('EmbedComponent', () => {
@@ -25,7 +26,7 @@ describe('EmbedComponent', () => {
         TranslateModule.forRoot()
       ],
       providers: [
-        MapToolService
+        MapToolService, PlatformService
       ]
     })
     .compileComponents();

--- a/src/app/map-tool/embed/embed.component.ts
+++ b/src/app/map-tool/embed/embed.component.ts
@@ -8,6 +8,7 @@ import { environment } from '../../../environments/environment';
 import { MapToolService } from '../map-tool.service';
 import { MapService } from '../map/map.service';
 import { RoutingService } from '../../services/routing.service';
+import { PlatformService } from '../../services/platform.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
 
@@ -21,6 +22,7 @@ export class EmbedComponent implements OnInit, AfterViewInit {
   id = 'embed-map';
   deployUrl = environment.deployUrl;
   @ViewChild(MapComponent) map;
+  mapUrl = '/';
 
   private defaultMapConfig = {
     style: `${environment.deployUrl}assets/style.json`,
@@ -39,7 +41,8 @@ export class EmbedComponent implements OnInit, AfterViewInit {
     private translate: TranslateService,
     private route: ActivatedRoute,
     private cdRef: ChangeDetectorRef,
-    private el: ElementRef
+    private el: ElementRef,
+    private platform: PlatformService
   ) {
     this.routing.setActivatedRoute(route);
     this.mapToolService.embed = true;
@@ -63,6 +66,8 @@ export class EmbedComponent implements OnInit, AfterViewInit {
         this.mapConfig['year'] = data['year'];
         this.mapToolService.setCurrentData(mapData);
         this.mapConfig = { ...this.mapConfig, ...this.mapToolService.mapConfig };
+        // Naive replacement of embed in route for map link
+        this.mapUrl = this.platform.nativeWindow.location.href.replace('/embed', '');
         this.routing.updatePymSearch();
       });
     this.cdRef.detectChanges();

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.html
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.html
@@ -1,4 +1,7 @@
 <div class="map-legend">
+  <div class="label bubble" [class.both-labels]="hasChoropleth" *ngIf="hasBubbles">
+    <span>{{ bubbleLabel }}</span>
+  </div>
   <div class="legend-item small-bubble bubble-no-data" *ngIf="hasBubbles">
     <span>{{ noData }}</span>
     <div class="legend-circle"></div>
@@ -12,6 +15,9 @@
     <div class="legend-circle"></div>
   </div>
   <div class="legend-divider" *ngIf="hasBubbles && hasChoropleth"></div>
+  <div class="label choropleth" [class.both-labels]="hasBubbles" *ngIf="hasChoropleth">
+    <span>{{ choroplethLabel }}</span>
+  </div>
   <div class="legend-item choropleth-no-data" *ngIf="hasChoropleth">
     <span>{{ noData }}</span>
     <div class="no-data-square"></div>

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -177,6 +177,8 @@ app-ui-hint.legend-hint {
   height: grid(2);
   color: $grey_wcag;
   text-align: center;
+  text-transform: uppercase;
+  line-height: 1;
   @include defaultFontBold(12px);
 
   span { width: 100%; padding: grid(0.25); }
@@ -194,7 +196,7 @@ app-ui-hint.legend-hint {
 @media(min-width: $gtMobile) {
   .label {
     &.bubble { width: grid(20); }
-    &.choropleth { width: calc(100% - #{grid(16.5)}); }
+    &.choropleth { width: calc(100% - #{grid(20)}); }
   }
 }
 

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -61,7 +61,7 @@ $bubbleColor: rgba(255,4,0,0.65);
     background: $bubbleColor;
   }
 }
-.bubble-no-data {
+.legend-item.bubble-no-data {
   font-family: $boldFontStack;
   .legend-circle {
     background: #fff;
@@ -77,7 +77,7 @@ $bubbleColor: rgba(255,4,0,0.65);
 }
 
 // choropleth no data
-.choropleth-no-data {
+.legend-item.choropleth-no-data {
   font-family: $boldFontStack;
   .no-data-square {
     position: absolute;
@@ -177,7 +177,7 @@ app-ui-hint.legend-hint {
   height: grid(2);
   color: $grey_wcag;
   text-align: center;
-  @include numberFont(12px);
+  @include defaultFontBold(12px);
 
   span { width: 100%; padding: grid(0.25); }
 

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -169,3 +169,37 @@ app-ui-hint.legend-hint {
     margin-top: grid(1);
   }
 }
+
+.label {
+  display: none;
+  position: absolute;
+  top: 0;
+  height: grid(2);
+  color: $grey_wcag;
+  text-align: center;
+  @include numberFont(12px);
+
+  span { width: 100%; padding: grid(0.25); }
+
+  &.bubble {
+    left: 0;
+    width: grid(16.5);
+  }
+  &.choropleth {
+    width: calc(100% - #{grid(16.5)});
+    right: 0;
+  }
+}
+
+@media(min-width: $gtMobile) {
+  .label {
+    &.bubble { width: grid(20); }
+    &.choropleth { width: calc(100% - #{grid(16.5)}); }
+  }
+}
+
+:host-context(.embed) {
+  .label { display: inherit; }
+  .legend-item { margin: grid(5) grid(1) 0; }
+  .legend-hint { display: none; }
+}

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.ts
@@ -27,6 +27,8 @@ export class UiMapLegendComponent implements OnChanges {
   maxBubbleValue: number;
   hasBubbles = false;
   hasChoropleth = false;
+  bubbleLabel: string;
+  choroplethLabel: string;
   noData: string;
   hintData;
   legendGradient;
@@ -70,11 +72,13 @@ export class UiMapLegendComponent implements OnChanges {
         min: this.formatValue(this.stops[2]),
         max: this.formatValue(this.stops[this.stops.length - 2])
       }));
+      this.choroplethLabel = this.translatePipe.transform(this.choropleth.langKey);
     }
     if (this.hasBubbles) {
       legendText.push(this.translatePipe.transform('MAP.BUBBLE_LEGEND_HINT', {
         attribute: this.bubbles.name.toLowerCase()
       }));
+      this.bubbleLabel = this.translatePipe.transform(this.bubbles.langKey);
     }
     this.hintData = legendText.join(' ');
   }


### PR DESCRIPTION
Closes #1089 after design review and tweaks. Adds labels to legend when embedded based on export legend designs, and sets the Eviction Lab logo link to the initial map view for the embed creation.

<img width="469" alt="screen shot 2018-04-13 at 10 04 42 am" src="https://user-images.githubusercontent.com/8291663/38742494-532a9c2e-3f02-11e8-835f-ba43875ebfa2.png">
<img width="703" alt="screen shot 2018-04-13 at 10 04 49 am" src="https://user-images.githubusercontent.com/8291663/38742495-54331b8c-3f02-11e8-873a-05de2887e4ad.png">
