### PR TITLE
Use webpack translate loader

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { FooterComponent } from './footer/footer.component';
 import { MenuComponent } from './menu/menu.component';
 import { ServicesModule } from './services/services.module';
 import { EmbedComponent } from './map-tool/embed/embed.component';
+import { WebpackTranslateLoader } from './webpack-translate-loader';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, `${environment.deployUrl}assets/i18n/`, '.json');
@@ -50,8 +51,7 @@ export class CustomOption extends ToastOptions {
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
-        useFactory: (createTranslateLoader),
-        deps: [HttpClient]
+        useClass: WebpackTranslateLoader
       }
     }),
     ServicesModule.forRoot(),

--- a/src/app/webpack-translate-loader.ts
+++ b/src/app/webpack-translate-loader.ts
@@ -1,0 +1,9 @@
+import { TranslateLoader } from '@ngx-translate/core';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromPromise';
+
+export class WebpackTranslateLoader implements TranslateLoader {
+  getTranslation(lang: string): Observable<any> {
+    return Observable.fromPromise(System.import(`../assets/i18n/${lang}.json`));
+  }
+}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,3 +7,8 @@ declare module "*.json" {
   const value: any;
   export default value;
 }
+
+declare var System: System;
+interface System {
+  import(request: string): Promise<any>;
+}


### PR DESCRIPTION
Instead of loading translation language files through HTTP, they are pulled in using webpack.  This should ensure the proper translations are bundled with each build.  Closes #1113 