### PR TITLE
Fix tertiary event

### DIFF
--- a/src/app/map-tool/map-tool.service.ts
+++ b/src/app/map-tool/map-tool.service.ts
@@ -270,7 +270,7 @@ export class MapToolService {
       }
       if (this.activeFeatures.length === 3) {
         this.analytics.trackEvent('tertiaryLocationSelection', {
-          tertiaryLocationSelection: this.getFullLocationName(this.activeFeatures[2]),
+          tertiaryLocation: this.getFullLocationName(this.activeFeatures[2]),
           locationSelectedLevel: this.activeFeatures[2].properties.layerId,
           combinedSelections: this.getCurrentDataString()
         });


### PR DESCRIPTION
Closes #1162. Not sure how to test it, but it looks like `tertiaryLocationSelection` should be `tertiaryLocation` based on the custom dimensions set up in Google Analytics and the other events