### PR TITLE
#1229: Revision to accommodate limited custom dimensions

### DIFF
--- a/src/app/map-tool/data-panel/data-panel.component.ts
+++ b/src/app/map-tool/data-panel/data-panel.component.ts
@@ -112,11 +112,11 @@ export class DataPanelComponent implements OnInit {
     const comparisonDownloadType = [
       this.mapToolService.getActiveLocationNames(), yearString, fileTypes
     ].join('|');
-    const downloadPDF = fileTypes.indexOf('pdf') > -1 ? 1 : 0;
-    const downloadPPT = fileTypes.indexOf('pptx') > -1 ? 1 : 0;
-    const downloadXLSX = fileTypes.indexOf('xlsx') > -1 ? 1 : 0;
     this.analytics.trackEvent('comparisonDataDownload', {
-      comparisonDownloadType, downloadPDF, downloadPPT, downloadXLSX
+      comparisonDownloadType, fileTypes
+    });
+    this.analytics.trackEvent('fileDownload', {
+      fileTypes
     });
   }
 


### PR DESCRIPTION
@Lane After further testing with GA, it looks like the previous solution won't quite work, because we've maxed out or number of custom dimensions. I'm adding a second event to specifically track the file types per download, with the hopes that between these two events @james-minton can get the data he needs. 