### PR TITLE
Add low flags outside of states

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -50,8 +50,8 @@
           <span *ngIf="f.properties[prop.yearAttr] >= 0">{{ prefix(prop.id) }}{{ processValue(f, prop) }}{{ suffix(prop.id) }}</span>
           <span *ngIf="!(f.properties[prop.yearAttr] >= 0)">{{ 'DATA.UNAVAILABLE' | translate }}</span>
           <app-ui-hint *ngIf="isHighProp(f, prop.yearAttr)" placement="right" container="body" [hint]="'MAP.FLAG_99TH' | translate"></app-ui-hint>
-          <app-ui-hint *ngIf="isLowProp(f, prop.id)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_LOW' | translate"></app-ui-hint>
-          <app-ui-hint *ngIf="isMarylandFiling(f, prop.id)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_MARYLAND_FILING' | translate"></app-ui-hint>
+          <app-ui-hint *ngIf="isLowProp(f, prop.yearAttr)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_LOW' | translate"></app-ui-hint>
+          <app-ui-hint *ngIf="isMarylandFiling(f, prop.yearAttr)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_MARYLAND_FILING' | translate"></app-ui-hint>
         </div>
         <span *ngIf="prop.id === 'divider'"
           class="card-stat-label"

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -167,22 +167,24 @@ export class LocationCardsComponent implements OnInit {
   }
 
   /** Checks if the property name exists in the feature's high flagged properties */
-  isHighProp(feature, prop: string) {
+  isHighProp(feature, yearProp: string) {
     if (!feature['highProps']) { return false; }
-    return feature['highProps'].indexOf(prop) > -1 &&
-      !this.isMarylandFiling(feature, prop);
+    return feature['highProps'].indexOf(yearProp) > -1 &&
+      !this.isMarylandFiling(feature, yearProp);
   }
 
   /** Checks if the property name exists in the feature's low flagged properties */
-  isLowProp(feature, prop: string) {
+  isLowProp(feature, yearProp: string) {
     if (!feature['lowProps']) { return false; }
+    const prop = yearProp.split('-')[0];
     return feature['lowProps'].indexOf(prop) > -1 &&
-      !this.isHighProp(feature, prop) &&
-      !this.isMarylandFiling(feature, prop);
+      !this.isHighProp(feature, yearProp) &&
+      !this.isMarylandFiling(feature, yearProp);
   }
 
   /** Special case to check for the Maryland eviction filing rate */
-  isMarylandFiling(feature, prop: string) {
+  isMarylandFiling(feature, yearProp: string) {
+    const prop = yearProp.split('-')[0];
     return feature.properties['GEOID'].slice(0, 2) === '24' && prop === 'efr';
   }
 

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -169,18 +169,21 @@ export class LocationCardsComponent implements OnInit {
   /** Checks if the property name exists in the feature's high flagged properties */
   isHighProp(feature, prop: string) {
     if (!feature['highProps']) { return false; }
-    return feature['highProps'].indexOf(prop) > -1;
+    return feature['highProps'].indexOf(prop) > -1 &&
+      !this.isMarylandFiling(feature, prop);
   }
 
   /** Checks if the property name exists in the feature's low flagged properties */
   isLowProp(feature, prop: string) {
     if (!feature['lowProps']) { return false; }
-    return feature['lowProps'].indexOf(prop) > -1;
+    return feature['lowProps'].indexOf(prop) > -1 &&
+      !this.isHighProp(feature, prop) &&
+      !this.isMarylandFiling(feature, prop);
   }
 
   /** Special case to check for the Maryland eviction filing rate */
   isMarylandFiling(feature, prop: string) {
-    return feature.properties['GEOID'] === '24' && prop === 'efr';
+    return feature.properties['GEOID'].slice(0, 2) === '24' && prop === 'efr';
   }
 
   getAbbrYear() {

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -441,7 +441,8 @@ export class MapToolService {
         .join(',');
     });
     feature['lowProps'] = Object.keys(this.lowFlags)
-      .filter((p: string) => this.lowFlags[p].indexOf(feature.properties['GEOID']) > -1);
+      .filter((p: string) =>
+        this.lowFlags[p].indexOf((feature.properties['GEOID'] as string).slice(0, 2)) > -1);
   }
 
   /** Get location name and truncate if it's too long */


### PR DESCRIPTION
Closes #1118. Adds low flags for a state to all areas within it, unless they have a high flag or Maryland filing flag, in which case it should default to those.

This is ready for review/merge, confirmed with research