### PR TITLE
fix error with properties being undefined

### DIFF
--- a/src/app/map-tool/map/map.service.ts
+++ b/src/app/map-tool/map/map.service.ts
@@ -286,12 +286,18 @@ export class MapService {
     const highlightFeatures = features
       .map((f, i) => {
         // make sure feature has a geo depth value so geometry is cached
-        const geoDepth = f['properties']['geoDepth'];
-        if (!geoDepth) { f['properties']['geoDepth'] = 0.1; }
+        if (f && f.hasOwnProperty('properties')) {
+          const geoDepth = f['properties']['geoDepth'];
+          if (!geoDepth) { f['properties']['geoDepth'] = 0.1; }
+        }
         f = this.getUpdatedFeature(f);
-        f['properties']['color'] = this.colors[i];
+        if (f && f.hasOwnProperty('properties')) {
+          f['properties']['color'] = this.colors[i];
+        }
         return f;
-      });
+      })
+      // filter any null features
+      .filter(f => !!f);
     this.setHighlightedFeatures(highlightFeatures);
     return highlightFeatures;
   }


### PR DESCRIPTION
Sometimes a null feature ends up in the mix when updating highlighted features, causing #1157 .  It doesn't happen often and I'm not sure the steps to replicate it, but this should handle those cases by:

- Only attempting to access the `properties` key if it exists in the feature object
- Filtering any null features from the array.

Closes #1157 