### PR TITLE
hide tooltip overflow on graph embed

### DIFF
--- a/src/app/eviction-graphs/graph-embed/graph-embed.component.scss
+++ b/src/app/eviction-graphs/graph-embed/graph-embed.component.scss
@@ -12,6 +12,9 @@
       transform: translate(-1*grid(1), 0); // add some extra space from the axis
     }
   }
+  ::ng-deep .line-tooltips {
+    overflow:hidden; // prevents tooltips from expanding width on iOS
+  }
 }
 
 h1 {


### PR DESCRIPTION
Tooltip overflow expands the embed width on iOS.  This hides the overflow so that doesn't happen.