### PR TITLE
Revert "Add low flags outside of states"

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.html
+++ b/src/app/map-tool/location-cards/location-cards.component.html
@@ -50,8 +50,8 @@
           <span *ngIf="f.properties[prop.yearAttr] >= 0">{{ prefix(prop.id) }}{{ processValue(f, prop) }}{{ suffix(prop.id) }}</span>
           <span *ngIf="!(f.properties[prop.yearAttr] >= 0)">{{ 'DATA.UNAVAILABLE' | translate }}</span>
           <app-ui-hint *ngIf="isHighProp(f, prop.yearAttr)" placement="right" container="body" [hint]="'MAP.FLAG_99TH' | translate"></app-ui-hint>
-          <app-ui-hint *ngIf="isLowProp(f, prop.yearAttr)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_LOW' | translate"></app-ui-hint>
-          <app-ui-hint *ngIf="isMarylandFiling(f, prop.yearAttr)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_MARYLAND_FILING' | translate"></app-ui-hint>
+          <app-ui-hint *ngIf="isLowProp(f, prop.id)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_LOW' | translate"></app-ui-hint>
+          <app-ui-hint *ngIf="isMarylandFiling(f, prop.id)" class="low-flag" placement="right" container="body" [hint]="'MAP.FLAG_MARYLAND_FILING' | translate"></app-ui-hint>
         </div>
         <span *ngIf="prop.id === 'divider'"
           class="card-stat-label"

--- a/src/app/map-tool/location-cards/location-cards.component.ts
+++ b/src/app/map-tool/location-cards/location-cards.component.ts
@@ -167,25 +167,20 @@ export class LocationCardsComponent implements OnInit {
   }
 
   /** Checks if the property name exists in the feature's high flagged properties */
-  isHighProp(feature, yearProp: string) {
+  isHighProp(feature, prop: string) {
     if (!feature['highProps']) { return false; }
-    return feature['highProps'].indexOf(yearProp) > -1 &&
-      !this.isMarylandFiling(feature, yearProp);
+    return feature['highProps'].indexOf(prop) > -1;
   }
 
   /** Checks if the property name exists in the feature's low flagged properties */
-  isLowProp(feature, yearProp: string) {
+  isLowProp(feature, prop: string) {
     if (!feature['lowProps']) { return false; }
-    const prop = yearProp.split('-')[0];
-    return feature['lowProps'].indexOf(prop) > -1 &&
-      !this.isHighProp(feature, yearProp) &&
-      !this.isMarylandFiling(feature, yearProp);
+    return feature['lowProps'].indexOf(prop) > -1;
   }
 
   /** Special case to check for the Maryland eviction filing rate */
-  isMarylandFiling(feature, yearProp: string) {
-    const prop = yearProp.split('-')[0];
-    return feature.properties['GEOID'].slice(0, 2) === '24' && prop === 'efr';
+  isMarylandFiling(feature, prop: string) {
+    return feature.properties['GEOID'] === '24' && prop === 'efr';
   }
 
   getAbbrYear() {

--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -441,8 +441,7 @@ export class MapToolService {
         .join(',');
     });
     feature['lowProps'] = Object.keys(this.lowFlags)
-      .filter((p: string) =>
-        this.lowFlags[p].indexOf((feature.properties['GEOID'] as string).slice(0, 2)) > -1);
+      .filter((p: string) => this.lowFlags[p].indexOf(feature.properties['GEOID']) > -1);
   }
 
   /** Get location name and truncate if it's too long */


### PR DESCRIPTION
Reverts EvictionLab/eviction-maps#1119

Taking out this PR for now so 1.0.4 can be pushed, as it has some high priority bug fixes.  Will create an issue for handling this, but it's in limbo until we hear back from research:

> Just talked to Matt, we are going to hold off on implementing these for now as we actually think we should take a more nuanced approach to the flagging. We’ll try to get that together for you in the next week, and once Lillian and I touch base we can set up a phone call to go over the flags.