### PR TITLE
debounce update tweet function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3007,6 +3007,11 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "debounce-decorator": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/debounce-decorator/-/debounce-decorator-1.0.6.tgz",
+      "integrity": "sha512-xlJprzmFMdcaHiA/f/Hyhg/A3wh8dpfHMVmN3IV1KijJRrEgHl3gEE7lHkZOfnPR3fi4A1JiUn07ZYpayx8tXQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "clipboard": "^1.7.1",
     "core-js": "^2.4.1",
     "d3-dsv": "^1.0.8",
+    "debounce-decorator": "^1.0.6",
     "hammerjs": "^2.0.8",
     "intl": "^1.2.5",
     "lodash.debounce": "^4.0.8",

--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, OnInit, Input, Output, EventEmitter, SimpleChanges, OnChanges, ChangeDetectorRef
 } from '@angular/core';
+import Debounce from 'debounce-decorator';
 import { environment } from '../../../environments/environment';
 import { DownloadFormComponent } from './download-form/download-form.component';
 import { UiDialogService } from '../../ui/ui-dialog/ui-dialog.service';
@@ -134,7 +135,10 @@ export class DataPanelComponent implements OnInit {
 
   /**
    * Update Twitter share text
+   * Note: This function must be debounced so that `this.platform.currentUrl`
+   *  is accurate when called.
    */
+  @Debounce(1000)
   updateTwitterText() {
     if (!this.mapToolService.activeBubbleHighlight) { return; }
     const featLength = this.locations.length;


### PR DESCRIPTION
The URL no longer updates instantaneously since #1144, so when `updateTwitterText()` is called  `platform.currentUrl()` is not accurate.

This PR debounces the `updateTwitterText()` function so that the URL is updated before the function runs.