### PR TITLE
fix footer columns when spanish

### DIFF
--- a/src/theme/base/footer.scss
+++ b/src/theme/base/footer.scss
@@ -133,7 +133,7 @@ footer {
   .footer-content {
     @include fill-parent();
     margin:auto;
-    height: grid(40);
+    height: grid(43);
     width: grid(88);
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
Boost footer height so funders text doesn't flow into the second column when spanish is selected.