### PR TITLE
Fix error when bar graph is default

### DIFF
--- a/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
+++ b/src/app/map-tool/data-panel/eviction-graphs/eviction-graphs.component.ts
@@ -320,6 +320,7 @@ export class EvictionGraphsComponent implements OnInit {
   }
 
   tooltipValue(val: number): string {
+    if (!this.graphSettings) { return ''; }
     let valStr = val.toString();
     if (this.graphSettings.axis.y.maxVal > 0 && val > this.graphSettings.axis.y.maxVal) {
       valStr = '>' + this.graphSettings.axis.y.maxVal;


### PR DESCRIPTION
 When the bar graph is the default the tooltips are initialized before the graph settings are set.  This returns an empty string when graph settings are not yet available.

Closes #1127 