### PR TITLE
Do not include bottom label in keyboard nav for `ui-select`

### DIFF
--- a/src/app/ui/ui-select/ui-select.component.html
+++ b/src/app/ui/ui-select/ui-select.component.html
@@ -22,6 +22,8 @@
         {{getLabel(value)}}
       </a>
     </li>
-    <li *ngIf="bottomLabel" class="bottom-label"><a class="dropdown-item">{{bottomLabel}}</a></li>
+    <li *ngIf="bottomLabel">
+      <p class="bottom-label">{{bottomLabel}}</p>
+    </li>
   </ul>
 </div>

--- a/src/app/ui/ui-select/ui-select.component.scss
+++ b/src/app/ui/ui-select/ui-select.component.scss
@@ -5,3 +5,18 @@
   display:block;
   position:relative;
 }
+
+.bottom-label {
+  display: block;
+  clear: both;
+  font-weight: normal;
+  padding: $defaultPadding;
+  border-top: 1px solid $shadingColor;
+  min-height: grid(6);
+  white-space: normal;
+  box-sizing: border-box;
+  text-decoration: none;
+  font-style:italic;
+  color: $grey_wcag;
+  margin-bottom:0;
+}


### PR DESCRIPTION
  - Takes the bottom label out of the `<a>` tag so it isn't given keyboard focus

Closes #1114 