### PR TITLE
Adjusts positioning of CI info icon in map cards, #1212

### DIFF
--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -189,7 +189,7 @@
         }
       }
       .ci-tip {
-        margin-left: grid(0.4);
+        margin-left: grid(0.78);
         margin-top: grid(0.6);
       }
     }

--- a/src/app/map-tool/location-cards/location-cards.component.scss
+++ b/src/app/map-tool/location-cards/location-cards.component.scss
@@ -182,7 +182,7 @@
         fill: $grey_wcag;
         .icon {
           position: absolute;
-          bottom: 1px;
+          bottom: 7px;
           svg {
             fill: $grey_wcag;
           }


### PR DESCRIPTION
@james-minton Here's the adjusted positioning. Let me know if you want more adjustments.

<img width="622" alt="Screen Shot 2019-11-20 at 6 14 13 PM" src="https://user-images.githubusercontent.com/746182/69289325-be72a700-0bc1-11ea-9404-68f18d998df3.png">
