### PR TITLE
Adjust style on compact version of embeds

### DIFF
--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -200,8 +200,20 @@ app-ui-hint.legend-hint {
   }
 }
 
+
 :host-context(.embed) {
   .label { display: inherit; }
   .legend-item { margin: grid(5) grid(1) 0; }
   .legend-hint { display: none; }
+  .map-legend .label span { padding: 8px 2px 0; }
 }
+
+@media(max-width: $gtMobile) {
+  :host-context(.embed) {
+    width:auto;
+    left: auto;
+    .map-legend { padding-top: 8px; }
+    
+  }
+}
+

--- a/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
+++ b/src/app/map-tool/map/map-legend/ui-map-legend.component.scss
@@ -212,8 +212,7 @@ app-ui-hint.legend-hint {
   :host-context(.embed) {
     width:auto;
     left: auto;
+    border-right: 1px solid $shadingColor;
     .map-legend { padding-top: 8px; }
-    
   }
 }
-


### PR DESCRIPTION
I've noticed on a few sites with the map embeds that the legend spans the entire width.  This covers up potential map space, and looks weird if the embed only had bubbled.  I've adjusted so a more compact version is displayed when the embed is small.

Closes #1137 

## Before: 
![evictionlab org_map_](https://user-images.githubusercontent.com/21034/39277199-e8f96536-48a9-11e8-8cdb-f3f9670c3486.png)

![evictionlab org_map_ 1](https://user-images.githubusercontent.com/21034/39277205-f13f2af0-48a9-11e8-90cb-9d8a9598d2bd.png)

## After:
![localhost_4200_ 2](https://user-images.githubusercontent.com/21034/39277220-fd77f6f8-48a9-11e8-9c1d-9201a71c7864.png)

![localhost_4200_ 5](https://user-images.githubusercontent.com/21034/39277396-c2082aec-48aa-11e8-9d12-a90e5d9ce369.png)

