### PR TITLE
Add map link from rankings

### DIFF
--- a/src/app/ranking/ranking-panel/ranking-panel.component.html
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.html
@@ -23,6 +23,7 @@
           {{ location.name }} <span>{{ location.displayParentLocation }}</span>
         </h2>
         <span class="rank-value">{{dataProperty.name}} {{dataProperty.value.includes('Rate') && location[dataProperty.value] > 100 ? '>100' : (location[dataProperty.value] | number:'1.0-2') }}{{dataProperty.value.includes('Rate') ? '%' : '' }}</span>
+        <a [attr.href]="mapLink" target="_blank" class="rank-link">{{ 'RANKINGS.MAP_LINK' | translate }}</a>
         <!-- COMING SOON
           <a href="#" class="rank-link">{{ 'RANKINGS.TOP_EVICTORS_LINK' | translate }}</a>
         --> 

--- a/src/app/ranking/ranking-panel/ranking-panel.component.ts
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.ts
@@ -26,13 +26,26 @@ export class RankingPanelComponent implements OnChanges {
   constructor(public el: ElementRef) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if ('location' in changes) {
+    if ('location' in changes && this.location) {
       let baseUrl = environment.siteNav.find(l => l.langKey === 'NAV.MAP').defaultUrl;
       if (!baseUrl.endsWith('/')) { baseUrl += '/'; }
 
-      this.mapLink = `${baseUrl}#/${environment.rankingsYear}?geography=cities&type=er&locations=${
-        this.location.geoId},${this.location.latLon[1]},${this.location.latLon[0]}`;
+      this.mapLink = `${baseUrl}#/${environment.rankingsYear}?geography=cities&type=er&bounds=${
+        this.centerBounds(this.location.latLon)}&locations=${this.location.geoId},${
+        this.location.latLon[1]},${this.location.latLon[0]}`;
     }
+  }
+
+  /**
+   * Return an approximate bounding box string for a given center point
+   * @param latLon
+   */
+  private centerBounds(latLon: number[]): string {
+    const lon = latLon[1];
+    const lat = latLon[0];
+    const lonPad = 0.5;
+    const latPad = 0.25;
+    return `${lon - lonPad},${lat - latPad},${lon + lonPad},${lat + latPad}`;
   }
 
 }

--- a/src/app/ranking/ranking-panel/ranking-panel.component.ts
+++ b/src/app/ranking/ranking-panel/ranking-panel.component.ts
@@ -1,8 +1,9 @@
 import {
-  Component, OnInit, Input, Output, EventEmitter, ElementRef
+  Component, OnChanges, SimpleChanges, Input, Output, EventEmitter, ElementRef
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { RankingLocation } from '../ranking-location';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-ranking-panel',
@@ -10,7 +11,7 @@ import { RankingLocation } from '../ranking-location';
   styleUrls: ['./ranking-panel.component.scss'],
   providers: [DecimalPipe]
 })
-export class RankingPanelComponent {
+export class RankingPanelComponent implements OnChanges {
   @Input() year: number;
   @Input() rank: number;
   @Input() topCount: number;
@@ -20,7 +21,18 @@ export class RankingPanelComponent {
   @Output() goToNext = new EventEmitter();
   @Output() close = new EventEmitter();
   @Output() locationClick = new EventEmitter<number>();
+  mapLink: string;
 
   constructor(public el: ElementRef) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if ('location' in changes) {
+      let baseUrl = environment.siteNav.find(l => l.langKey === 'NAV.MAP').defaultUrl;
+      if (!baseUrl.endsWith('/')) { baseUrl += '/'; }
+
+      this.mapLink = `${baseUrl}#/${environment.rankingsYear}?geography=cities&type=er&locations=${
+        this.location.geoId},${this.location.latLon[1]},${this.location.latLon[0]}`;
+    }
+  }
 
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -191,6 +191,7 @@
     "LIST_INTRO": "Viewing {{year}} eviction rankings for locations across America. Scroll through the list or use the search bar to find a place. To refine your results, choose an area type and a data type. You can also search within states using the Region menu. (For more about the locations ranked here, <a href='https://evictionlab.org/help-faq/#rankings-locations'>see our FAQ</a>.)",
     "SEARCH_FILTER": "Search & Filter",
     "TOP_EVICTORS_LINK": "View Top Evictors",
+    "MAP_LINK": "View in Map",
     "SHARE_VIA": "Share via",
     "SHARE_JUDGMENT": "evicted",
     "SHARE_PASSIVE_JUDGMENT": "were evicted",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -195,6 +195,7 @@
     "LIST_INTRO": "Ver los rankings de desalojos en el {{year}} para lugares en todo Estados Unidos. Desplácese por la lista o use la barra de búsqueda para encontrar un lugar. Para refinar sus resultados, elija un tipo de área y un tipo de datos. También se puede buscar dentro de estados usando el menú de Región. (Para obtener más información sobre los lugares clasificados aquí, <a href='https://evictionlab.org/es/help-faq/#rankings-locations'>consulte nuestras Preguntas frecuentes</a>).",
     "SEARCH_FILTER": "Buscar y filtrar",
     "TOP_EVICTORS_LINK": "Ver los desalojadores principales",
+    "MAP_LINK": "Ver en el mapa",
     "SHARE_VIA": "Compartir por",
     "SHARE_JUDGMENT": "desalojó",
     "SHARE_PASSIVE_JUDGMENT": "fueron desalojados",


### PR DESCRIPTION
Closes #1147. Adds a map link in the rankings panel that loads the map with the selected city, rankings year, and eviction rate as the bubble layer. We could also set the bounds to some arbitrary bounding box based on the location center, but not sure if it's necessary. If "view in map" is "ver en el mapa" in Spanish then this should be good to go. 

<img width="757" alt="screen shot 2018-04-26 at 12 15 13 pm" src="https://user-images.githubusercontent.com/8291663/39321161-d9ed1040-494b-11e8-9e0c-0cd74266d260.png">
